### PR TITLE
Sort imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ markers = [
     "tensorstore",
     "zarr_python",
 ]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -1,9 +1,10 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from pathlib import Path
+
 import matplotlib.pyplot as plt
-import seaborn as sns
 import pandas as pd
+import seaborn as sns
 
 
 def load_benchmarks_json(path_to_file: Path) -> dict:

--- a/src/zarr_benchmarks/read_write_tensorstore.py
+++ b/src/zarr_benchmarks/read_write_tensorstore.py
@@ -1,7 +1,9 @@
-from typing import Literal
-import tensorstore as ts
-import numpy as np
 import pathlib
+from typing import Literal
+
+import numpy as np
+import tensorstore as ts
+
 from zarr_benchmarks import utils
 
 

--- a/src/zarr_benchmarks/read_write_zarr_v2.py
+++ b/src/zarr_benchmarks/read_write_zarr_v2.py
@@ -1,10 +1,12 @@
-from typing import Literal
-import zarr
-import numcodecs
-from numcodecs import Blosc, GZip, Zstd
 import pathlib
-from zarr_benchmarks import utils
+from typing import Literal
+
+import numcodecs
 import numpy as np
+import zarr
+from numcodecs import Blosc, GZip, Zstd
+
+from zarr_benchmarks import utils
 
 
 def get_compression_ratio(store_path: pathlib.Path) -> float:

--- a/src/zarr_benchmarks/read_write_zarr_v3.py
+++ b/src/zarr_benchmarks/read_write_zarr_v3.py
@@ -1,9 +1,11 @@
 import pathlib
+from typing import Any, Literal
+
 import numpy as np
 import zarr
 from numcodecs import Blosc, GZip, Zstd
 from zarr.codecs import BloscCodec, GzipCodec, ZstdCodec
-from typing import Any, Literal
+
 from zarr_benchmarks import utils
 
 

--- a/src/zarr_benchmarks/utils.py
+++ b/src/zarr_benchmarks/utils.py
@@ -1,9 +1,10 @@
 import pathlib
-from typing import Literal
-import numpy as np
-import imageio.v3 as iio
 import shutil
+from typing import Literal
+
+import imageio.v3 as iio
 import numcodecs
+import numpy as np
 
 
 def get_image(image_dir_path: pathlib.Path) -> np.array:

--- a/tests/benchmarks/test_read_tensorstore_benchmark.py
+++ b/tests/benchmarks/test_read_tensorstore_benchmark.py
@@ -1,9 +1,10 @@
 import pytest
+
 from tests.benchmarks.benchmark_parameters import (
-    CHUNK_SIZE,
     BLOSC_CLEVEL,
     BLOSC_CNAME,
     BLOSC_SHUFFLE,
+    CHUNK_SIZE,
     GZIP_LEVEL,
     ZSTD_LEVEL,
 )

--- a/tests/benchmarks/test_read_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_read_zarr_python_benchmark.py
@@ -1,9 +1,10 @@
 import pytest
+
 from tests.benchmarks.benchmark_parameters import (
-    CHUNK_SIZE,
     BLOSC_CLEVEL,
     BLOSC_CNAME,
     BLOSC_SHUFFLE,
+    CHUNK_SIZE,
     GZIP_LEVEL,
     ZSTD_LEVEL,
 )

--- a/tests/benchmarks/test_write_tensorstore_benchmark.py
+++ b/tests/benchmarks/test_write_tensorstore_benchmark.py
@@ -1,14 +1,15 @@
 import pytest
-from zarr_benchmarks.utils import remove_output_dir
+
 from tests.benchmarks.benchmark_parameters import (
-    CHUNK_SIZE,
     BLOSC_CLEVEL,
-    BLOSC_SHUFFLE,
     BLOSC_CNAME,
+    BLOSC_SHUFFLE,
+    CHUNK_SIZE,
     GZIP_LEVEL,
     ZSTD_LEVEL,
 )
 from zarr_benchmarks import read_write_tensorstore
+from zarr_benchmarks.utils import remove_output_dir
 
 pytestmark = [pytest.mark.tensorstore]
 

--- a/tests/benchmarks/test_write_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_write_zarr_python_benchmark.py
@@ -1,13 +1,14 @@
 import pytest
-from zarr_benchmarks.utils import remove_output_dir
+
 from tests.benchmarks.benchmark_parameters import (
-    CHUNK_SIZE,
     BLOSC_CLEVEL,
-    BLOSC_SHUFFLE,
     BLOSC_CNAME,
+    BLOSC_SHUFFLE,
+    CHUNK_SIZE,
     GZIP_LEVEL,
     ZSTD_LEVEL,
 )
+from zarr_benchmarks.utils import remove_output_dir
 
 try:
     from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-import pytest
 import pathlib
-from zarr_benchmarks.utils import get_image
+
 import numpy as np
+import pytest
+
+from zarr_benchmarks.utils import get_image
 
 
 def pytest_addoption(parser):

--- a/tests/tests/test_write_zarr_array.py
+++ b/tests/tests/test_write_zarr_array.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
+
 from zarr_benchmarks import read_write_tensorstore
-from pathlib import Path
 
 try:
     from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr


### PR DESCRIPTION
This adds configuration for `ruff` to sort imports. I think this is a readability gain.

Note that the ruff config I added is the [default set of options](https://docs.astral.sh/ruff/configuration/), plus `"I"` that enables import sorting.