### PR TITLE
write spec v2 with zarr-python v3

### DIFF
--- a/src/read_write_zarr_v2.py
+++ b/src/read_write_zarr_v2.py
@@ -2,7 +2,7 @@ import zarr
 import numcodecs
 from numcodecs import Blosc, GZip, Zstd
 import pathlib
-from utils import remove_output_dir
+import utils
 import numpy as np
 
 
@@ -27,7 +27,7 @@ def write_zarr_array(
     compressor: numcodecs.abc.Codec,
 ) -> None:
     if overwrite:
-        remove_output_dir(store_path)
+        utils.remove_output_dir(store_path)
 
     zarr_array = zarr.open_array(
         store=store_path,
@@ -41,16 +41,7 @@ def write_zarr_array(
 
 
 def get_blosc_compressor(cname: str, clevel: int, shuffle: str) -> numcodecs.abc.Codec:
-    match shuffle:
-        case "shuffle":
-            shuffle_int = Blosc.SHUFFLE
-        case "noshuffle":
-            shuffle_int = Blosc.NOSHUFFLE
-        case "bitshuffle":
-            shuffle_int = Blosc.BITSHUFFLE
-        case _:
-            raise ValueError(f"invalid shuffle value for blosc {shuffle}")
-
+    shuffle_int = utils.get_numcodec_shuffle(shuffle)
     return Blosc(cname=cname, clevel=clevel, shuffle=shuffle_int)
 
 

--- a/src/read_write_zarr_v2.py
+++ b/src/read_write_zarr_v2.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import zarr
 import numcodecs
 from numcodecs import Blosc, GZip, Zstd
@@ -40,7 +41,9 @@ def write_zarr_array(
     zarr_array[:] = image
 
 
-def get_blosc_compressor(cname: str, clevel: int, shuffle: str) -> numcodecs.abc.Codec:
+def get_blosc_compressor(
+    cname: str, clevel: int, shuffle: Literal["shuffle", "noshuffle", "bitshuffle"]
+) -> numcodecs.abc.Codec:
     shuffle_int = utils.get_numcodec_shuffle(shuffle)
     return Blosc(cname=cname, clevel=clevel, shuffle=shuffle_int)
 

--- a/src/read_write_zarr_v3.py
+++ b/src/read_write_zarr_v3.py
@@ -3,7 +3,7 @@ import numpy as np
 import zarr
 from numcodecs import Blosc, GZip, Zstd
 from zarr.codecs import BloscCodec, GzipCodec, ZstdCodec
-from typing import Any
+from typing import Any, Literal
 import utils
 
 
@@ -26,7 +26,7 @@ def write_zarr_array(
     overwrite: bool,
     chunks: tuple[int],
     compressor: Any = "auto",
-    zarr_spec: int = 2,
+    zarr_spec: Literal[2, 3] = 2,
 ) -> None:
     if overwrite:
         utils.remove_output_dir(store_path)
@@ -43,7 +43,10 @@ def write_zarr_array(
 
 
 def get_blosc_compressor(
-    cname: str, clevel: int, shuffle: str, zarr_spec: int = 2
+    cname: str,
+    clevel: int,
+    shuffle: Literal["shuffle", "noshuffle", "bitshuffle"],
+    zarr_spec: Literal[2, 3] = 2,
 ) -> Any:
     if zarr_spec == 2:
         shuffle_int = utils.get_numcodec_shuffle(shuffle)
@@ -54,7 +57,7 @@ def get_blosc_compressor(
         raise ValueError(f"invalid zarr spec version {zarr_spec}")
 
 
-def get_gzip_compressor(level: int, zarr_spec: int = 2) -> Any:
+def get_gzip_compressor(level: int, zarr_spec: Literal[2, 3] = 2) -> Any:
     if zarr_spec == 2:
         return GZip(level=level)
     elif zarr_spec == 3:
@@ -63,7 +66,7 @@ def get_gzip_compressor(level: int, zarr_spec: int = 2) -> Any:
         raise ValueError(f"invalid zarr spec version {zarr_spec}")
 
 
-def get_zstd_compressor(level: int, zarr_spec: int = 2) -> Any:
+def get_zstd_compressor(level: int, zarr_spec: Literal[2, 3] = 2) -> Any:
     if zarr_spec == 2:
         return Zstd(level=level)
     elif zarr_spec == 3:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Literal
 import numpy as np
 import imageio.v3 as iio
 import shutil
@@ -24,7 +25,7 @@ def remove_output_dir(output_dir: pathlib.Path) -> None:
         shutil.rmtree(output_dir)
 
 
-def get_numcodec_shuffle(shuffle: str) -> int:
+def get_numcodec_shuffle(shuffle: Literal["shuffle", "noshuffle", "bitshuffle"]) -> int:
     match shuffle:
         case "shuffle":
             return numcodecs.Blosc.SHUFFLE

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,7 @@ import pathlib
 import numpy as np
 import imageio.v3 as iio
 import shutil
+import numcodecs
 
 
 def get_image(image_dir_path: pathlib.Path) -> np.array:
@@ -21,3 +22,15 @@ def get_image(image_dir_path: pathlib.Path) -> np.array:
 def remove_output_dir(output_dir: pathlib.Path) -> None:
     if output_dir.exists():
         shutil.rmtree(output_dir)
+
+
+def get_numcodec_shuffle(shuffle: str) -> int:
+    match shuffle:
+        case "shuffle":
+            return numcodecs.Blosc.SHUFFLE
+        case "noshuffle":
+            return numcodecs.Blosc.NOSHUFFLE
+        case "bitshuffle":
+            return numcodecs.Blosc.BITSHUFFLE
+        case _:
+            raise ValueError(f"invalid shuffle value for blosc {shuffle}")


### PR DESCRIPTION
This PR changes the `zarr-python v3` code to default to writing zarr spec v2. This means we are currently testing `zarr-python v2` (spec v2) and `zarr-python v3` (spec v2). I'm working on adding tensorstore (with spec v2) on another branch also.

See [info about running the benchmarks](https://github.com/HEFTIEProject/zarr-benchmarks?tab=readme-ov-file#running-the-benchmarks) for setup instructions. Use `--dev-image` for a quicker test run.