### PR TITLE
add action to run benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,41 @@
+---
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+concurrency:
+  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  benchmarks:
+    timeout-minutes: 10
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run benchmarks with tox
+        run: |
+          tox -- --dev-image --rounds=1 --warmup-rounds=0

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   linting:
+    timeout-minutes: 10
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For https://github.com/HEFTIEProject/zarr-benchmarks/issues/21

Adds an action to run the benchmarks with the small dev image (100x100x100 numpy array), using the minimum number of rounds (1) and no warmup rounds. 

I tried using a 1x1x1 image locally, but this wasn't much faster - so sticking with the existing `--dev-image` option for now. In future, once we have more combinations of paramaters / benchmarks, we may want to change this to run a subset of the benchmarks for the sake of fast runtime.