### PR TITLE
Create own pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,86 @@
 ---
 repos:
-  - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.200.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
     hooks:
-      - id: mirsg-hooks
+      - id: ruff
+        args:
+          - --exit-non-zero-on-fix
+          - --fix
+      - id: ruff-format
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.30.0
+    hooks:
+      - id: typos
+        args:
+          - --force-exclude
+          - --hidden
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+        args:
+          - --disable=MD013
+          - --disable=MD033
+          - --dot
+          - --fix
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: forbid-tabs
+        exclude: .tsv$
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort-fix
+        args:
+          - --all
+          - --in-place
+          - --spaces-indent-inline-array=4
+          - --trailing-comma-inline-array
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        args:
+          - --prose-wrap=always
+          - --quote-props=as-needed
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args:
+          - --enforce-all
+          - --maxkb=2000
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+        exclude: .j2$
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.31.2
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args:
+          - --external-sources
+          - --shell=bash
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-pyyaml]
+        exclude: ^testing/resources/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,9 +78,3 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-pyyaml]
-        exclude: ^testing/resources/


### PR DESCRIPTION
Closes #6 

This PR:

- Creates our own `pre-commit-config.yaml`
- Removes unnecessary hooks such as ansible-lint, hado-lint, yaml-lint
- Keeps relevant linting such as ruff, prettier, toml, actions, shell, markdown, json

It runs much faster now so good for developer velocity 🚀 

I tried out mypy and it takes longer to run plus doesn't allow for optional input arguments by default so I didn't include it, but happy to discuss.