### PR TITLE
Add tensorstore benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Then run tox with:
 tox
 ```
 
-This will run all benchmarks via `zarr-python` version 2 and 3 with the example
-Human Organ Atlas image.
+This will run all benchmarks via `zarr-python` version 2 + 3 and `tensorstore`
+with the example Human Organ Atlas image.
 
 For a quicker run, add `--dev-image`:
 
@@ -107,6 +107,19 @@ tox -- --dev-image --rounds=1 --warmup-rounds=0
 
 Everything after the first `--` will be passed to the internal `pytest` call, so
 you can also add any pytest options you require.
+
+To run a subset of the benchmarks, use the `-e` option:
+
+```bash
+# tensorstore only
+tox run -e py313-tensorstore
+
+# zarr-python v2 only
+tox run -e py313-zarrv2
+
+# zarr-python v3 only
+tox run -e py313-zarrv3
+```
 
 ## Running pre-commit locally
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
 Homepage = "https://github.com/HEFTIEProject/zarr-benchmarks"
 Issues = "https://github.com/HEFTIEProject/zarr-benchmarks/issues"
 
+[tool.pytest]
+
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/HEFTIEProject/zarr-benchmarks"
 Issues = "https://github.com/HEFTIEProject/zarr-benchmarks/issues"
-[tool.pytest]
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,21 +29,61 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/HEFTIEProject/zarr-benchmarks"
 Issues = "https://github.com/HEFTIEProject/zarr-benchmarks/issues"
+[tool.pytest]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "tensorstore",
+    "zarr_python",
+]
 
 # override sorting inline arrays for tox configuration - otherwise 'commands' lines are sorted and broken
 [tool.tomlsort]
 overrides."tool.tox.*".inline_arrays = false
 
 [tool.tox]
-env_list = ["py313-zarrv2", "py313-zarrv3"]
+env_list = ["py313-zarrv2", "py313-zarrv3", "py313-tensorstore"]
 requires = ["tox>=4.24"]
 
+[tool.tox.env.py313-tensorstore]
+commands = [
+    [
+        "pytest",
+        "--benchmark-save=tensorstore",
+        "--benchmark-save-data",
+        "-m",
+        "tensorstore",
+        {extend = true, replace = "posargs"},
+    ],
+]
+deps = ["tensorstore==0.1.73", "zarr==3.0.6", "numcodecs==0.15.1"]
+description = "Run benchmarks under tensorstore"
+
 [tool.tox.env.py313-zarrv2]
-commands = [["pytest", "--benchmark-save=zarr-python-v2", "--benchmark-save-data", {extend = true, replace = "posargs"}]]
+commands = [
+    [
+        "pytest",
+        "--benchmark-save=zarr-python-v2",
+        "--benchmark-save-data",
+        "-m",
+        "zarr_python",
+        {extend = true, replace = "posargs"},
+    ],
+]
 deps = ["zarr==2.18.4", "numcodecs==0.15.1"]
 description = "Run benchmarks under zarr-python version 2"
 
 [tool.tox.env.py313-zarrv3]
-commands = [["pytest", "--benchmark-save=zarr-python-v3", "--benchmark-save-data", {extend = true, replace = "posargs"}]]
+commands = [
+    [
+        "pytest",
+        "--benchmark-save=zarr-python-v3",
+        "--benchmark-save-data",
+        "-m",
+        "zarr_python",
+        {extend = true, replace = "posargs"},
+    ],
+]
 deps = ["zarr==3.0.6", "numcodecs==0.15.1"]
 description = "Run benchmarks under zarr-python version 3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "imageio",
     "pytest",
     "pytest-benchmark",
+    "tensorstore",
     "tox",
     "zarr",
 ]

--- a/src/read_write_tensorstore.py
+++ b/src/read_write_tensorstore.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pathlib
+import tensorstore as ts
+from utils import remove_output_dir
+
+
+def read_zarr_array(store_path: pathlib.Path) -> np.array:
+    zarr_read = ts.open(
+        {
+            "driver": "zarr",
+            "kvstore": {
+                "driver": "file",
+                "path": store_path,
+            },
+        },
+        read=True,
+    ).result()
+    read_image = zarr_read[:].read().result()
+    return read_image
+
+
+def write_zarr_array(
+    image: np.array,
+    store_path: pathlib.Path,
+    overwrite: bool,
+    chunks: tuple[int],
+    compressor: dict,
+) -> None:
+    if overwrite:
+        remove_output_dir(store_path)
+
+    dataset = ts.open(
+        {
+            "driver": "zarr",
+            "kvstore": {
+                "driver": "file",
+                "path": store_path,
+            },
+            "metadata": {
+                "dtype": image.dtype.str,
+                "shape": image.shape,
+                "chunks": chunks,
+                "compressor": compressor,
+            },
+            "create": True,
+            "delete_existing": False,
+        },
+    ).result()
+
+    write_future = dataset[:].write(image)
+    write_future.result()
+
+
+def get_blosc_compressor(cname: str, clevel: int, shuffle: str) -> dict:
+    # see the zarr shuffle docs: https://google.github.io/tensorstore/driver/zarr/index.html#json-driver/zarr/Compressor/blosc.shuffle
+    match shuffle:
+        case "noshuffle":
+            shuffle_int = 0
+        case "shuffle":
+            shuffle_int = 1
+        case "bitshuffle":
+            shuffle_int = 2
+        case _:
+            raise ValueError(f"invalid shuffle value for blosc {shuffle}")
+
+    return {"id": "blosc", "cname": cname, "clevel": clevel, "shuffle": shuffle_int}
+
+
+def get_gzip_compressor(level: int) -> dict:
+    return {"id": "gzip", "level": level}
+
+
+def get_zstd_compressor(level: int) -> dict:
+    return {"id": "zstd", "level": level}

--- a/src/read_write_tensorstore.py
+++ b/src/read_write_tensorstore.py
@@ -1,16 +1,17 @@
+import tensorstore as ts
 import numpy as np
 import pathlib
-import tensorstore as ts
-from utils import remove_output_dir
+import utils
 
 
 def read_zarr_array(store_path: pathlib.Path) -> np.array:
+    """Read the v2 zarr spec with tensorstore"""
     zarr_read = ts.open(
         {
             "driver": "zarr",
             "kvstore": {
                 "driver": "file",
-                "path": store_path,
+                "path": str(store_path),
             },
         },
         read=True,
@@ -26,15 +27,16 @@ def write_zarr_array(
     chunks: tuple[int],
     compressor: dict,
 ) -> None:
+    """Write the v2 zarr spec with tensorstore"""
     if overwrite:
-        remove_output_dir(store_path)
+        utils.remove_output_dir(store_path)
 
     dataset = ts.open(
         {
             "driver": "zarr",
             "kvstore": {
                 "driver": "file",
-                "path": store_path,
+                "path": str(store_path),
             },
             "metadata": {
                 "dtype": image.dtype.str,

--- a/src/read_write_tensorstore.py
+++ b/src/read_write_tensorstore.py
@@ -12,7 +12,7 @@ def read_zarr_array(store_path: pathlib.Path) -> np.array:
             "driver": "zarr",
             "kvstore": {
                 "driver": "file",
-                "path": str(store_path),
+                "path": str(store_path.resolve()),
             },
         },
         read=True,
@@ -37,7 +37,7 @@ def write_zarr_array(
             "driver": "zarr",
             "kvstore": {
                 "driver": "file",
-                "path": str(store_path),
+                "path": str(store_path.resolve()),
             },
             "metadata": {
                 "dtype": image.dtype.str,

--- a/src/read_write_tensorstore.py
+++ b/src/read_write_tensorstore.py
@@ -24,6 +24,7 @@ def read_zarr_array(store_path: pathlib.Path) -> np.array:
 def write_zarr_array(
     image: np.array,
     store_path: pathlib.Path,
+    *,
     overwrite: bool,
     chunks: tuple[int],
     compressor: dict,

--- a/src/read_write_tensorstore.py
+++ b/src/read_write_tensorstore.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import tensorstore as ts
 import numpy as np
 import pathlib
@@ -53,7 +54,9 @@ def write_zarr_array(
     write_future.result()
 
 
-def get_blosc_compressor(cname: str, clevel: int, shuffle: str) -> dict:
+def get_blosc_compressor(
+    cname: str, clevel: int, shuffle: Literal["shuffle", "noshuffle", "bitshuffle"]
+) -> dict:
     # see the zarr shuffle docs: https://google.github.io/tensorstore/driver/zarr/index.html#json-driver/zarr/Compressor/blosc.shuffle
     match shuffle:
         case "noshuffle":

--- a/src/read_write_zarr_v2.py
+++ b/src/read_write_zarr_v2.py
@@ -23,6 +23,7 @@ def read_zarr_array(store_path: pathlib.Path) -> np.array:
 def write_zarr_array(
     image: np.array,
     store_path: pathlib.Path,
+    *,
     overwrite: bool,
     chunks: tuple[int],
     compressor: numcodecs.abc.Codec,

--- a/src/read_write_zarr_v3.py
+++ b/src/read_write_zarr_v3.py
@@ -23,6 +23,7 @@ def read_zarr_array(store_path: pathlib.Path) -> np.array:
 def write_zarr_array(
     image: np.array,
     store_path: pathlib.Path,
+    *,
     overwrite: bool,
     chunks: tuple[int],
     compressor: Any = "auto",

--- a/tests/test_read_tensorstore_benchmark.py
+++ b/tests/test_read_tensorstore_benchmark.py
@@ -14,8 +14,9 @@ try:
 except ImportError:
     import read_write_zarr_v2 as read_write_zarr
 
+pytestmark = [pytest.mark.tensorstore]
 
-@pytest.mark.tensorstore
+
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
@@ -55,7 +56,6 @@ def test_read_blosc(
     )
 
 
-@pytest.mark.tensorstore
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
@@ -83,7 +83,6 @@ def test_read_gzip(
     )
 
 
-@pytest.mark.tensorstore
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)

--- a/tests/test_read_tensorstore_benchmark.py
+++ b/tests/test_read_tensorstore_benchmark.py
@@ -1,0 +1,117 @@
+import pytest
+from tests.benchmark_parameters import (
+    CHUNK_SIZE,
+    BLOSC_CLEVEL,
+    BLOSC_CNAME,
+    BLOSC_SHUFFLE,
+    GZIP_LEVEL,
+    ZSTD_LEVEL,
+)
+import read_write_tensorstore
+
+try:
+    import read_write_zarr_v3 as read_write_zarr
+except ImportError:
+    import read_write_zarr_v2 as read_write_zarr
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(
+    group="read",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
+@pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
+@pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
+def test_read_blosc(
+    benchmark,
+    image,
+    rounds,
+    warmup_rounds,
+    store_path,
+    chunk_size,
+    blosc_clevel,
+    blosc_shuffle,
+    blosc_cname,
+):
+    blosc_compressor = read_write_tensorstore.get_blosc_compressor(
+        blosc_cname, blosc_clevel, blosc_shuffle
+    )
+
+    read_write_tensorstore.write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressor=blosc_compressor,
+    )
+
+    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(
+        read_write_tensorstore.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(
+    group="read",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
+def test_read_gzip(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, gzip_level
+):
+    gzip_compressor = read_write_tensorstore.get_gzip_compressor(gzip_level)
+
+    read_write_tensorstore.write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressor=gzip_compressor,
+    )
+
+    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(
+        read_write_tensorstore.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(
+    group="read",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
+def test_read_zstd(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, zstd_level
+):
+    zstd_compressor = read_write_tensorstore.get_zstd_compressor(zstd_level)
+
+    read_write_tensorstore.write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressor=zstd_compressor,
+    )
+
+    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(
+        read_write_tensorstore.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/test_read_tensorstore_benchmark.py
+++ b/tests/test_read_tensorstore_benchmark.py
@@ -16,9 +16,7 @@ except ImportError:
 
 
 @pytest.mark.tensorstore
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
 @pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
@@ -58,9 +56,7 @@ def test_read_blosc(
 
 
 @pytest.mark.tensorstore
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
 def test_read_gzip(
@@ -88,9 +84,7 @@ def test_read_gzip(
 
 
 @pytest.mark.tensorstore
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
 def test_read_zstd(

--- a/tests/test_read_zarr_python_benchmark.py
+++ b/tests/test_read_zarr_python_benchmark.py
@@ -14,6 +14,7 @@ except ImportError:
     import read_write_zarr_v2 as read_write_zarr
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="read",
 )
@@ -55,6 +56,7 @@ def test_read_blosc(
     )
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="read",
 )
@@ -84,6 +86,7 @@ def test_read_gzip(
     )
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="read",
 )

--- a/tests/test_read_zarr_python_benchmark.py
+++ b/tests/test_read_zarr_python_benchmark.py
@@ -13,8 +13,9 @@ try:
 except ImportError:
     import read_write_zarr_v2 as read_write_zarr
 
+pytestmark = [pytest.mark.zarr_python]
 
-@pytest.mark.zarr_python
+
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
@@ -54,7 +55,6 @@ def test_read_blosc(
     )
 
 
-@pytest.mark.zarr_python
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
@@ -82,7 +82,6 @@ def test_read_gzip(
     )
 
 
-@pytest.mark.zarr_python
 @pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)

--- a/tests/test_read_zarr_python_benchmark.py
+++ b/tests/test_read_zarr_python_benchmark.py
@@ -15,9 +15,7 @@ except ImportError:
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
 @pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
@@ -57,9 +55,7 @@ def test_read_blosc(
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
 def test_read_gzip(
@@ -87,9 +83,7 @@ def test_read_gzip(
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="read",
-)
+@pytest.mark.benchmark(group="read")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
 def test_read_zstd(

--- a/tests/test_write_tensorstore_benchmark.py
+++ b/tests/test_write_tensorstore_benchmark.py
@@ -1,0 +1,108 @@
+import pytest
+from utils import remove_output_dir
+from tests.benchmark_parameters import (
+    CHUNK_SIZE,
+    BLOSC_CLEVEL,
+    BLOSC_SHUFFLE,
+    BLOSC_CNAME,
+    GZIP_LEVEL,
+    ZSTD_LEVEL,
+)
+import read_write_tensorstore
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(group="write")
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
+@pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
+@pytest.mark.parametrize("blosc_cname", BLOSC_CNAME)
+def test_write_blosc(
+    benchmark,
+    image,
+    rounds,
+    warmup_rounds,
+    store_path,
+    chunk_size,
+    blosc_clevel,
+    blosc_shuffle,
+    blosc_cname,
+):
+    blosc_compressor = read_write_tensorstore.get_blosc_compressor(
+        blosc_cname, blosc_clevel, blosc_shuffle
+    )
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressor": blosc_compressor,
+        }
+
+    benchmark.pedantic(
+        read_write_tensorstore.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(
+    group="write",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
+def test_write_gzip(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, gzip_level
+):
+    gzip_compressor = read_write_tensorstore.get_gzip_compressor(gzip_level)
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressor": gzip_compressor,
+        }
+
+    benchmark.pedantic(
+        read_write_tensorstore.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )
+
+
+@pytest.mark.tensorstore
+@pytest.mark.benchmark(
+    group="write",
+)
+@pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
+@pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
+def test_write_zstd(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, zstd_level
+):
+    zstd_compressor = read_write_tensorstore.get_zstd_compressor(zstd_level)
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressor": zstd_compressor,
+        }
+
+    benchmark.pedantic(
+        read_write_tensorstore.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/test_write_tensorstore_benchmark.py
+++ b/tests/test_write_tensorstore_benchmark.py
@@ -51,9 +51,7 @@ def test_write_blosc(
 
 
 @pytest.mark.tensorstore
-@pytest.mark.benchmark(
-    group="write",
-)
+@pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
 def test_write_gzip(
@@ -80,9 +78,7 @@ def test_write_gzip(
 
 
 @pytest.mark.tensorstore
-@pytest.mark.benchmark(
-    group="write",
-)
+@pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
 def test_write_zstd(

--- a/tests/test_write_tensorstore_benchmark.py
+++ b/tests/test_write_tensorstore_benchmark.py
@@ -10,8 +10,9 @@ from tests.benchmark_parameters import (
 )
 import read_write_tensorstore
 
+pytestmark = [pytest.mark.tensorstore]
 
-@pytest.mark.tensorstore
+
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
@@ -50,7 +51,6 @@ def test_write_blosc(
     )
 
 
-@pytest.mark.tensorstore
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
@@ -77,7 +77,6 @@ def test_write_gzip(
     )
 
 
-@pytest.mark.tensorstore
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)

--- a/tests/test_write_zarr_python_benchmark.py
+++ b/tests/test_write_zarr_python_benchmark.py
@@ -14,8 +14,9 @@ try:
 except ImportError:
     import read_write_zarr_v2 as read_write_zarr
 
+pytestmark = [pytest.mark.zarr_python]
 
-@pytest.mark.zarr_python
+
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
@@ -54,7 +55,6 @@ def test_write_blosc(
     )
 
 
-@pytest.mark.zarr_python
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
@@ -81,7 +81,6 @@ def test_write_gzip(
     )
 
 
-@pytest.mark.zarr_python
 @pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)

--- a/tests/test_write_zarr_python_benchmark.py
+++ b/tests/test_write_zarr_python_benchmark.py
@@ -16,9 +16,7 @@ except ImportError:
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="write",
-)
+@pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("blosc_clevel", BLOSC_CLEVEL)
 @pytest.mark.parametrize("blosc_shuffle", BLOSC_SHUFFLE)
@@ -57,9 +55,7 @@ def test_write_blosc(
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="write",
-)
+@pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("gzip_level", GZIP_LEVEL)
 def test_write_gzip(
@@ -86,9 +82,7 @@ def test_write_gzip(
 
 
 @pytest.mark.zarr_python
-@pytest.mark.benchmark(
-    group="write",
-)
+@pytest.mark.benchmark(group="write")
 @pytest.mark.parametrize("chunk_size", CHUNK_SIZE)
 @pytest.mark.parametrize("zstd_level", ZSTD_LEVEL)
 def test_write_zstd(

--- a/tests/test_write_zarr_python_benchmark.py
+++ b/tests/test_write_zarr_python_benchmark.py
@@ -15,6 +15,7 @@ except ImportError:
     import read_write_zarr_v2 as read_write_zarr
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="write",
 )
@@ -55,6 +56,7 @@ def test_write_blosc(
     )
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="write",
 )
@@ -83,6 +85,7 @@ def test_write_gzip(
     )
 
 
+@pytest.mark.zarr_python
 @pytest.mark.benchmark(
     group="write",
 )


### PR DESCRIPTION
For https://github.com/HEFTIEProject/zarr-benchmarks/issues/10

This PR adds benchmarks for read/write of zarr spec v2 with `tensorstore`. Test with `tox -- --dev-image`.