### PR TITLE
Add compression settings

### DIFF
--- a/src/read_write_zarr.py
+++ b/src/read_write_zarr.py
@@ -22,7 +22,7 @@ def write_zarr_array(
     image: np.array,
     store_path: pathlib.Path,
     overwrite: bool,
-    chunk_size: tuple[int],
+    chunks: tuple[int],
     compressors: zarr.core.array.CompressorsLike = "auto",
 ) -> None:
     if overwrite:
@@ -31,7 +31,7 @@ def write_zarr_array(
     zarr_array = zarr.create_array(
         store=store_path,
         shape=image.shape,
-        chunks=chunk_size,
+        chunks=chunks,
         dtype=image.dtype,
         compressors=compressors,
     )

--- a/tests/benchmark_parameters.py
+++ b/tests/benchmark_parameters.py
@@ -1,8 +1,23 @@
 import zarr
 
-CHUNK_SIZE = (400, 300, 200, 100)
+# CHUNK_SIZE = (400, 300, 200, 100)
+CHUNK_SIZE = (100,)
 COMPRESSORS = (
     zarr.codecs.GzipCodec(),
     zarr.codecs.BloscCodec(),
     zarr.codecs.ZstdCodec(),
+)
+
+BLOSC_CLEVEL = (1, 3, 5, 7, 9)  # range 1-9
+BLOSC_SHUFFLE = (
+    zarr.codecs.BloscShuffle.bitshuffle,
+    zarr.codecs.BloscShuffle.shuffle,
+    zarr.codecs.BloscShuffle.noshuffle,
+)
+BLOSC_CNAME = (
+    zarr.codecs.BloscCname.blosclz,
+    zarr.codecs.BloscCname.lz4,
+    zarr.codecs.BloscCname.lz4hc,
+    zarr.codecs.BloscCname.zlib,
+    zarr.codecs.BloscCname.zstd,
 )

--- a/tests/benchmark_parameters.py
+++ b/tests/benchmark_parameters.py
@@ -1,28 +1,22 @@
 import zarr
 
-# CHUNK_SIZE = (400, 300, 200, 100)
-CHUNK_SIZE = (100,)
-COMPRESSORS = (
-    zarr.codecs.GzipCodec(),
-    zarr.codecs.BloscCodec(),
-    zarr.codecs.ZstdCodec(),
-)
+CHUNK_SIZE = (300, 200, 100)
 
-BLOSC_CLEVEL = (1, 5, 9)  # range 1-9
+BLOSC_CLEVEL = (1, 3, 5)  # range 1-9
 BLOSC_SHUFFLE = (
-    zarr.codecs.BloscShuffle.bitshuffle,
-    zarr.codecs.BloscShuffle.shuffle,
+    # zarr.codecs.BloscShuffle.bitshuffle,
+    # zarr.codecs.BloscShuffle.shuffle,
     zarr.codecs.BloscShuffle.noshuffle,
 )
 BLOSC_CNAME = (
     # zarr.codecs.BloscCname.blosclz,
     # zarr.codecs.BloscCname.lz4,
     # zarr.codecs.BloscCname.lz4hc,
-    zarr.codecs.BloscCname.zlib,
+    # zarr.codecs.BloscCname.zlib,
     zarr.codecs.BloscCname.zstd,
 )
 
-GZIP_LEVEL = (1, 5, 9)  # range 1-9
+GZIP_LEVEL = (1, 3, 5)  # range 1-9
 
 # range 1-22 (according to zstd docs, levels>=20 should be used with caution, as they need more memory)
 ZSTD_LEVEL = (1, 7, 13)

--- a/tests/benchmark_parameters.py
+++ b/tests/benchmark_parameters.py
@@ -8,16 +8,21 @@ COMPRESSORS = (
     zarr.codecs.ZstdCodec(),
 )
 
-BLOSC_CLEVEL = (1, 3, 5, 7, 9)  # range 1-9
+BLOSC_CLEVEL = (1, 5, 9)  # range 1-9
 BLOSC_SHUFFLE = (
     zarr.codecs.BloscShuffle.bitshuffle,
     zarr.codecs.BloscShuffle.shuffle,
     zarr.codecs.BloscShuffle.noshuffle,
 )
 BLOSC_CNAME = (
-    zarr.codecs.BloscCname.blosclz,
-    zarr.codecs.BloscCname.lz4,
-    zarr.codecs.BloscCname.lz4hc,
+    # zarr.codecs.BloscCname.blosclz,
+    # zarr.codecs.BloscCname.lz4,
+    # zarr.codecs.BloscCname.lz4hc,
     zarr.codecs.BloscCname.zlib,
     zarr.codecs.BloscCname.zstd,
 )
+
+GZIP_LEVEL = (1, 5, 9)  # range 1-9
+
+# range 1-22 (according to zstd docs, levels>=20 should be used with caution, as they need more memory)
+ZSTD_LEVEL = (1, 7, 13)

--- a/tests/benchmark_parameters.py
+++ b/tests/benchmark_parameters.py
@@ -3,18 +3,12 @@ import zarr
 CHUNK_SIZE = (300, 200, 100)
 
 BLOSC_CLEVEL = (1, 3, 5)  # range 1-9
-BLOSC_SHUFFLE = (
-    # zarr.codecs.BloscShuffle.bitshuffle,
-    # zarr.codecs.BloscShuffle.shuffle,
-    zarr.codecs.BloscShuffle.noshuffle,
-)
-BLOSC_CNAME = (
-    # zarr.codecs.BloscCname.blosclz,
-    # zarr.codecs.BloscCname.lz4,
-    # zarr.codecs.BloscCname.lz4hc,
-    # zarr.codecs.BloscCname.zlib,
-    zarr.codecs.BloscCname.zstd,
-)
+
+# possible options are BloscShuffle.bitshuffle, BloscShuffle.shuffle and BloscShuffle.noshuffle
+BLOSC_SHUFFLE = (zarr.codecs.BloscShuffle.noshuffle,)
+
+# possible options are BloscCname.blosclz, BloscCname.lz4, BloscCname.lz4hc, BloscCname.zlib and BloscCname.zstd
+BLOSC_CNAME = (zarr.codecs.BloscCname.zstd,)
 
 GZIP_LEVEL = (1, 3, 5)  # range 1-9
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,4 @@ def image():
         )
     )
 
-    # image = np.random.rand(100, 100, 100)
-
     return image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,17 @@
 import pytest
 import pathlib
 from src.read_write_zarr import get_image
-import numpy as np
 
 
 @pytest.fixture(scope="session")
 def image():
     """Reading the image from jpeg is slow, so we only do it once per testing session."""
-    # image = get_image(
-    #     image_dir_path=pathlib.Path(
-    #         "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
-    #     )
-    # )
+    image = get_image(
+        image_dir_path=pathlib.Path(
+            "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
+        )
+    )
 
-    image = np.random.rand(100, 100, 100)
+    # image = np.random.rand(100, 100, 100)
 
     return image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
 import pytest
 import pathlib
 from src.read_write_zarr import get_image
+import numpy as np
 
 
 @pytest.fixture(scope="session")
 def image():
     """Reading the image from jpeg is slow, so we only do it once per testing session."""
-    image = get_image(
-        image_dir_path=pathlib.Path(
-            "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
-        )
-    )
+    # image = get_image(
+    #     image_dir_path=pathlib.Path(
+    #         "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
+    #     )
+    # )
+
+    image = np.random.rand(100, 100, 100)
 
     return image

--- a/tests/test_read_benchmark.py
+++ b/tests/test_read_benchmark.py
@@ -1,21 +1,82 @@
 import pytest
 from src.read_write_zarr import write_zarr_array, read_zarr_array, get_compression_ratio
-from tests.benchmark_parameters import CHUNK_SIZE, COMPRESSORS
+from tests.benchmark_parameters import (
+    CHUNK_SIZE,
+    BLOSC_CLEVEL,
+    BLOSC_CNAME,
+    BLOSC_SHUFFLE,
+    GZIP_LEVEL,
+    ZSTD_LEVEL,
+)
 import pathlib
+import zarr
 
 
 @pytest.mark.benchmark(
     group="read",
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
-@pytest.mark.parametrize(
-    "compressors", COMPRESSORS, ids=[type(compressor) for compressor in COMPRESSORS]
-)
-def test_read(benchmark, image, chunk_size, compressors):
+@pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
+@pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
+@pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
+def test_read_blosc(
+    benchmark, image, chunk_size, blosc_clevel, blosc_shuffle, blosc_cname
+):
     store_path = pathlib.Path("data/output/heart-example.zarr")
-    overwrite = True
-    chunks = (chunk_size, chunk_size, chunk_size)
-    write_zarr_array(image, store_path, overwrite, chunks, compressors)
+
+    write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressors=zarr.codecs.BloscCodec(
+            cname=blosc_cname, clevel=blosc_clevel, shuffle=blosc_shuffle
+        ),
+    )
+
+    compression_ratio = get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(read_zarr_array, args=(store_path,), rounds=3, warmup_rounds=1)
+
+
+@pytest.mark.benchmark(
+    group="read",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
+def test_read_gzip(benchmark, image, chunk_size, gzip_level):
+    store_path = pathlib.Path("data/output/heart-example.zarr")
+
+    write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressors=zarr.codecs.GzipCodec(level=gzip_level),
+    )
+
+    compression_ratio = get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(read_zarr_array, args=(store_path,), rounds=3, warmup_rounds=1)
+
+
+@pytest.mark.benchmark(
+    group="read",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
+def test_read_zstd(benchmark, image, chunk_size, zstd_level):
+    store_path = pathlib.Path("data/output/heart-example.zarr")
+
+    write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressors=zarr.codecs.ZstdCodec(level=zstd_level),
+    )
 
     compression_ratio = get_compression_ratio(store_path)
     benchmark.extra_info["compression_ratio"] = compression_ratio

--- a/tests/test_write_benchmark.py
+++ b/tests/test_write_benchmark.py
@@ -7,6 +7,8 @@ from tests.benchmark_parameters import (
     BLOSC_CLEVEL,
     BLOSC_SHUFFLE,
     BLOSC_CNAME,
+    GZIP_LEVEL,
+    ZSTD_LEVEL,
 )
 
 
@@ -37,22 +39,43 @@ def test_write_blosc(
     benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)
 
 
-# @pytest.mark.benchmark(
-#     group="write",
-# )
-# @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
-# def test_write_gzip(benchmark, image, chunk_size, compressors):
-#     store_path = pathlib.Path("data/output/heart-example.zarr")
-#     overwrite = False
+@pytest.mark.benchmark(
+    group="write",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
+def test_write_gzip(benchmark, image, chunk_size, gzip_level):
+    store_path = pathlib.Path("data/output/heart-example.zarr")
 
-#     def setup():
-#         remove_output_dir(store_path)
-#         return (
-#             image,
-#             store_path,
-#             overwrite,
-#             (chunk_size, chunk_size, chunk_size),
-#             compressors,
-#         ), {}
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressors": zarr.codecs.GzipCodec(level=gzip_level),
+        }
 
-#     benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)
+    benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)
+
+
+@pytest.mark.benchmark(
+    group="write",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
+def test_write_zstd(benchmark, image, chunk_size, zstd_level):
+    store_path = pathlib.Path("data/output/heart-example.zarr")
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressors": zarr.codecs.ZstdCodec(level=zstd_level),
+        }
+
+    benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)

--- a/tests/test_write_benchmark.py
+++ b/tests/test_write_benchmark.py
@@ -1,28 +1,58 @@
 import pytest
 from src.read_write_zarr import write_zarr_array, remove_output_dir
 import pathlib
-from tests.benchmark_parameters import CHUNK_SIZE, COMPRESSORS
+import zarr
+from tests.benchmark_parameters import (
+    CHUNK_SIZE,
+    BLOSC_CLEVEL,
+    BLOSC_SHUFFLE,
+    BLOSC_CNAME,
+)
 
 
 @pytest.mark.benchmark(
     group="write",
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
-@pytest.mark.parametrize(
-    "compressors", COMPRESSORS, ids=[type(compressor) for compressor in COMPRESSORS]
-)
-def test_write(benchmark, image, chunk_size, compressors):
+@pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
+@pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
+@pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
+def test_write_blosc(
+    benchmark, image, chunk_size, blosc_clevel, blosc_shuffle, blosc_cname
+):
     store_path = pathlib.Path("data/output/heart-example.zarr")
-    overwrite = False
 
     def setup():
         remove_output_dir(store_path)
-        return (
-            image,
-            store_path,
-            overwrite,
-            (chunk_size, chunk_size, chunk_size),
-            compressors,
-        ), {}
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressors": zarr.codecs.BloscCodec(
+                cname=blosc_cname, clevel=blosc_clevel, shuffle=blosc_shuffle
+            ),
+        }
 
     benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)
+
+
+# @pytest.mark.benchmark(
+#     group="write",
+# )
+# @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+# def test_write_gzip(benchmark, image, chunk_size, compressors):
+#     store_path = pathlib.Path("data/output/heart-example.zarr")
+#     overwrite = False
+
+#     def setup():
+#         remove_output_dir(store_path)
+#         return (
+#             image,
+#             store_path,
+#             overwrite,
+#             (chunk_size, chunk_size, chunk_size),
+#             compressors,
+#         ), {}
+
+#     benchmark.pedantic(write_zarr_array, setup=setup, rounds=3, warmup_rounds=1)


### PR DESCRIPTION
For https://github.com/HEFTIEProject/zarr-benchmarks/issues/11

- adds main compression settings for each compressor (`blosc`, `gzip` and `zstd`)
- as they have different settings, I've split the read/write functions to have one per compressor
- for now, I'm only testing a few possible combinations of settings (although I've documented all possible values under `benchmark_parameters`). This already takes a while to run - so we should check with David which combinations he wants to test.

If you want to test this quickly, replace the image in `conftest` with `image = np.random.rand(100, 100, 100)`. The full size image takes a while to run for all combinations.