### PR TITLE
Git ignore uv lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# uv
+uv.lock
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.


### PR DESCRIPTION
A quick one, I used `uv` to make a venv for me and it worked great! I thought worth gitignoring the lockfile it makes though.