### PR TITLE
Enable type checking with mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,7 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
@@ -82,7 +81,7 @@ def plot_relplot_benchmarks(
     hue: str,
     size: str,
     title: str,
-    output_filename: str = None,
+    output_filename: str | None = None,
 ) -> None:
     graph = sns.relplot(
         data=data,
@@ -114,7 +113,7 @@ def plot_relplot_subplots_benchmarks(
     x_axis: str,
     y_axis: str,
     hue: str,
-    output_filename: str = None,
+    output_filename: str | None = None,
 ) -> None:
     graph = sns.relplot(
         data=data,
@@ -135,7 +134,7 @@ def plot_relplot_subplots_benchmarks(
         )
 
 
-def get_axis_labels(x_axis: str, y_axis: str, group: str) -> str:
+def get_axis_labels(x_axis: str, y_axis: str, group: str) -> tuple[str, str]:
     if x_axis.startswith("stats"):
         x_axis_label = f"{x_axis.split('.')[-1]} {group} time (s)"
     else:
@@ -149,9 +148,9 @@ def get_axis_labels(x_axis: str, y_axis: str, group: str) -> str:
     return x_axis_label, y_axis_label
 
 
-def save_plot_as_png(plt: plt, output_filename: str) -> None:
+def save_plot_as_png(grid: sns.FacetGrid, output_filename: str) -> None:
     Path(output_filename).parent.mkdir(parents=True, exist_ok=True)
-    plt.savefig(output_filename, format="png", dpi=300)
+    grid.savefig(output_filename, format="png", dpi=300)
 
 
 if __name__ == "__main__":
@@ -176,7 +175,7 @@ if __name__ == "__main__":
     read_zarr_v2_chunks_200 = read_zarr_v2[read_zarr_v2.chunk_size == 200]
 
     benchmark_name = Path(zarr_v2_path).stem
-    data = load_benchmarks_json(zarr_v2_path)
+    data = load_benchmarks_json(Path(zarr_v2_path))
     machine_info = data["machine_info"]["machine"]
     date = datetime.now().strftime("%Y-%m-%d")
 

--- a/src/zarr_benchmarks/read_write_tensorstore.py
+++ b/src/zarr_benchmarks/read_write_tensorstore.py
@@ -1,7 +1,7 @@
 import pathlib
 from typing import Literal
 
-import numpy as np
+import numpy.typing as npt
 import tensorstore as ts
 
 from zarr_benchmarks import utils
@@ -27,7 +27,7 @@ def open_zarr_array(store_path: pathlib.Path) -> ts.TensorStore:
     ).result()
 
 
-def read_zarr_array(store_path: pathlib.Path) -> np.array:
+def read_zarr_array(store_path: pathlib.Path) -> npt.NDArray:
     """Read the v2 zarr spec with tensorstore"""
     zarr_read = open_zarr_array(store_path)
     read_image = zarr_read[:].read().result()
@@ -35,7 +35,7 @@ def read_zarr_array(store_path: pathlib.Path) -> np.array:
 
 
 def write_zarr_array(
-    image: np.array,
+    image: npt.NDArray,
     store_path: pathlib.Path,
     *,
     overwrite: bool,

--- a/src/zarr_benchmarks/read_write_zarr_v2.py
+++ b/src/zarr_benchmarks/read_write_zarr_v2.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import numcodecs
 import numpy as np
+import numpy.typing as npt
 import zarr
 from numcodecs import Blosc, GZip, Zstd
 
@@ -16,14 +17,14 @@ def get_compression_ratio(store_path: pathlib.Path) -> float:
     return compression_ratio
 
 
-def read_zarr_array(store_path: pathlib.Path) -> np.array:
+def read_zarr_array(store_path: pathlib.Path) -> npt.NDArray:
     zarr_read = zarr.open_array(store_path, mode="r")
     read_image = zarr_read[:]
-    return read_image
+    return np.asarray(read_image)
 
 
 def write_zarr_array(
-    image: np.array,
+    image: npt.NDArray,
     store_path: pathlib.Path,
     *,
     overwrite: bool,

--- a/src/zarr_benchmarks/read_write_zarr_v2.py
+++ b/src/zarr_benchmarks/read_write_zarr_v2.py
@@ -2,7 +2,6 @@ import pathlib
 from typing import Literal
 
 import numcodecs
-import numpy as np
 import numpy.typing as npt
 import zarr
 from numcodecs import Blosc, GZip, Zstd

--- a/src/zarr_benchmarks/read_write_zarr_v2.py
+++ b/src/zarr_benchmarks/read_write_zarr_v2.py
@@ -20,7 +20,7 @@ def get_compression_ratio(store_path: pathlib.Path) -> float:
 def read_zarr_array(store_path: pathlib.Path) -> npt.NDArray:
     zarr_read = zarr.open_array(store_path, mode="r")
     read_image = zarr_read[:]
-    return np.asarray(read_image)
+    return read_image
 
 
 def write_zarr_array(

--- a/src/zarr_benchmarks/read_write_zarr_v3.py
+++ b/src/zarr_benchmarks/read_write_zarr_v3.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import Any, Literal
 
-import numpy as np
 import numpy.typing as npt
 import zarr
 from numcodecs import Blosc, GZip, Zstd

--- a/src/zarr_benchmarks/read_write_zarr_v3.py
+++ b/src/zarr_benchmarks/read_write_zarr_v3.py
@@ -2,6 +2,7 @@ import pathlib
 from typing import Any, Literal
 
 import numpy as np
+import numpy.typing as npt
 import zarr
 from numcodecs import Blosc, GZip, Zstd
 from zarr.codecs import BloscCodec, GzipCodec, ZstdCodec
@@ -16,14 +17,14 @@ def get_compression_ratio(store_path: pathlib.Path) -> float:
     return compression_ratio
 
 
-def read_zarr_array(store_path: pathlib.Path) -> np.array:
+def read_zarr_array(store_path: pathlib.Path) -> npt.NDArray:
     zarr_read = zarr.open_array(store_path, mode="r")
     read_image = zarr_read[:]
-    return read_image
+    return np.asarray(read_image)
 
 
 def write_zarr_array(
-    image: np.array,
+    image: npt.NDArray,
     store_path: pathlib.Path,
     *,
     overwrite: bool,

--- a/src/zarr_benchmarks/read_write_zarr_v3.py
+++ b/src/zarr_benchmarks/read_write_zarr_v3.py
@@ -20,7 +20,7 @@ def get_compression_ratio(store_path: pathlib.Path) -> float:
 def read_zarr_array(store_path: pathlib.Path) -> npt.NDArray:
     zarr_read = zarr.open_array(store_path, mode="r")
     read_image = zarr_read[:]
-    return np.asarray(read_image)
+    return read_image
 
 
 def write_zarr_array(

--- a/src/zarr_benchmarks/utils.py
+++ b/src/zarr_benchmarks/utils.py
@@ -6,9 +6,10 @@ from typing import Literal
 import imageio.v3 as iio
 import numcodecs
 import numpy as np
+import numpy.typing as npt
 
 
-def get_image(image_dir_path: pathlib.Path) -> np.array:
+def get_image(image_dir_path: pathlib.Path) -> npt.NDArray:
     """Read a series of jpeg to one 3D numpy array"""
     image_slices = []
     for image_slice in image_dir_path.iterdir():

--- a/tests/benchmarks/test_read_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_read_zarr_python_benchmark.py
@@ -12,7 +12,9 @@ from tests.benchmarks.benchmark_parameters import (
 try:
     from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr
 except ImportError:
-    from zarr_benchmarks import read_write_zarr_v2 as read_write_zarr
+    from zarr_benchmarks import (  # type: ignore[no-redef]
+        read_write_zarr_v2 as read_write_zarr,
+    )
 
 pytestmark = [pytest.mark.zarr_python]
 

--- a/tests/benchmarks/test_write_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_write_zarr_python_benchmark.py
@@ -13,7 +13,9 @@ from zarr_benchmarks.utils import remove_output_dir
 try:
     from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr
 except ImportError:
-    from zarr_benchmarks import read_write_zarr_v2 as read_write_zarr
+    from zarr_benchmarks import (  # type: ignore[no-redef]
+        read_write_zarr_v2 as read_write_zarr,
+    )
 
 pytestmark = [pytest.mark.zarr_python]
 

--- a/tests/tests/test_write_zarr_array.py
+++ b/tests/tests/test_write_zarr_array.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -8,11 +9,13 @@ from zarr_benchmarks import read_write_tensorstore
 try:
     from zarr_benchmarks import read_write_zarr_v3 as read_write_zarr
 except ImportError:
-    from zarr_benchmarks import read_write_zarr_v2 as read_write_zarr
+    from zarr_benchmarks import (  # type: ignore[no-redef]
+        read_write_zarr_v2 as read_write_zarr,
+    )
 
 
 def assert_empty_chunks_written(
-    output_dir: Path, write_zarr_array: callable, write_empty_chunks: bool
+    output_dir: Path, write_zarr_array: Callable, write_empty_chunks: bool
 ) -> None:
     """Check an empty chunk is written to file when write_empty_chunks=True"""
 


### PR DESCRIPTION
If we're adding typing, we might as well check it's correct. This adds `mypy` to pre-commit to check the typing, and also fixes the errors it found.