### PR TITLE
Move benchmark deps into tox configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "imageio",
+    # Plotting results
     "matplotlib",
     "pandas",
-    "pytest",
-    "pytest-benchmark",
     "seaborn",
-    "tensorstore",
+    # Running benchmarks
     "tox",
-    "zarr",
 ]
 description = "zarr benchmarks"
 license = {file = "LICENSE"}
@@ -47,6 +44,7 @@ markers = [
 overrides."tool.tox.*".inline_arrays = false
 
 [tool.tox]
+deps = ["pytest", "pytest-benchmark", "imageio"]
 env_list = ["py313-zarrv2", "py313-zarrv3", "py313-tensorstore"]
 requires = ["tox>=4.24"]
 


### PR DESCRIPTION
Instead of installing all the test packages as part of the main package in this repo, install them as part of the tox testing environment. Because all the benchmarks are run via tox, there isn't a need to specify them as part of the top level package.

Fixes https://github.com/HEFTIEProject/zarr-benchmarks/issues/26