### PR TITLE
Allow adjustment of rounds for all benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,15 @@ tox -- --dev-image
 ```
 
 This will run all benchmarks with a small 100x100x100 numpy array, which is
-useful for quick test runs during development. Everything after the first `--`
-will be passed to the internal `pytest` call, so you can also add any pytest
-options you require.
+useful for quick test runs during development. You can also override the default
+number of rounds / warmup rounds for each benchmark with:
+
+```bash
+tox -- --dev-image --rounds=1 --warmup-rounds=0
+```
+
+Everything after the first `--` will be passed to the internal `pytest` call, so
+you can also add any pytest options you require.
 
 ## Running pre-commit locally
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,32 @@ def pytest_addoption(parser):
         help="Use a small 100x100x100 image to test benchmarks",
     )
 
+    parser.addoption(
+        "--rounds",
+        action="store",
+        default=3,
+        type=int,
+        help="number of rounds for each benchmark",
+    )
+
+    parser.addoption(
+        "--warmup-rounds",
+        action="store",
+        default=1,
+        type=int,
+        help="number of warmup rounds for each benchmark",
+    )
+
+
+@pytest.fixture
+def rounds(request):
+    return request.config.getoption("--rounds")
+
+
+@pytest.fixture
+def warmup_rounds(request):
+    return request.config.getoption("--warmup-rounds")
+
 
 @pytest.fixture(scope="session")
 def dev_image(request):

--- a/tests/test_read_benchmark.py
+++ b/tests/test_read_benchmark.py
@@ -22,7 +22,15 @@ except ImportError:
 @pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
 @pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
 def test_read_blosc(
-    benchmark, image, store_path, chunk_size, blosc_clevel, blosc_shuffle, blosc_cname
+    benchmark,
+    image,
+    rounds,
+    warmup_rounds,
+    store_path,
+    chunk_size,
+    blosc_clevel,
+    blosc_shuffle,
+    blosc_cname,
 ):
     blosc_compressor = read_write_zarr.get_blosc_compressor(
         blosc_cname, blosc_clevel, blosc_shuffle
@@ -40,7 +48,10 @@ def test_read_blosc(
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(
-        read_write_zarr.read_zarr_array, args=(store_path,), rounds=3, warmup_rounds=1
+        read_write_zarr.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )
 
 
@@ -49,7 +60,9 @@ def test_read_blosc(
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
-def test_read_gzip(benchmark, image, store_path, chunk_size, gzip_level):
+def test_read_gzip(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, gzip_level
+):
     gzip_compressor = read_write_zarr.get_gzip_compressor(gzip_level)
 
     read_write_zarr.write_zarr_array(
@@ -64,7 +77,10 @@ def test_read_gzip(benchmark, image, store_path, chunk_size, gzip_level):
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(
-        read_write_zarr.read_zarr_array, args=(store_path,), rounds=3, warmup_rounds=1
+        read_write_zarr.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )
 
 
@@ -73,7 +89,9 @@ def test_read_gzip(benchmark, image, store_path, chunk_size, gzip_level):
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
-def test_read_zstd(benchmark, image, store_path, chunk_size, zstd_level):
+def test_read_zstd(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, zstd_level
+):
     zstd_compressor = read_write_zarr.get_zstd_compressor(zstd_level)
 
     read_write_zarr.write_zarr_array(
@@ -88,5 +106,8 @@ def test_read_zstd(benchmark, image, store_path, chunk_size, zstd_level):
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(
-        read_write_zarr.read_zarr_array, args=(store_path,), rounds=3, warmup_rounds=1
+        read_write_zarr.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )

--- a/tests/test_write_benchmark.py
+++ b/tests/test_write_benchmark.py
@@ -23,7 +23,15 @@ except ImportError:
 @pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
 @pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
 def test_write_blosc(
-    benchmark, image, store_path, chunk_size, blosc_clevel, blosc_shuffle, blosc_cname
+    benchmark,
+    image,
+    rounds,
+    warmup_rounds,
+    store_path,
+    chunk_size,
+    blosc_clevel,
+    blosc_shuffle,
+    blosc_cname,
 ):
     blosc_compressor = read_write_zarr.get_blosc_compressor(
         blosc_cname, blosc_clevel, blosc_shuffle
@@ -40,7 +48,10 @@ def test_write_blosc(
         }
 
     benchmark.pedantic(
-        read_write_zarr.write_zarr_array, setup=setup, rounds=3, warmup_rounds=1
+        read_write_zarr.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )
 
 
@@ -49,7 +60,9 @@ def test_write_blosc(
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
-def test_write_gzip(benchmark, image, store_path, chunk_size, gzip_level):
+def test_write_gzip(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, gzip_level
+):
     gzip_compressor = read_write_zarr.get_gzip_compressor(gzip_level)
 
     def setup():
@@ -63,7 +76,10 @@ def test_write_gzip(benchmark, image, store_path, chunk_size, gzip_level):
         }
 
     benchmark.pedantic(
-        read_write_zarr.write_zarr_array, setup=setup, rounds=3, warmup_rounds=1
+        read_write_zarr.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )
 
 
@@ -72,7 +88,9 @@ def test_write_gzip(benchmark, image, store_path, chunk_size, gzip_level):
 )
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
-def test_write_zstd(benchmark, image, store_path, chunk_size, zstd_level):
+def test_write_zstd(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, zstd_level
+):
     zstd_compressor = read_write_zarr.get_zstd_compressor(zstd_level)
 
     def setup():
@@ -86,5 +104,8 @@ def test_write_zstd(benchmark, image, store_path, chunk_size, zstd_level):
         }
 
     benchmark.pedantic(
-        read_write_zarr.write_zarr_array, setup=setup, rounds=3, warmup_rounds=1
+        read_write_zarr.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
     )


### PR DESCRIPTION
As we're adding more combinations of parameters, I thought it would be useful to have options to control `rounds` / `warmup-rounds` via the commandline. This can speed up execution for test runs! This PR:

- adds commandline options e.g. `tox -- --dev-image --rounds=1 --warmup-rounds=0` for adjusting rounds
- defines `rounds`/`warmup-rounds` via fixtures, so that all benchmarks use the same settings