### PR TITLE
Remove dependency of tensorstore tests on zarr-python

### DIFF
--- a/src/zarr_benchmarks/utils.py
+++ b/src/zarr_benchmarks/utils.py
@@ -29,7 +29,7 @@ def remove_output_dir(output_dir: pathlib.Path) -> None:
 
 def get_directory_size(path: pathlib.Path) -> int:
     """
-    Get total size of a directory.
+    Get total size of a directory in bytes.
     """
     total_size = 0
     if not path.is_dir():

--- a/src/zarr_benchmarks/utils.py
+++ b/src/zarr_benchmarks/utils.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 from typing import Literal
@@ -24,6 +25,21 @@ def get_image(image_dir_path: pathlib.Path) -> np.array:
 def remove_output_dir(output_dir: pathlib.Path) -> None:
     if output_dir.exists():
         shutil.rmtree(output_dir)
+
+
+def get_directory_size(path: pathlib.Path) -> int:
+    """
+    Get total size of a directory.
+    """
+    total_size = 0
+    if not path.is_dir():
+        raise ValueError(f"Path not a directory: {path}")
+    for dirpath, dirnames, filenames in path.walk():
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            total_size += os.path.getsize(fp)
+
+    return total_size
 
 
 def get_numcodec_shuffle(shuffle: Literal["shuffle", "noshuffle", "bitshuffle"]) -> int:

--- a/tests/benchmarks/test_read_tensorstore_benchmark.py
+++ b/tests/benchmarks/test_read_tensorstore_benchmark.py
@@ -10,11 +10,6 @@ from tests.benchmarks.benchmark_parameters import (
 )
 from zarr_benchmarks import read_write_tensorstore
 
-try:
-    from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr
-except ImportError:
-    from zarr_benchmarks import read_write_zarr_v2 as read_write_zarr
-
 pytestmark = [pytest.mark.tensorstore]
 
 
@@ -46,7 +41,7 @@ def test_read_blosc(
         compressor=blosc_compressor,
     )
 
-    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    compression_ratio = read_write_tensorstore.get_compression_ratio(store_path)
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(
@@ -73,7 +68,7 @@ def test_read_gzip(
         compressor=gzip_compressor,
     )
 
-    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    compression_ratio = read_write_tensorstore.get_compression_ratio(store_path)
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(
@@ -100,7 +95,7 @@ def test_read_zstd(
         compressor=zstd_compressor,
     )
 
-    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    compression_ratio = read_write_tensorstore.get_compression_ratio(store_path)
     benchmark.extra_info["compression_ratio"] = compression_ratio
 
     benchmark.pedantic(


### PR DESCRIPTION
See discussion in https://github.com/HEFTIEProject/zarr-benchmarks/pull/39. This removes the dependency of the tensorstore tests on zarr-python, which should enable us to clean up the dependencies of various environments. Because of other open PRs that will conflict, I left cleaning up dependencies for later.

Depends on https://github.com/HEFTIEProject/zarr-benchmarks/pull/42