### PR TITLE
add --dev-image option to pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,33 @@
 import pytest
 import pathlib
 from src.read_write_zarr import get_image
+import numpy as np
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dev-image",
+        action="store_true",
+        help="Use a small 100x100x100 image to test benchmarks",
+    )
 
 
 @pytest.fixture(scope="session")
-def image():
-    """Reading the image from jpeg is slow, so we only do it once per testing session."""
-    image = get_image(
+def dev_image(request):
+    return request.config.getoption("--dev-image")
+
+
+@pytest.fixture(scope="session")
+def image(dev_image):
+    """If '--dev_image' isn't set, read the image from a series of jpeg. This process is quite slow, so we only do it once
+    per testing session. If '--dev_image' is set, use a small 100x100x100 numpy array instead - this is useful for quick
+    test runs during development."""
+
+    if dev_image:
+        return np.random.rand(100, 100, 100)
+
+    return get_image(
         image_dir_path=pathlib.Path(
             "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
         )
     )
-
-    return image


### PR DESCRIPTION
As we have more combinations of parameters now, running with the full size image is rather slow. You can manually replace the contents of the `image` fixture with `image = np.random.rand(100, 100, 100)`, but this is also a pain to do every time.

This PR adds a `--dev-image` commandline option to pytest to substitute the small numpy array for development (e.g. `pytest --dev-image`)