### PR TITLE
add example results from full-size image benchmarks

### DIFF
--- a/example_results/0001_zarr-python-v2.json
+++ b/example_results/0001_zarr-python-v2.json
@@ -1,0 +1,18131 @@
+{
+  "machine_info": {
+    "node": "FLDSMDFR-2",
+    "processor": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "machine": "AMD64",
+    "python_compiler": "MSC v.1942 64 bit (AMD64)",
+    "python_implementation": "CPython",
+    "python_implementation_version": "3.13.2",
+    "python_version": "3.13.2",
+    "python_build": ["main", "Feb 17 2025 13:52:56"],
+    "release": "11",
+    "system": "Windows",
+    "cpu": {
+      "python_version": "3.13.2.final.0 (64 bit)",
+      "cpuinfo_version": [9, 0, 0],
+      "cpuinfo_version_string": "9.0.0",
+      "arch": "X86_64",
+      "bits": 64,
+      "count": 24,
+      "arch_string_raw": "AMD64",
+      "vendor_id_raw": "GenuineIntel",
+      "brand_raw": "13th Gen Intel(R) Core(TM) i7-13700K",
+      "hz_actual_friendly": "3.4000 GHz",
+      "hz_actual": [3400000000, 0],
+      "l2_cache_size": 25165824,
+      "stepping": 1,
+      "model": 183,
+      "family": 6,
+      "l3_cache_size": 31457280,
+      "hz_advertised_friendly": "3.4180 GHz",
+      "hz_advertised": [3418000000, 0],
+      "flags": [
+        "3dnow",
+        "3dnowprefetch",
+        "abm",
+        "acpi",
+        "adx",
+        "aes",
+        "apic",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "clflush",
+        "clflushopt",
+        "clwb",
+        "cmov",
+        "cx16",
+        "cx8",
+        "de",
+        "dts",
+        "erms",
+        "est",
+        "f16c",
+        "fma",
+        "fpu",
+        "fxsr",
+        "gfni",
+        "ht",
+        "hypervisor",
+        "ia64",
+        "intel_pt",
+        "invpcid",
+        "lahf_lm",
+        "mca",
+        "mce",
+        "mmx",
+        "monitor",
+        "movbe",
+        "msr",
+        "mtrr",
+        "osxsave",
+        "pae",
+        "pat",
+        "pbe",
+        "pcid",
+        "pclmulqdq",
+        "pdcm",
+        "pge",
+        "pni",
+        "popcnt",
+        "pse",
+        "pse36",
+        "rdpid",
+        "rdrnd",
+        "rdseed",
+        "sep",
+        "serial",
+        "sha",
+        "smap",
+        "smep",
+        "ss",
+        "sse",
+        "sse2",
+        "sse4_1",
+        "sse4_2",
+        "ssse3",
+        "tm",
+        "tm2",
+        "tsc",
+        "tscdeadline",
+        "umip",
+        "vaes",
+        "vme",
+        "vpclmulqdq",
+        "x2apic",
+        "xsave",
+        "xtpr"
+      ],
+      "l2_cache_line_size": 2048,
+      "l2_cache_associativity": 7
+    }
+  },
+  "commit_info": {
+    "id": "unknown",
+    "time": null,
+    "author_time": null,
+    "dirty": false,
+    "error": "FileNotFoundError(2, 'The system cannot find the file specified', None, 2, None)",
+    "project": "zarr-benchmarks",
+    "branch": "(unknown)"
+  },
+  "benchmarks": [
+    {
+      "group": "read",
+      "name": "test_read_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9142235100928449
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6048639000000549,
+        "max": 0.6255302999998094,
+        "mean": 0.6128307999994528,
+        "stddev": 0.011116346041495294,
+        "rounds": 3,
+        "median": 0.6080981999984942,
+        "iqr": 0.015499799999815878,
+        "q1": 0.6056724749996647,
+        "q3": 0.6211722749994806,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6048639000000549,
+        "hd15iqr": 0.6255302999998094,
+        "ops": 1.6317717712636064,
+        "total": 1.8384923999983585,
+        "data": [0.6080981999984942, 0.6255302999998094, 0.6048639000000549],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9130178602183359
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5933172000004561,
+        "max": 0.6023373999996693,
+        "mean": 0.5976232666677485,
+        "stddev": 0.004523924270866748,
+        "rounds": 3,
+        "median": 0.5972152000031201,
+        "iqr": 0.006765149999409914,
+        "q1": 0.5942917000011221,
+        "q3": 0.601056850000532,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5933172000004561,
+        "hd15iqr": 0.6023373999996693,
+        "ops": 1.6732949598429119,
+        "total": 1.7928698000032455,
+        "data": [0.5933172000004561, 0.5972152000031201, 0.6023373999996693],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9117305186869487
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.570866299996851,
+        "max": 0.5838788999972166,
+        "mean": 0.5769263333301448,
+        "stddev": 0.006552053228287121,
+        "rounds": 3,
+        "median": 0.5760337999963667,
+        "iqr": 0.009759450000274228,
+        "q1": 0.5721581749967299,
+        "q3": 0.5819176249970042,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.570866299996851,
+        "hd15iqr": 0.5838788999972166,
+        "ops": 1.7333235496944326,
+        "total": 1.7307789999904344,
+        "data": [0.5760337999963667, 0.5838788999972166, 0.570866299996851],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9118823240330303
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.529228499995952,
+        "max": 0.5430991999965045,
+        "mean": 0.5365540999967683,
+        "stddev": 0.0069682110197019686,
+        "rounds": 3,
+        "median": 0.5373345999978483,
+        "iqr": 0.010403025000414345,
+        "q1": 0.5312550249964261,
+        "q3": 0.5416580499968404,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.529228499995952,
+        "hd15iqr": 0.5430991999965045,
+        "ops": 1.86374496067782,
+        "total": 1.6096622999903047,
+        "data": [0.5373345999978483, 0.529228499995952, 0.5430991999965045],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4642340103541889
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4967075000022305,
+        "max": 0.5198192000025301,
+        "mean": 0.5060912666667718,
+        "stddev": 0.012152839473820362,
+        "rounds": 3,
+        "median": 0.5017470999955549,
+        "iqr": 0.017333775000224705,
+        "q1": 0.4979674000005616,
+        "q3": 0.5153011750007863,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4967075000022305,
+        "hd15iqr": 0.5198192000025301,
+        "ops": 1.975928188973146,
+        "total": 1.5182738000003155,
+        "data": [0.4967075000022305, 0.5017470999955549, 0.5198192000025301],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5200611306575664
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46844070000224747,
+        "max": 0.4929875000016182,
+        "mean": 0.4814508666677284,
+        "stddev": 0.012339563319330189,
+        "rounds": 3,
+        "median": 0.4829243999993196,
+        "iqr": 0.01841009999952803,
+        "q1": 0.4720616250015155,
+        "q3": 0.4904717250010435,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46844070000224747,
+        "hd15iqr": 0.4929875000016182,
+        "ops": 2.077055145671067,
+        "total": 1.4443526000031852,
+        "data": [0.4929875000016182, 0.4829243999993196, 0.46844070000224747],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7091701375287827
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4517122000033851,
+        "max": 0.46159349999652477,
+        "mean": 0.45798429999801255,
+        "stddev": 0.005452366429412864,
+        "rounds": 3,
+        "median": 0.46064719999412773,
+        "iqr": 0.007410974994854769,
+        "q1": 0.45394595000107074,
+        "q3": 0.4613569249959255,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4517122000033851,
+        "hd15iqr": 0.46159349999652477,
+        "ops": 2.1834809621297926,
+        "total": 1.3739528999940376,
+        "data": [0.46064719999412773, 0.4517122000033851, 0.46159349999652477],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8569406689889976
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5698667999968166,
+        "max": 0.5788010000032955,
+        "mean": 0.5757400999985597,
+        "stddev": 0.005087944353696967,
+        "rounds": 3,
+        "median": 0.5785524999955669,
+        "iqr": 0.006700650004859199,
+        "q1": 0.5720382249965041,
+        "q3": 0.5787388750013633,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5698667999968166,
+        "hd15iqr": 0.5788010000032955,
+        "ops": 1.7368948245962055,
+        "total": 1.727220299995679,
+        "data": [0.5788010000032955, 0.5698667999968166, 0.5785524999955669],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8171482584256577
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5078419999990729,
+        "max": 0.5265801999994437,
+        "mean": 0.5159354333324396,
+        "stddev": 0.009626110904616203,
+        "rounds": 3,
+        "median": 0.5133840999988024,
+        "iqr": 0.01405365000027814,
+        "q1": 0.5092275249990053,
+        "q3": 0.5232811749992834,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5078419999990729,
+        "hd15iqr": 0.5265801999994437,
+        "ops": 1.9382270249224314,
+        "total": 1.547806299997319,
+        "data": [0.5078419999990729, 0.5265801999994437, 0.5133840999988024],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5304637186342946
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.489088799993624,
+        "max": 0.5002553000012995,
+        "mean": 0.49556909999713145,
+        "stddev": 0.005795409969197748,
+        "rounds": 3,
+        "median": 0.49736319999647094,
+        "iqr": 0.008374875005756621,
+        "q1": 0.4911573999943357,
+        "q3": 0.49953227500009234,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.489088799993624,
+        "hd15iqr": 0.5002553000012995,
+        "ops": 2.017882067315715,
+        "total": 1.4867072999913944,
+        "data": [0.5002553000012995, 0.489088799993624, 0.49736319999647094],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.523364534600934
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4757312000001548,
+        "max": 0.47674800000095274,
+        "mean": 0.4762725666660117,
+        "stddev": 0.0005115964850347659,
+        "rounds": 3,
+        "median": 0.47633849999692757,
+        "iqr": 0.0007626000005984679,
+        "q1": 0.475883024999348,
+        "q3": 0.47664562499994645,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4757312000001548,
+        "hd15iqr": 0.47674800000095274,
+        "ops": 2.099638043400586,
+        "total": 1.428817699998035,
+        "data": [0.47674800000095274, 0.4757312000001548, 0.47633849999692757],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7170508534547024
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46657750000304077,
+        "max": 0.47565250000479864,
+        "mean": 0.46967333333547384,
+        "stddev": 0.005179200189865215,
+        "rounds": 3,
+        "median": 0.46678999999858206,
+        "iqr": 0.0068062500013184035,
+        "q1": 0.4666306250019261,
+        "q3": 0.4734368750032445,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46657750000304077,
+        "hd15iqr": 0.47565250000479864,
+        "ops": 2.1291394018440672,
+        "total": 1.4090200000064215,
+        "data": [0.47565250000479864, 0.46657750000304077, 0.46678999999858206],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8828477160527375
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.648896099999547,
+        "max": 0.6533714999968652,
+        "mean": 0.6517867999985659,
+        "stddev": 0.0025072950136369185,
+        "rounds": 3,
+        "median": 0.6530927999992855,
+        "iqr": 0.0033565499979886226,
+        "q1": 0.6499452749994816,
+        "q3": 0.6533018249974702,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.648896099999547,
+        "hd15iqr": 0.6533714999968652,
+        "ops": 1.5342440196736116,
+        "total": 1.9553603999956977,
+        "data": [0.648896099999547, 0.6533714999968652, 0.6530927999992855],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8683558466995238
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4690455000018119,
+        "max": 0.47277000000030966,
+        "mean": 0.4710482000009506,
+        "stddev": 0.0018780717949827264,
+        "rounds": 3,
+        "median": 0.47132910000073025,
+        "iqr": 0.0027933749988733325,
+        "q1": 0.4696164000015415,
+        "q3": 0.4724097750004148,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4690455000018119,
+        "hd15iqr": 0.47277000000030966,
+        "ops": 2.1229250000275597,
+        "total": 1.4131446000028518,
+        "data": [0.4690455000018119, 0.47277000000030966, 0.47132910000073025],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.589715055073732
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5238144999966607,
+        "max": 0.5305386000036378,
+        "mean": 0.5268656333331213,
+        "stddev": 0.0034049064227177793,
+        "rounds": 3,
+        "median": 0.5262437999990652,
+        "iqr": 0.005043075005232822,
+        "q1": 0.5244218249972619,
+        "q3": 0.5294649000024947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5238144999966607,
+        "hd15iqr": 0.5305386000036378,
+        "ops": 1.8980171351729258,
+        "total": 1.5805968999993638,
+        "data": [0.5262437999990652, 0.5238144999966607, 0.5305386000036378],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5340085378197466
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48677499999757856,
+        "max": 0.5089220000008936,
+        "mean": 0.4978002666660662,
+        "stddev": 0.011073815135263688,
+        "rounds": 3,
+        "median": 0.49770379999972647,
+        "iqr": 0.016610250002486282,
+        "q1": 0.48950719999811554,
+        "q3": 0.5061174500006018,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48677499999757856,
+        "hd15iqr": 0.5089220000008936,
+        "ops": 2.008837815008281,
+        "total": 1.4934007999981986,
+        "data": [0.48677499999757856, 0.49770379999972647, 0.5089220000008936],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.760191094214826
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47914070000115316,
+        "max": 0.4995033000013791,
+        "mean": 0.49128813333421323,
+        "stddev": 0.010735730554604915,
+        "rounds": 3,
+        "median": 0.4952204000001075,
+        "iqr": 0.015271950000169454,
+        "q1": 0.48316062500089174,
+        "q3": 0.4984325750010612,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47914070000115316,
+        "hd15iqr": 0.4995033000013791,
+        "ops": 2.0354654064475857,
+        "total": 1.4738644000026397,
+        "data": [0.4952204000001075, 0.47914070000115316, 0.4995033000013791],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.902533931702627
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8405898999990313,
+        "max": 0.8643003000033787,
+        "mean": 0.8539603000002293,
+        "stddev": 0.012142209856639255,
+        "rounds": 3,
+        "median": 0.8569906999982777,
+        "iqr": 0.01778280000326049,
+        "q1": 0.8446900999988429,
+        "q3": 0.8624729000021034,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8405898999990313,
+        "hd15iqr": 0.8643003000033787,
+        "ops": 1.1710146244500261,
+        "total": 2.5618809000006877,
+        "data": [0.8643003000033787, 0.8569906999982777, 0.8405898999990313],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.910052164487152
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5123069999972358,
+        "max": 0.5268222000013338,
+        "mean": 0.5218582666663375,
+        "stddev": 0.0082737825768138,
+        "rounds": 3,
+        "median": 0.5264456000004429,
+        "iqr": 0.010886400003073504,
+        "q1": 0.5158416499980376,
+        "q3": 0.5267280500011111,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5123069999972358,
+        "hd15iqr": 0.5268222000013338,
+        "ops": 1.916229106397147,
+        "total": 1.5655747999990126,
+        "data": [0.5123069999972358, 0.5264456000004429, 0.5268222000013338],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904688511985352
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6379579000058584,
+        "max": 0.6486529000030714,
+        "mean": 0.6434385000029579,
+        "stddev": 0.00535246700726806,
+        "rounds": 3,
+        "median": 0.6437046999999438,
+        "iqr": 0.008021249997909763,
+        "q1": 0.6393946000043798,
+        "q3": 0.6474158500022895,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6379579000058584,
+        "hd15iqr": 0.6486529000030714,
+        "ops": 1.5541500858207942,
+        "total": 1.9303155000088736,
+        "data": [0.6486529000030714, 0.6379579000058584, 0.6437046999999438],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5805268381721949
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5631617000035476,
+        "max": 0.5696649000019534,
+        "mean": 0.565544100002929,
+        "stddev": 0.0035832148238537703,
+        "rounds": 3,
+        "median": 0.5638057000032859,
+        "iqr": 0.0048773999988043215,
+        "q1": 0.5633227000034822,
+        "q3": 0.5682001000022865,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5631617000035476,
+        "hd15iqr": 0.5696649000019534,
+        "ops": 1.768208703786002,
+        "total": 1.6966323000087868,
+        "data": [0.5631617000035476, 0.5638057000032859, 0.5696649000019534],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7911155124807967
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5383295000065118,
+        "max": 0.5434883999987505,
+        "mean": 0.541068066668231,
+        "stddev": 0.002594131188335519,
+        "rounds": 3,
+        "median": 0.5413862999994308,
+        "iqr": 0.0038691749941790476,
+        "q1": 0.5390937000047415,
+        "q3": 0.5429628749989206,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5383295000065118,
+        "hd15iqr": 0.5434883999987505,
+        "ops": 1.8481963020988526,
+        "total": 1.6232042000046931,
+        "data": [0.5434883999987505, 0.5413862999994308, 0.5383295000065118],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9460769417247328
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2468561999994563,
+        "max": 1.2536512000006041,
+        "mean": 1.2494659000003594,
+        "stddev": 0.0036612692843252994,
+        "rounds": 3,
+        "median": 1.2478903000010177,
+        "iqr": 0.005096250000860891,
+        "q1": 1.2471147249998467,
+        "q3": 1.2522109750007075,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2468561999994563,
+        "hd15iqr": 1.2536512000006041,
+        "ops": 0.8003419701167613,
+        "total": 3.748397700001078,
+        "data": [1.2478903000010177, 1.2468561999994563, 1.2536512000006041],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9737890938213212
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6037041999952635,
+        "max": 0.6111409000004642,
+        "mean": 0.6074031000001318,
+        "stddev": 0.00371850260845321,
+        "rounds": 3,
+        "median": 0.6073642000046675,
+        "iqr": 0.005577525003900519,
+        "q1": 0.6046191999976145,
+        "q3": 0.610196725001515,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6037041999952635,
+        "hd15iqr": 0.6111409000004642,
+        "ops": 1.6463531384673262,
+        "total": 1.8222093000003952,
+        "data": [0.6111409000004642, 0.6073642000046675, 0.6037041999952635],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904688511985352
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.637323999995715,
+        "max": 0.6431441999957315,
+        "mean": 0.6408908999971269,
+        "stddev": 0.0031245544859355057,
+        "rounds": 3,
+        "median": 0.6422044999999343,
+        "iqr": 0.004365150000012363,
+        "q1": 0.6385441249967698,
+        "q3": 0.6429092749967822,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.637323999995715,
+        "hd15iqr": 0.6431441999957315,
+        "ops": 1.5603279747059646,
+        "total": 1.9226726999913808,
+        "data": [0.6422044999999343, 0.637323999995715, 0.6431441999957315],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.584049224992698
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.54383450000023,
+        "max": 0.5586855000001378,
+        "mean": 0.552027066667506,
+        "stddev": 0.007543422569740152,
+        "rounds": 3,
+        "median": 0.5535612000021501,
+        "iqr": 0.01113824999993085,
+        "q1": 0.5462661750007101,
+        "q3": 0.5574044250006409,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.54383450000023,
+        "hd15iqr": 0.5586855000001378,
+        "ops": 1.8115053778736445,
+        "total": 1.656081200002518,
+        "data": [0.54383450000023, 0.5535612000021501, 0.5586855000001378],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8143126771756353
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5381847000026028,
+        "max": 0.5448757999984082,
+        "mean": 0.5406483333329865,
+        "stddev": 0.00367777593306207,
+        "rounds": 3,
+        "median": 0.5388844999979483,
+        "iqr": 0.005018324996854062,
+        "q1": 0.5383596500014391,
+        "q3": 0.5433779749982932,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5381847000026028,
+        "hd15iqr": 0.5448757999984082,
+        "ops": 1.8496311527221485,
+        "total": 1.6219449999989592,
+        "data": [0.5448757999984082, 0.5388844999979483, 0.5381847000026028],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9649828413427581
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2195173000000068,
+        "max": 1.259980100003304,
+        "mean": 1.234928966667212,
+        "stddev": 0.021886046565612025,
+        "rounds": 3,
+        "median": 1.2252894999983255,
+        "iqr": 0.03034710000247287,
+        "q1": 1.2209603499995865,
+        "q3": 1.2513074500020593,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2195173000000068,
+        "hd15iqr": 1.259980100003304,
+        "ops": 0.8097631742324167,
+        "total": 3.7047869000016362,
+        "data": [1.2195173000000068, 1.2252894999983255, 1.259980100003304],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.982129616640949
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5870203000013134,
+        "max": 0.5952013999994961,
+        "mean": 0.5916193333323463,
+        "stddev": 0.004184287895407413,
+        "rounds": 3,
+        "median": 0.5926362999962294,
+        "iqr": 0.006135824998636963,
+        "q1": 0.5884243000000424,
+        "q3": 0.5945601249986794,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5870203000013134,
+        "hd15iqr": 0.5952013999994961,
+        "ops": 1.690276067158615,
+        "total": 1.7748579999970389,
+        "data": [0.5952013999994961, 0.5870203000013134, 0.5926362999962294],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.585119298842301
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7848317000025418,
+        "max": 0.7935400000060326,
+        "mean": 0.788928666668653,
+        "stddev": 0.0043768769736061315,
+        "rounds": 3,
+        "median": 0.7884142999973847,
+        "iqr": 0.006531225002618157,
+        "q1": 0.7857273500012525,
+        "q3": 0.7922585750038706,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7848317000025418,
+        "hd15iqr": 0.7935400000060326,
+        "ops": 1.2675417211325597,
+        "total": 2.366786000005959,
+        "data": [0.7848317000025418, 0.7935400000060326, 0.7884142999973847],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5886821806475286
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6345935999997891,
+        "max": 0.6537779000063892,
+        "mean": 0.6462371000015992,
+        "stddev": 0.010229049424798463,
+        "rounds": 3,
+        "median": 0.6503397999986191,
+        "iqr": 0.014388225004950073,
+        "q1": 0.6385301499994966,
+        "q3": 0.6529183750044467,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6345935999997891,
+        "hd15iqr": 0.6537779000063892,
+        "ops": 1.5474196699594087,
+        "total": 1.9387113000047975,
+        "data": [0.6345935999997891, 0.6537779000063892, 0.6503397999986191],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8340805338917407
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.526656499998353,
+        "max": 0.5446909000020241,
+        "mean": 0.5379389666680557,
+        "stddev": 0.00983382911702017,
+        "rounds": 3,
+        "median": 0.54246950000379,
+        "iqr": 0.013525800002753385,
+        "q1": 0.5306097499997122,
+        "q3": 0.5441355500024656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.526656499998353,
+        "hd15iqr": 0.5446909000020241,
+        "ops": 1.8589469474463016,
+        "total": 1.613816900004167,
+        "data": [0.526656499998353, 0.5446909000020241, 0.54246950000379],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9776813990348094
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1503423000031034,
+        "max": 1.159673499998462,
+        "mean": 1.154252366667303,
+        "stddev": 0.004845649099175621,
+        "rounds": 3,
+        "median": 1.1527413000003435,
+        "iqr": 0.006998399996518856,
+        "q1": 1.1509420500024135,
+        "q3": 1.1579404499989323,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1503423000031034,
+        "hd15iqr": 1.159673499998462,
+        "ops": 0.8663616630800776,
+        "total": 3.462757100001909,
+        "data": [1.1503423000031034, 1.159673499998462, 1.1527413000003435],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9897956150038008
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6870536999995238,
+        "max": 0.7045231999945827,
+        "mean": 0.6970279666638817,
+        "stddev": 0.00899472413258888,
+        "rounds": 3,
+        "median": 0.6995069999975385,
+        "iqr": 0.013102124996294151,
+        "q1": 0.6901670249990275,
+        "q3": 0.7032691499953216,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6870536999995238,
+        "hd15iqr": 0.7045231999945827,
+        "ops": 1.4346626646649552,
+        "total": 2.091083899991645,
+        "data": [0.6870536999995238, 0.6995069999975385, 0.7045231999945827],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5977228454754633
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7867331000015838,
+        "max": 0.7916949999998906,
+        "mean": 0.7890919666654858,
+        "stddev": 0.00248994496335512,
+        "rounds": 3,
+        "median": 0.7888477999949828,
+        "iqr": 0.003721424998730072,
+        "q1": 0.7872617749999336,
+        "q3": 0.7909831999986636,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7867331000015838,
+        "hd15iqr": 0.7916949999998906,
+        "ops": 1.2672794075268075,
+        "total": 2.367275899996457,
+        "data": [0.7867331000015838, 0.7888477999949828, 0.7916949999998906],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5925611743395638
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6607211000009556,
+        "max": 0.6700744000045233,
+        "mean": 0.6648835333350386,
+        "stddev": 0.004760704946035733,
+        "rounds": 3,
+        "median": 0.6638550999996369,
+        "iqr": 0.007014975002675783,
+        "q1": 0.6615046000006259,
+        "q3": 0.6685195750033017,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6607211000009556,
+        "hd15iqr": 0.6700744000045233,
+        "ops": 1.5040228098055397,
+        "total": 1.9946506000051158,
+        "data": [0.6638550999996369, 0.6700744000045233, 0.6607211000009556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8501842658208678
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5193310000031488,
+        "max": 0.5356616999997641,
+        "mean": 0.5256637000008292,
+        "stddev": 0.008760636887193743,
+        "rounds": 3,
+        "median": 0.5219983999995748,
+        "iqr": 0.01224802499746147,
+        "q1": 0.5199978500022553,
+        "q3": 0.5322458749997168,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5193310000031488,
+        "hd15iqr": 0.5356616999997641,
+        "ops": 1.9023569632037034,
+        "total": 1.5769911000024877,
+        "data": [0.5193310000031488, 0.5356616999997641, 0.5219983999995748],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9829446374707804
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1780095999929472,
+        "max": 1.2141616999942926,
+        "mean": 1.1959567333299976,
+        "stddev": 0.018077429080079328,
+        "rounds": 3,
+        "median": 1.1956989000027534,
+        "iqr": 0.02711407500100904,
+        "q1": 1.1824319249953987,
+        "q3": 1.2095459999964078,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1780095999929472,
+        "hd15iqr": 1.2141616999942926,
+        "ops": 0.8361506500453576,
+        "total": 3.587870199989993,
+        "data": [1.1780095999929472, 1.2141616999942926, 1.1956989000027534],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9890801910613674
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7255816999968374,
+        "max": 0.7391325999997207,
+        "mean": 0.7328080999989955,
+        "stddev": 0.006820321871544922,
+        "rounds": 3,
+        "median": 0.7337100000004284,
+        "iqr": 0.010163175002162461,
+        "q1": 0.7276137749977352,
+        "q3": 0.7377769499998976,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7255816999968374,
+        "hd15iqr": 0.7391325999997207,
+        "ops": 1.3646137372135634,
+        "total": 2.1984242999969865,
+        "data": [0.7255816999968374, 0.7337100000004284, 0.7391325999997207],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.6036514878200498
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8009012999973493,
+        "max": 0.8302640999972937,
+        "mean": 0.814373899998221,
+        "stddev": 0.01482993925384255,
+        "rounds": 3,
+        "median": 0.8119563000000198,
+        "iqr": 0.0220220999999583,
+        "q1": 0.8036650499980169,
+        "q3": 0.8256871499979752,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8009012999973493,
+        "hd15iqr": 0.8302640999972937,
+        "ops": 1.2279371919976618,
+        "total": 2.4431216999946628,
+        "data": [0.8302640999972937, 0.8119563000000198, 0.8009012999973493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5994497842896909
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6666211999981897,
+        "max": 0.6830300000001444,
+        "mean": 0.6731767999978425,
+        "stddev": 0.008687220712583483,
+        "rounds": 3,
+        "median": 0.6698791999951936,
+        "iqr": 0.012306600001465995,
+        "q1": 0.6674356999974407,
+        "q3": 0.6797422999989067,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6666211999981897,
+        "hd15iqr": 0.6830300000001444,
+        "ops": 1.4854938554079773,
+        "total": 2.0195303999935277,
+        "data": [0.6698791999951936, 0.6666211999981897, 0.6830300000001444],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8626923305989416
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.512967300004675,
+        "max": 0.5329263000021456,
+        "mean": 0.5249829000022146,
+        "stddev": 0.010584305827032278,
+        "rounds": 3,
+        "median": 0.5290550999998231,
+        "iqr": 0.014969249998102896,
+        "q1": 0.5169892500034621,
+        "q3": 0.531958500001565,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.512967300004675,
+        "hd15iqr": 0.5329263000021456,
+        "ops": 1.9048239475910198,
+        "total": 1.5749487000066438,
+        "data": [0.5290550999998231, 0.5329263000021456, 0.512967300004675],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9894077164496287
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.132653599997866,
+        "max": 1.1693556000027456,
+        "mean": 1.151213066666969,
+        "stddev": 0.018354551918880392,
+        "rounds": 3,
+        "median": 1.1516300000002957,
+        "iqr": 0.02752650000365975,
+        "q1": 1.1373976999984734,
+        "q3": 1.1649242000021331,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.132653599997866,
+        "hd15iqr": 1.1693556000027456,
+        "ops": 0.8686489312488728,
+        "total": 3.4536392000009073,
+        "data": [1.1516300000002957, 1.1693556000027456, 1.132653599997866],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9965852079529791
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6657226000024821,
+        "max": 0.6929142000008142,
+        "mean": 0.6781230333338802,
+        "stddev": 0.013752544565590585,
+        "rounds": 3,
+        "median": 0.6757322999983444,
+        "iqr": 0.02039369999874907,
+        "q1": 0.6682250250014476,
+        "q3": 0.6886187250001967,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6657226000024821,
+        "hd15iqr": 0.6929142000008142,
+        "ops": 1.4746586546156155,
+        "total": 2.0343691000016406,
+        "data": [0.6757322999983444, 0.6657226000024821, 0.6929142000008142],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.604916544871098
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7824197000009008,
+        "max": 0.8240433999962988,
+        "mean": 0.8013995666672903,
+        "stddev": 0.021052353528888717,
+        "rounds": 3,
+        "median": 0.7977356000046711,
+        "iqr": 0.031217774996548542,
+        "q1": 0.7862486750018434,
+        "q3": 0.8174664499983919,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7824197000009008,
+        "hd15iqr": 0.8240433999962988,
+        "ops": 1.2478169961566261,
+        "total": 2.4041987000018707,
+        "data": [0.7977356000046711, 0.7824197000009008, 0.8240433999962988],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.6047553009397102
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6422144000025582,
+        "max": 0.651194400001259,
+        "mean": 0.6457656333344252,
+        "stddev": 0.004775348004292568,
+        "rounds": 3,
+        "median": 0.6438880999994581,
+        "iqr": 0.006734999999025604,
+        "q1": 0.6426328250017832,
+        "q3": 0.6493678250008088,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6422144000025582,
+        "hd15iqr": 0.651194400001259,
+        "ops": 1.5485494247138516,
+        "total": 1.9372969000032754,
+        "data": [0.6438880999994581, 0.6422144000025582, 0.651194400001259],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8749816867062035
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5105742999949143,
+        "max": 0.5408199000012246,
+        "mean": 0.5267257999973177,
+        "stddev": 0.015227401321328249,
+        "rounds": 3,
+        "median": 0.5287831999958144,
+        "iqr": 0.022684200004732702,
+        "q1": 0.5151265249951393,
+        "q3": 0.537810724999872,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5105742999949143,
+        "hd15iqr": 0.5408199000012246,
+        "ops": 1.8985210141692173,
+        "total": 1.5801773999919533,
+        "data": [0.5408199000012246, 0.5105742999949143, 0.5287831999958144],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9943418172032257
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1453447000021697,
+        "max": 1.1670085000005201,
+        "mean": 1.1566879666667471,
+        "stddev": 0.01086805158211837,
+        "rounds": 3,
+        "median": 1.1577106999975513,
+        "iqr": 0.01624784999876283,
+        "q1": 1.148436200001015,
+        "q3": 1.164684049999778,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1453447000021697,
+        "hd15iqr": 1.1670085000005201,
+        "ops": 0.8645373936773302,
+        "total": 3.470063900000241,
+        "data": [1.1577106999975513, 1.1453447000021697, 1.1670085000005201],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.0392725993080854
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7595633000019006,
+        "max": 0.7773606000046129,
+        "mean": 0.7708532666705045,
+        "stddev": 0.00981535318039065,
+        "rounds": 3,
+        "median": 0.7756359000049997,
+        "iqr": 0.013347975002034218,
+        "q1": 0.7635814500026754,
+        "q3": 0.7769294250047096,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7595633000019006,
+        "hd15iqr": 0.7773606000046129,
+        "ops": 1.2972637507514677,
+        "total": 2.3125598000115133,
+        "data": [0.7756359000049997, 0.7773606000046129, 0.7595633000019006],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070701192516244
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5160775000040303,
+        "max": 0.5406399000057718,
+        "mean": 0.525376300002487,
+        "stddev": 0.013323363043337972,
+        "rounds": 3,
+        "median": 0.5194114999976591,
+        "iqr": 0.01842180000130611,
+        "q1": 0.5169110000024375,
+        "q3": 0.5353328000037436,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5160775000040303,
+        "hd15iqr": 0.5406399000057718,
+        "ops": 1.903397621847933,
+        "total": 1.5761289000074612,
+        "data": [0.5194114999976591, 0.5406399000057718, 0.5160775000040303],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9066541881716474
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49495179999939865,
+        "max": 0.5504223000025377,
+        "mean": 0.5163774000005409,
+        "stddev": 0.029810721930762403,
+        "rounds": 3,
+        "median": 0.5037580999996862,
+        "iqr": 0.04160287500235427,
+        "q1": 0.49715337499947054,
+        "q3": 0.5387562500018248,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49495179999939865,
+        "hd15iqr": 0.5504223000025377,
+        "ops": 1.936568099221524,
+        "total": 1.5491322000016226,
+        "data": [0.5504223000025377, 0.49495179999939865, 0.5037580999996862],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9074269186832664
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4816943000041647,
+        "max": 0.5249102999950992,
+        "mean": 0.5047361666681051,
+        "stddev": 0.02175025481857598,
+        "rounds": 3,
+        "median": 0.5076039000050514,
+        "iqr": 0.03241199999320088,
+        "q1": 0.48817170000438637,
+        "q3": 0.5205836999975872,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4816943000041647,
+        "hd15iqr": 0.5249102999950992,
+        "ops": 1.9812330996632568,
+        "total": 1.5142085000043153,
+        "data": [0.5249102999950992, 0.4816943000041647, 0.5076039000050514],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9077839201307305
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4640967000013916,
+        "max": 0.5321442999993451,
+        "mean": 0.49367320000116405,
+        "stddev": 0.03488487348721704,
+        "rounds": 3,
+        "median": 0.4847786000027554,
+        "iqr": 0.051035699998465134,
+        "q1": 0.46926717500173254,
+        "q3": 0.5203028750001977,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4640967000013916,
+        "hd15iqr": 0.5321442999993451,
+        "ops": 2.0256315311376882,
+        "total": 1.481019600003492,
+        "data": [0.5321442999993451, 0.4640967000013916, 0.4847786000027554],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070603451784431
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4814824999994016,
+        "max": 0.5148171999971964,
+        "mean": 0.4947206666644585,
+        "stddev": 0.01769402303030643,
+        "rounds": 3,
+        "median": 0.48786229999677744,
+        "iqr": 0.02500102499834611,
+        "q1": 0.4830774499987456,
+        "q3": 0.5080784749970917,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4814824999994016,
+        "hd15iqr": 0.5148171999971964,
+        "ops": 2.0213426836244226,
+        "total": 1.4841619999933755,
+        "data": [0.48786229999677744, 0.4814824999994016, 0.5148171999971964],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9047149358109123
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4611384000018006,
+        "max": 0.4746835000041756,
+        "mean": 0.4659395333364955,
+        "stddev": 0.007584647950785772,
+        "rounds": 3,
+        "median": 0.46199670000351034,
+        "iqr": 0.010158825001781224,
+        "q1": 0.46135297500222805,
+        "q3": 0.4715118000040093,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4611384000018006,
+        "hd15iqr": 0.4746835000041756,
+        "ops": 2.1462012309606124,
+        "total": 1.3978186000094865,
+        "data": [0.46199670000351034, 0.4746835000041756, 0.4611384000018006],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9046905952611644
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4480237000025227,
+        "max": 0.46787030000268715,
+        "mean": 0.4602110333338108,
+        "stddev": 0.01067002453915014,
+        "rounds": 3,
+        "median": 0.46473909999622265,
+        "iqr": 0.014884950000123354,
+        "q1": 0.45220255000094767,
+        "q3": 0.467087500001071,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4480237000025227,
+        "hd15iqr": 0.46787030000268715,
+        "ops": 2.1729161788145506,
+        "total": 1.3806331000014325,
+        "data": [0.46473909999622265, 0.46787030000268715, 0.4480237000025227],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9052423324922303
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4595664000007673,
+        "max": 0.47195940000528935,
+        "mean": 0.4669077666670394,
+        "stddev": 0.006506056510138271,
+        "rounds": 3,
+        "median": 0.46919749999506166,
+        "iqr": 0.009294750003391528,
+        "q1": 0.4619741749993409,
+        "q3": 0.47126892500273243,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4595664000007673,
+        "hd15iqr": 0.47195940000528935,
+        "ops": 2.1417506226944356,
+        "total": 1.4007233000011183,
+        "data": [0.47195940000528935, 0.46919749999506166, 0.4595664000007673],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9057194361958583
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.43290829999750713,
+        "max": 0.47540870000375435,
+        "mean": 0.45566063333535567,
+        "stddev": 0.02140888165782207,
+        "rounds": 3,
+        "median": 0.45866490000480553,
+        "iqr": 0.031875300004685414,
+        "q1": 0.43934744999933173,
+        "q3": 0.47122275000401714,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.43290829999750713,
+        "hd15iqr": 0.47540870000375435,
+        "ops": 2.19461574435381,
+        "total": 1.366981900006067,
+        "data": [0.47540870000375435, 0.45866490000480553, 0.43290829999750713],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9046372916870644
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40011080000113,
+        "max": 0.455068700000993,
+        "mean": 0.4231999000015397,
+        "stddev": 0.028511489651606062,
+        "rounds": 3,
+        "median": 0.41442020000249613,
+        "iqr": 0.04121842499989725,
+        "q1": 0.4036881500014715,
+        "q3": 0.44490657500136876,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40011080000113,
+        "hd15iqr": 0.455068700000993,
+        "ops": 2.3629495186467713,
+        "total": 1.269599700004619,
+        "data": [0.455068700000993, 0.40011080000113, 0.41442020000249613],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.90506301854224
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41381209999963176,
+        "max": 0.4686943000051542,
+        "mean": 0.43540300000313437,
+        "stddev": 0.029252153586625366,
+        "rounds": 3,
+        "median": 0.4237026000046171,
+        "iqr": 0.04116165000414185,
+        "q1": 0.4162847250008781,
+        "q3": 0.45744637500501995,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41381209999963176,
+        "hd15iqr": 0.4686943000051542,
+        "ops": 2.29672280621126,
+        "total": 1.306209000009403,
+        "data": [0.4686943000051542, 0.41381209999963176, 0.4237026000046171],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9055014321288464
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4235648999965633,
+        "max": 0.4482803999999305,
+        "mean": 0.4352826333318565,
+        "stddev": 0.012407370757089649,
+        "rounds": 3,
+        "median": 0.43400259999907576,
+        "iqr": 0.018536625002525398,
+        "q1": 0.42617432499719143,
+        "q3": 0.44471094999971683,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4235648999965633,
+        "hd15iqr": 0.4482803999999305,
+        "ops": 2.297357908229724,
+        "total": 1.3058478999955696,
+        "data": [0.43400259999907576, 0.4235648999965633, 0.4482803999999305],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.905330357101406
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.430938999998034,
+        "max": 0.47658919999958016,
+        "mean": 0.4556067333323881,
+        "stddev": 0.023047149126331518,
+        "rounds": 3,
+        "median": 0.45929199999955017,
+        "iqr": 0.034237650001159636,
+        "q1": 0.438027249998413,
+        "q3": 0.47226489999957266,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.430938999998034,
+        "hd15iqr": 0.47658919999958016,
+        "ops": 2.1948753757123463,
+        "total": 1.3668201999971643,
+        "data": [0.45929199999955017, 0.430938999998034, 0.47658919999958016],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9036035787574495
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46005159999913303,
+        "max": 0.4907556000034674,
+        "mean": 0.4791650333330229,
+        "stddev": 0.016677201389727385,
+        "rounds": 3,
+        "median": 0.48668789999646833,
+        "iqr": 0.02302800000325078,
+        "q1": 0.46671067499846686,
+        "q3": 0.48973867500171764,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46005159999913303,
+        "hd15iqr": 0.4907556000034674,
+        "ops": 2.086963635564353,
+        "total": 1.4374950999990688,
+        "data": [0.48668789999646833, 0.46005159999913303, 0.4907556000034674],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9025673264975664
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4266663000016706,
+        "max": 0.45607819999713684,
+        "mean": 0.43702896666703356,
+        "stddev": 0.016518392647335862,
+        "rounds": 3,
+        "median": 0.4283424000022933,
+        "iqr": 0.02205892499659967,
+        "q1": 0.4270853250018263,
+        "q3": 0.44914424999842595,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4266663000016706,
+        "hd15iqr": 0.45607819999713684,
+        "ops": 2.2881778469432357,
+        "total": 1.3110869000011007,
+        "data": [0.4266663000016706, 0.4283424000022933, 0.45607819999713684],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9023339563742911
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40475339999829885,
+        "max": 0.4252368999950704,
+        "mean": 0.41446419999556383,
+        "stddev": 0.010282955156009665,
+        "rounds": 3,
+        "median": 0.41340229999332223,
+        "iqr": 0.015362624997578678,
+        "q1": 0.4069156249970547,
+        "q3": 0.42227824999463337,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40475339999829885,
+        "hd15iqr": 0.4252368999950704,
+        "ops": 2.4127536226547512,
+        "total": 1.2433925999866915,
+        "data": [0.41340229999332223, 0.40475339999829885, 0.4252368999950704],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9022013701308849
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4854669000051217,
+        "max": 0.49642660000245087,
+        "mean": 0.4898530666687293,
+        "stddev": 0.005798032918154943,
+        "rounds": 3,
+        "median": 0.4876656999986153,
+        "iqr": 0.008219774997996865,
+        "q1": 0.4860166000034951,
+        "q3": 0.494236375001492,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4854669000051217,
+        "hd15iqr": 0.49642660000245087,
+        "ops": 2.041428477319844,
+        "total": 1.469559200006188,
+        "data": [0.49642660000245087, 0.4876656999986153, 0.4854669000051217],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.902280631424103
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48899169999640435,
+        "max": 0.5169879000022775,
+        "mean": 0.5005609999983184,
+        "stddev": 0.014616566355581392,
+        "rounds": 3,
+        "median": 0.4957033999962732,
+        "iqr": 0.02099715000440483,
+        "q1": 0.49066962499637157,
+        "q3": 0.5116667750007764,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48899169999640435,
+        "hd15iqr": 0.5169879000022775,
+        "ops": 1.997758514952942,
+        "total": 1.501682999994955,
+        "data": [0.4957033999962732, 0.5169879000022775, 0.48899169999640435],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9018523018993176
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4910755999953835,
+        "max": 0.5351579999987734,
+        "mean": 0.5069831333312322,
+        "stddev": 0.024467940203823008,
+        "rounds": 3,
+        "median": 0.49471579999953974,
+        "iqr": 0.03306180000254244,
+        "q1": 0.4919856499964226,
+        "q3": 0.525047449998965,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4910755999953835,
+        "hd15iqr": 0.5351579999987734,
+        "ops": 1.972452206504985,
+        "total": 1.5209493999936967,
+        "data": [0.5351579999987734, 0.4910755999953835, 0.49471579999953974],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9020108409793688
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4836462000021129,
+        "max": 0.525568299999577,
+        "mean": 0.508017599999827,
+        "stddev": 0.021777444257672113,
+        "rounds": 3,
+        "median": 0.5148382999977912,
+        "iqr": 0.031441574998098076,
+        "q1": 0.49144422500103246,
+        "q3": 0.5228857999991305,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4836462000021129,
+        "hd15iqr": 0.525568299999577,
+        "ops": 1.9684357392349014,
+        "total": 1.524052799999481,
+        "data": [0.5148382999977912, 0.525568299999577, 0.4836462000021129],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9008680705267562
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4971083999989787,
+        "max": 0.5342301999990013,
+        "mean": 0.5174428999986654,
+        "stddev": 0.01881339894030226,
+        "rounds": 3,
+        "median": 0.5209900999980164,
+        "iqr": 0.027841350000016973,
+        "q1": 0.5030788249987381,
+        "q3": 0.5309201749987551,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4971083999989787,
+        "hd15iqr": 0.5342301999990013,
+        "ops": 1.9325803871356222,
+        "total": 1.5523286999959964,
+        "data": [0.4971083999989787, 0.5209900999980164, 0.5342301999990013],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9015650058316207
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4893255999995745,
+        "max": 0.5368111999996472,
+        "mean": 0.5063732333340644,
+        "stddev": 0.02642340481240188,
+        "rounds": 3,
+        "median": 0.4929829000029713,
+        "iqr": 0.03561420000005455,
+        "q1": 0.4902399250004237,
+        "q3": 0.5258541250004782,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4893255999995745,
+        "hd15iqr": 0.5368111999996472,
+        "ops": 1.9748279217204998,
+        "total": 1.519119700002193,
+        "data": [0.4893255999995745, 0.4929829000029713, 0.5368111999996472],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9014089616024192
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5204627999992226,
+        "max": 0.5281899000037811,
+        "mean": 0.5255251000028996,
+        "stddev": 0.004386117111713411,
+        "rounds": 3,
+        "median": 0.5279226000056951,
+        "iqr": 0.005795325003418839,
+        "q1": 0.5223277500008408,
+        "q3": 0.5281230750042596,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5204627999992226,
+        "hd15iqr": 0.5281899000037811,
+        "ops": 1.9028586836185035,
+        "total": 1.5765753000086988,
+        "data": [0.5204627999992226, 0.5279226000056951, 0.5281899000037811],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9003555497209594
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5027931000004173,
+        "max": 0.5396641999977874,
+        "mean": 0.5245251999998194,
+        "stddev": 0.01929951371086062,
+        "rounds": 3,
+        "median": 0.5311183000012534,
+        "iqr": 0.02765332499802753,
+        "q1": 0.5098744000006263,
+        "q3": 0.5375277249986539,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5027931000004173,
+        "hd15iqr": 0.5396641999977874,
+        "ops": 1.9064860944723807,
+        "total": 1.573575599999458,
+        "data": [0.5311183000012534, 0.5027931000004173, 0.5396641999977874],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8997571110353255
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4921004999996512,
+        "max": 0.5283780999961891,
+        "mean": 0.5123764999977235,
+        "stddev": 0.018512669631759765,
+        "rounds": 3,
+        "median": 0.5166508999973303,
+        "iqr": 0.027208199997403426,
+        "q1": 0.498238099999071,
+        "q3": 0.5254462999964744,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4921004999996512,
+        "hd15iqr": 0.5283780999961891,
+        "ops": 1.9516898218486658,
+        "total": 1.5371294999931706,
+        "data": [0.5283780999961891, 0.4921004999996512, 0.5166508999973303],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8998885191196577
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40283289999933913,
+        "max": 0.42851940000400646,
+        "mean": 0.41940763333453407,
+        "stddev": 0.01437779448360243,
+        "rounds": 3,
+        "median": 0.4268706000002567,
+        "iqr": 0.019264875003500492,
+        "q1": 0.4088423249995685,
+        "q3": 0.428107200003069,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40283289999933913,
+        "hd15iqr": 0.42851940000400646,
+        "ops": 2.384315211550681,
+        "total": 1.2582229000036023,
+        "data": [0.42851940000400646, 0.40283289999933913, 0.4268706000002567],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8987519315541346
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3966973000060534,
+        "max": 0.4380488000024343,
+        "mean": 0.417186533336159,
+        "stddev": 0.020678273704303567,
+        "rounds": 3,
+        "median": 0.4168134999999893,
+        "iqr": 0.03101362499728566,
+        "q1": 0.4017263500045374,
+        "q3": 0.43273997500182304,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3966973000060534,
+        "hd15iqr": 0.4380488000024343,
+        "ops": 2.397009299421043,
+        "total": 1.251559600008477,
+        "data": [0.4380488000024343, 0.3966973000060534, 0.4168134999999893],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8972287184501084
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41835100000025705,
+        "max": 0.44833980000112206,
+        "mean": 0.4351683000010477,
+        "stddev": 0.015323215217665241,
+        "rounds": 3,
+        "median": 0.438814100001764,
+        "iqr": 0.02249160000064876,
+        "q1": 0.4234667750006338,
+        "q3": 0.44595837500128255,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41835100000025705,
+        "hd15iqr": 0.44833980000112206,
+        "ops": 2.297961501326251,
+        "total": 1.3055049000031431,
+        "data": [0.438814100001764, 0.44833980000112206, 0.41835100000025705],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964311026155158
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4183145999995759,
+        "max": 0.4699248999968404,
+        "mean": 0.4454134666666505,
+        "stddev": 0.02590225617405803,
+        "rounds": 3,
+        "median": 0.4480009000035352,
+        "iqr": 0.03870772499794839,
+        "q1": 0.4257361750005657,
+        "q3": 0.4644438999985141,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4183145999995759,
+        "hd15iqr": 0.4699248999968404,
+        "ops": 2.2451049975738715,
+        "total": 1.3362403999999515,
+        "data": [0.4480009000035352, 0.4183145999995759, 0.4699248999968404],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8954552613391704
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4492043999998714,
+        "max": 0.4924931999994442,
+        "mean": 0.46646753333334345,
+        "stddev": 0.022936140567994975,
+        "rounds": 3,
+        "median": 0.4577050000007148,
+        "iqr": 0.0324665999996796,
+        "q1": 0.45132955000008224,
+        "q3": 0.48379614999976184,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4492043999998714,
+        "hd15iqr": 0.4924931999994442,
+        "ops": 2.1437719209610835,
+        "total": 1.3994026000000304,
+        "data": [0.4924931999994442, 0.4492043999998714, 0.4577050000007148],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962510246034185
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.42493849999300437,
+        "max": 0.46416010000393726,
+        "mean": 0.44250346666619106,
+        "stddev": 0.019928366188044708,
+        "rounds": 3,
+        "median": 0.4384118000016315,
+        "iqr": 0.029416200008199667,
+        "q1": 0.42830682499516115,
+        "q3": 0.4577230250033608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.42493849999300437,
+        "hd15iqr": 0.46416010000393726,
+        "ops": 2.259869301214683,
+        "total": 1.3275103999985731,
+        "data": [0.46416010000393726, 0.42493849999300437, 0.4384118000016315],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.895879462795605
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4352031000016723,
+        "max": 0.4719531000009738,
+        "mean": 0.4589635666658675,
+        "stddev": 0.02060704681830767,
+        "rounds": 3,
+        "median": 0.4697344999949564,
+        "iqr": 0.02756249999947613,
+        "q1": 0.4438359499999933,
+        "q3": 0.47139844999946945,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4352031000016723,
+        "hd15iqr": 0.4719531000009738,
+        "ops": 2.17882218247623,
+        "total": 1.3768906999976025,
+        "data": [0.4697344999949564, 0.4352031000016723, 0.4719531000009738],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.896494392057532
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46402600000146776,
+        "max": 0.4917520000017248,
+        "mean": 0.47818056666680303,
+        "stddev": 0.013872195297224688,
+        "rounds": 3,
+        "median": 0.47876369999721646,
+        "iqr": 0.020794500000192784,
+        "q1": 0.46771042500040494,
+        "q3": 0.4885049250005977,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46402600000146776,
+        "hd15iqr": 0.4917520000017248,
+        "ops": 2.0912602261747737,
+        "total": 1.434541700000409,
+        "data": [0.46402600000146776, 0.4917520000017248, 0.47876369999721646],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962694554154644
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.44676389999949606,
+        "max": 0.48085859999991953,
+        "mean": 0.4624158000005991,
+        "stddev": 0.017217839124865707,
+        "rounds": 3,
+        "median": 0.45962490000238176,
+        "iqr": 0.025571025000317604,
+        "q1": 0.4499791500002175,
+        "q3": 0.4755501750005351,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.44676389999949606,
+        "hd15iqr": 0.48085859999991953,
+        "ops": 2.1625558642215608,
+        "total": 1.3872474000017974,
+        "data": [0.45962490000238176, 0.44676389999949606, 0.48085859999991953],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8960866515897383
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48235030000068946,
+        "max": 0.4971471000026213,
+        "mean": 0.49174416666695225,
+        "stddev": 0.008165903759610803,
+        "rounds": 3,
+        "median": 0.49573509999754606,
+        "iqr": 0.011097600001448882,
+        "q1": 0.4856964999999036,
+        "q3": 0.4967941000013525,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48235030000068946,
+        "hd15iqr": 0.4971471000026213,
+        "ops": 2.0335777580810195,
+        "total": 1.4752325000008568,
+        "data": [0.49573509999754606, 0.48235030000068946, 0.4971471000026213],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8958080487032736
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5003037999995286,
+        "max": 0.5243962999957148,
+        "mean": 0.5150503666664008,
+        "stddev": 0.012922355410358344,
+        "rounds": 3,
+        "median": 0.520451000003959,
+        "iqr": 0.018069374997139676,
+        "q1": 0.5053406000006362,
+        "q3": 0.5234099749977759,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5003037999995286,
+        "hd15iqr": 0.5243962999957148,
+        "ops": 1.9415576897311522,
+        "total": 1.5451510999992024,
+        "data": [0.5003037999995286, 0.520451000003959, 0.5243962999957148],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8967705341220795
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4405171000107657,
+        "max": 0.4718992999987677,
+        "mean": 0.4573605000041425,
+        "stddev": 0.015817522084303284,
+        "rounds": 3,
+        "median": 0.4596651000028942,
+        "iqr": 0.023536649991001468,
+        "q1": 0.44530410000879783,
+        "q3": 0.4688407499997993,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4405171000107657,
+        "hd15iqr": 0.4718992999987677,
+        "ops": 2.1864590404963753,
+        "total": 1.3720815000124276,
+        "data": [0.4596651000028942, 0.4405171000107657, 0.4718992999987677],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964479297622852
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4477857000019867,
+        "max": 0.46196770000096876,
+        "mean": 0.45536536667107913,
+        "stddev": 0.0071413350526858665,
+        "rounds": 3,
+        "median": 0.456342700010282,
+        "iqr": 0.010636499999236548,
+        "q1": 0.4499249500040605,
+        "q3": 0.46056145000329707,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4477857000019867,
+        "hd15iqr": 0.46196770000096876,
+        "ops": 2.196038770604008,
+        "total": 1.3660961000132374,
+        "data": [0.46196770000096876, 0.4477857000019867, 0.456342700010282],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.895066110298548
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4422367000079248,
+        "max": 0.4918261999991955,
+        "mean": 0.47046973333635833,
+        "stddev": 0.025499902042475625,
+        "rounds": 3,
+        "median": 0.47734630000195466,
+        "iqr": 0.037192124993453035,
+        "q1": 0.4510141000064323,
+        "q3": 0.4882062249998853,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4422367000079248,
+        "hd15iqr": 0.4918261999991955,
+        "ops": 2.1255352451866623,
+        "total": 1.411409200009075,
+        "data": [0.47734630000195466, 0.4918261999991955, 0.4422367000079248],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.893540285546729
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.42840229999274015,
+        "max": 0.46714789999532513,
+        "mean": 0.4469855666635946,
+        "stddev": 0.019421005857825593,
+        "rounds": 3,
+        "median": 0.44540650000271853,
+        "iqr": 0.029059200001938734,
+        "q1": 0.43265334999523475,
+        "q3": 0.4617125499971735,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.42840229999274015,
+        "hd15iqr": 0.46714789999532513,
+        "ops": 2.2372087033239914,
+        "total": 1.3409566999907838,
+        "data": [0.44540650000271853, 0.42840229999274015, 0.46714789999532513],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8939787599828672
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39478530001360923,
+        "max": 0.4136527999944519,
+        "mean": 0.40630583333647036,
+        "stddev": 0.010102456776023342,
+        "rounds": 3,
+        "median": 0.41047940000134986,
+        "iqr": 0.014150624985632021,
+        "q1": 0.3987088250105444,
+        "q3": 0.4128594499961764,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39478530001360923,
+        "hd15iqr": 0.4136527999944519,
+        "ops": 2.4612002042606145,
+        "total": 1.218917500009411,
+        "data": [0.4136527999944519, 0.39478530001360923, 0.41047940000134986],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8930361919718222
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.45337829999334645,
+        "max": 0.47681800001009833,
+        "mean": 0.46569526667008176,
+        "stddev": 0.011765395410513298,
+        "rounds": 3,
+        "median": 0.4668895000068005,
+        "iqr": 0.017579775012563914,
+        "q1": 0.45675609999670996,
+        "q3": 0.4743358750092739,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.45337829999334645,
+        "hd15iqr": 0.47681800001009833,
+        "ops": 2.147326957283511,
+        "total": 1.3970858000102453,
+        "data": [0.47681800001009833, 0.45337829999334645, 0.4668895000068005],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892781566320494
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4410117999941576,
+        "max": 0.4725447999953758,
+        "mean": 0.45710046666499693,
+        "stddev": 0.01577637145732275,
+        "rounds": 3,
+        "median": 0.45774480000545736,
+        "iqr": 0.023649750000913627,
+        "q1": 0.44519504999698256,
+        "q3": 0.4688447999978962,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4410117999941576,
+        "hd15iqr": 0.4725447999953758,
+        "ops": 2.187702863871472,
+        "total": 1.3713013999949908,
+        "data": [0.4725447999953758, 0.45774480000545736, 0.4410117999941576],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8915068843131124
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3954342000070028,
+        "max": 0.41224990000773687,
+        "mean": 0.40155673334083986,
+        "stddev": 0.00929300588763566,
+        "rounds": 3,
+        "median": 0.3969861000077799,
+        "iqr": 0.012611775000550551,
+        "q1": 0.3958221750071971,
+        "q3": 0.4084339500077476,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3954342000070028,
+        "hd15iqr": 0.41224990000773687,
+        "ops": 2.490308135740321,
+        "total": 1.2046702000225196,
+        "data": [0.3954342000070028, 0.3969861000077799, 0.41224990000773687],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891805391078564
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4086234999995213,
+        "max": 0.43089319999853615,
+        "mean": 0.4221019333296378,
+        "stddev": 0.011851667941435771,
+        "rounds": 3,
+        "median": 0.4267890999908559,
+        "iqr": 0.016702274999261135,
+        "q1": 0.41316489999735495,
+        "q3": 0.4298671749966161,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4086234999995213,
+        "hd15iqr": 0.43089319999853615,
+        "ops": 2.369095995632544,
+        "total": 1.2663057999889133,
+        "data": [0.4267890999908559, 0.43089319999853615, 0.4086234999995213],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891383403237082
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40017429999716114,
+        "max": 0.4056212999857962,
+        "mean": 0.40298189999399864,
+        "stddev": 0.0027273926468917484,
+        "rounds": 3,
+        "median": 0.4031500999990385,
+        "iqr": 0.004085249991476303,
+        "q1": 0.4009182499976305,
+        "q3": 0.4050034999891068,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40017429999716114,
+        "hd15iqr": 0.4056212999857962,
+        "ops": 2.481501030232108,
+        "total": 1.2089456999819959,
+        "data": [0.4031500999990385, 0.40017429999716114, 0.4056212999857962],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8908065659723856
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39646889999858104,
+        "max": 0.41763200001150835,
+        "mean": 0.4076314666696514,
+        "stddev": 0.010629296384659854,
+        "rounds": 3,
+        "median": 0.4087934999988647,
+        "iqr": 0.015872325009695487,
+        "q1": 0.39955004999865196,
+        "q3": 0.41542237500834744,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39646889999858104,
+        "hd15iqr": 0.41763200001150835,
+        "ops": 2.4531962857774423,
+        "total": 1.222894400008954,
+        "data": [0.39646889999858104, 0.4087934999988647, 0.41763200001150835],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8912805436324223
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40741759999946225,
+        "max": 0.4165982999984408,
+        "mean": 0.41256473333244986,
+        "stddev": 0.004690558192709662,
+        "rounds": 3,
+        "median": 0.4136782999994466,
+        "iqr": 0.006885524999233894,
+        "q1": 0.40898277499945834,
+        "q3": 0.41586829999869224,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40741759999946225,
+        "hd15iqr": 0.4165982999984408,
+        "ops": 2.423862049290062,
+        "total": 1.2376941999973496,
+        "data": [0.4165982999984408, 0.40741759999946225, 0.4136782999994466],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8911687282647895
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40223360000527464,
+        "max": 0.4197423000005074,
+        "mean": 0.4128022666651911,
+        "stddev": 0.009301283714308727,
+        "rounds": 3,
+        "median": 0.4164308999897912,
+        "iqr": 0.01313152499642456,
+        "q1": 0.4057829250014038,
+        "q3": 0.41891444999782834,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40223360000527464,
+        "hd15iqr": 0.4197423000005074,
+        "ops": 2.4224673185020653,
+        "total": 1.2384067999955732,
+        "data": [0.4197423000005074, 0.40223360000527464, 0.4164308999897912],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891537391048274
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41764849999162834,
+        "max": 0.4483846000075573,
+        "mean": 0.42922083333542105,
+        "stddev": 0.016715243223815537,
+        "rounds": 3,
+        "median": 0.4216294000070775,
+        "iqr": 0.023052075011946727,
+        "q1": 0.41864372499549063,
+        "q3": 0.44169580000743736,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41764849999162834,
+        "hd15iqr": 0.4483846000075573,
+        "ops": 2.3298030345571203,
+        "total": 1.2876625000062631,
+        "data": [0.4483846000075573, 0.41764849999162834, 0.4216294000070775],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8916263138659384
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4150187999912305,
+        "max": 0.4344608999963384,
+        "mean": 0.42797383332799654,
+        "stddev": 0.011219392041017164,
+        "rounds": 3,
+        "median": 0.43444179999642074,
+        "iqr": 0.014581575003830949,
+        "q1": 0.41987454999252805,
+        "q3": 0.434456124996359,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4150187999912305,
+        "hd15iqr": 0.4344608999963384,
+        "ops": 2.336591450518906,
+        "total": 1.2839214999839896,
+        "data": [0.4344608999963384, 0.4150187999912305, 0.43444179999642074],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891574182200763
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3969370999984676,
+        "max": 0.41036999999778345,
+        "mean": 0.40552879999935004,
+        "stddev": 0.007460589004842901,
+        "rounds": 3,
+        "median": 0.40927930000179913,
+        "iqr": 0.010074674999486888,
+        "q1": 0.4000226499993005,
+        "q3": 0.41009732499878737,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3969370999984676,
+        "hd15iqr": 0.41036999999778345,
+        "ops": 2.46591610756524,
+        "total": 1.2165863999980502,
+        "data": [0.41036999999778345, 0.40927930000179913, 0.3969370999984676],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8917724571804155
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4041464000038104,
+        "max": 0.42295029999513645,
+        "mean": 0.4114379333332181,
+        "stddev": 0.010087528896443005,
+        "rounds": 3,
+        "median": 0.40721710000070743,
+        "iqr": 0.014102924993494526,
+        "q1": 0.40491407500303467,
+        "q3": 0.4190169999965292,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4041464000038104,
+        "hd15iqr": 0.42295029999513645,
+        "ops": 2.4305002504232234,
+        "total": 1.2343137999996543,
+        "data": [0.4041464000038104, 0.40721710000070743, 0.42295029999513645],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8921586734943483
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39778189999924507,
+        "max": 0.4192004999931669,
+        "mean": 0.4092614999972284,
+        "stddev": 0.010792089357470697,
+        "rounds": 3,
+        "median": 0.4108020999992732,
+        "iqr": 0.016063949995441362,
+        "q1": 0.4010369499992521,
+        "q3": 0.41710089999469346,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39778189999924507,
+        "hd15iqr": 0.4192004999931669,
+        "ops": 2.4434255360124815,
+        "total": 1.2277844999916852,
+        "data": [0.4108020999992732, 0.39778189999924507, 0.4192004999931669],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8924614909501243
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40799279999919236,
+        "max": 0.4176625999971293,
+        "mean": 0.4125498999977329,
+        "stddev": 0.004858783440403423,
+        "rounds": 3,
+        "median": 0.4119942999968771,
+        "iqr": 0.007252349998452701,
+        "q1": 0.40899317499861354,
+        "q3": 0.41624552499706624,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40799279999919236,
+        "hd15iqr": 0.4176625999971293,
+        "ops": 2.42394919985557,
+        "total": 1.2376496999931987,
+        "data": [0.4119942999968771, 0.40799279999919236, 0.4176625999971293],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892498273134284
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41915780000272207,
+        "max": 0.44576230000529904,
+        "mean": 0.4323507333319867,
+        "stddev": 0.01330359746463815,
+        "rounds": 3,
+        "median": 0.432132099987939,
+        "iqr": 0.019953375001932727,
+        "q1": 0.4224013749990263,
+        "q3": 0.44235475000095903,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41915780000272207,
+        "hd15iqr": 0.44576230000529904,
+        "ops": 2.312936981263625,
+        "total": 1.29705219999596,
+        "data": [0.44576230000529904, 0.41915780000272207, 0.432132099987939],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8924534159078155
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41695500000787433,
+        "max": 0.4396506000048248,
+        "mean": 0.42957826666922,
+        "stddev": 0.01156083952097234,
+        "rounds": 3,
+        "median": 0.4321291999949608,
+        "iqr": 0.017021699997712858,
+        "q1": 0.42074855000464595,
+        "q3": 0.4377702500023588,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41695500000787433,
+        "hd15iqr": 0.4396506000048248,
+        "ops": 2.3278645070981003,
+        "total": 1.28873480000766,
+        "data": [0.4321291999949608, 0.41695500000787433, 0.4396506000048248],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8926641476600294
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.42332339999848045,
+        "max": 0.4428318999998737,
+        "mean": 0.43142093333396286,
+        "stddev": 0.010167572148870445,
+        "rounds": 3,
+        "median": 0.42810750000353437,
+        "iqr": 0.014631375001044944,
+        "q1": 0.42451942499974393,
+        "q3": 0.4391508000007889,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.42332339999848045,
+        "hd15iqr": 0.4428318999998737,
+        "ops": 2.3179218316369927,
+        "total": 1.2942628000018885,
+        "data": [0.42810750000353437, 0.42332339999848045, 0.4428318999998737],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8922352305441463
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.42493009999452624,
+        "max": 0.4449737999966601,
+        "mean": 0.43389689999457914,
+        "stddev": 0.010187093253612837,
+        "rounds": 3,
+        "median": 0.4317867999925511,
+        "iqr": 0.015032775001600385,
+        "q1": 0.42664427499403246,
+        "q3": 0.44167704999563284,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.42493009999452624,
+        "hd15iqr": 0.4449737999966601,
+        "ops": 2.30469496327928,
+        "total": 1.3016906999837374,
+        "data": [0.4317867999925511, 0.42493009999452624, 0.4449737999966601],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.890570058518558
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41767860000254586,
+        "max": 0.43673020000278484,
+        "mean": 0.42422063333409216,
+        "stddev": 0.010837410033755357,
+        "rounds": 3,
+        "median": 0.4182530999969458,
+        "iqr": 0.014288700000179233,
+        "q1": 0.41782222500114585,
+        "q3": 0.4321109250013251,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41767860000254586,
+        "hd15iqr": 0.43673020000278484,
+        "ops": 2.35726393631697,
+        "total": 1.2726619000022765,
+        "data": [0.41767860000254586, 0.4182530999969458, 0.43673020000278484],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8878840647372432
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4236348000122234,
+        "max": 0.44860249999328516,
+        "mean": 0.43244280000120244,
+        "stddev": 0.014013640864807527,
+        "rounds": 3,
+        "median": 0.4250910999980988,
+        "iqr": 0.018725774985796306,
+        "q1": 0.42399887500869227,
+        "q3": 0.4427246499944886,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4236348000122234,
+        "hd15iqr": 0.44860249999328516,
+        "ops": 2.3124445591352645,
+        "total": 1.2973284000036074,
+        "data": [0.4236348000122234, 0.4250910999980988, 0.44860249999328516],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.888247506571039
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37658270000247285,
+        "max": 0.3911567000031937,
+        "mean": 0.38629313333755516,
+        "stddev": 0.008409486095402995,
+        "rounds": 3,
+        "median": 0.3911400000069989,
+        "iqr": 0.010930500000540633,
+        "q1": 0.38022202500360436,
+        "q3": 0.391152525004145,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37658270000247285,
+        "hd15iqr": 0.3911567000031937,
+        "ops": 2.588707677405615,
+        "total": 1.1588794000126654,
+        "data": [0.3911567000031937, 0.37658270000247285, 0.3911400000069989],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8867094690559472
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37433380000584293,
+        "max": 0.39003979999688454,
+        "mean": 0.3820052666706033,
+        "stddev": 0.007859292078818593,
+        "rounds": 3,
+        "median": 0.38164220000908244,
+        "iqr": 0.011779499993281206,
+        "q1": 0.3761609000066528,
+        "q3": 0.387940399999934,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37433380000584293,
+        "hd15iqr": 0.39003979999688454,
+        "ops": 2.617764955744139,
+        "total": 1.14601580001181,
+        "data": [0.39003979999688454, 0.37433380000584293, 0.38164220000908244],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4146554643886753
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40188259999558795,
+        "max": 0.4086812000023201,
+        "mean": 0.4057064666655303,
+        "stddev": 0.0034779320114095955,
+        "rounds": 3,
+        "median": 0.40655559999868274,
+        "iqr": 0.005098950005049119,
+        "q1": 0.40305084999636165,
+        "q3": 0.40814980000141077,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40188259999558795,
+        "hd15iqr": 0.4086812000023201,
+        "ops": 2.464836235465808,
+        "total": 1.2171193999965908,
+        "data": [0.40655559999868274, 0.4086812000023201, 0.40188259999558795],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5072487473713738
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3856121999997413,
+        "max": 0.3980736999947112,
+        "mean": 0.3912882333291539,
+        "stddev": 0.006304393489993357,
+        "rounds": 3,
+        "median": 0.3901787999930093,
+        "iqr": 0.009346124996227445,
+        "q1": 0.3867538499980583,
+        "q3": 0.39609997499428573,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3856121999997413,
+        "hd15iqr": 0.3980736999947112,
+        "ops": 2.555660801480821,
+        "total": 1.1738646999874618,
+        "data": [0.3980736999947112, 0.3856121999997413, 0.3901787999930093],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.696736380586299
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.355534100002842,
+        "max": 0.36835380000411533,
+        "mean": 0.36131246666870237,
+        "stddev": 0.006502498799458741,
+        "rounds": 3,
+        "median": 0.3600494999991497,
+        "iqr": 0.009614775000954978,
+        "q1": 0.35666295000191894,
+        "q3": 0.3662777250028739,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.355534100002842,
+        "hd15iqr": 0.36835380000411533,
+        "ops": 2.7676875066614524,
+        "total": 1.083937400006107,
+        "data": [0.36835380000411533, 0.355534100002842, 0.3600494999991497],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8249262307488259
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48344270000234246,
+        "max": 0.5105991000018548,
+        "mean": 0.4949180000015379,
+        "stddev": 0.0140582388822517,
+        "rounds": 3,
+        "median": 0.4907122000004165,
+        "iqr": 0.02036729999963427,
+        "q1": 0.48526007500186097,
+        "q3": 0.5056273750014952,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48344270000234246,
+        "hd15iqr": 0.5105991000018548,
+        "ops": 2.020536735372107,
+        "total": 1.4847540000046138,
+        "data": [0.4907122000004165, 0.48344270000234246, 0.5105991000018548],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.7853658162698276
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39719859999604523,
+        "max": 0.44264350000594277,
+        "mean": 0.42115670000202954,
+        "stddev": 0.022823019673184654,
+        "rounds": 3,
+        "median": 0.4236280000041006,
+        "iqr": 0.03408367500742315,
+        "q1": 0.4038059499980591,
+        "q3": 0.43788962500548223,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39719859999604523,
+        "hd15iqr": 0.44264350000594277,
+        "ops": 2.3744131341022974,
+        "total": 1.2634701000060886,
+        "data": [0.4236280000041006, 0.39719859999604523, 0.44264350000594277],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.515787429133049
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.393033899992588,
+        "max": 0.4064174999948591,
+        "mean": 0.3980442333316508,
+        "stddev": 0.007298094111628319,
+        "rounds": 3,
+        "median": 0.39468130000750534,
+        "iqr": 0.010037700001703342,
+        "q1": 0.3934457499963173,
+        "q3": 0.40348344999802066,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.393033899992588,
+        "hd15iqr": 0.4064174999948591,
+        "ops": 2.512283601322266,
+        "total": 1.1941326999949524,
+        "data": [0.4064174999948591, 0.39468130000750534, 0.393033899992588],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5120094303648324
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3851079000014579,
+        "max": 0.3913120999932289,
+        "mean": 0.38897893332856864,
+        "stddev": 0.0033759146594782626,
+        "rounds": 3,
+        "median": 0.39051679999101907,
+        "iqr": 0.004653149993828265,
+        "q1": 0.3864601249988482,
+        "q3": 0.39111327499267645,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3851079000014579,
+        "hd15iqr": 0.3913120999932289,
+        "ops": 2.570833313369454,
+        "total": 1.1669367999857059,
+        "data": [0.3913120999932289, 0.39051679999101907, 0.3851079000014579],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7064357688003564
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.355310399987502,
+        "max": 0.37246120000781957,
+        "mean": 0.3647556666643747,
+        "stddev": 0.008706749645407916,
+        "rounds": 3,
+        "median": 0.36649539999780245,
+        "iqr": 0.01286310001523816,
+        "q1": 0.35810664999007713,
+        "q3": 0.3709697500053153,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.355310399987502,
+        "hd15iqr": 0.37246120000781957,
+        "ops": 2.741561246038536,
+        "total": 1.094266999993124,
+        "data": [0.36649539999780245, 0.355310399987502, 0.37246120000781957],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8534002413072403
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4613740000058897,
+        "max": 0.49941809999290854,
+        "mean": 0.4842401000011402,
+        "stddev": 0.02015362367424848,
+        "rounds": 3,
+        "median": 0.49192820000462234,
+        "iqr": 0.02853307499026414,
+        "q1": 0.46901255000557285,
+        "q3": 0.497545624995837,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4613740000058897,
+        "hd15iqr": 0.49941809999290854,
+        "ops": 2.065091263605896,
+        "total": 1.4527203000034206,
+        "data": [0.49192820000462234, 0.4613740000058897, 0.49941809999290854],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8363352414187193
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.392825000002631,
+        "max": 0.3949360999977216,
+        "mean": 0.39362629999717075,
+        "stddev": 0.0011437285470787424,
+        "rounds": 3,
+        "median": 0.3931177999911597,
+        "iqr": 0.0015833249963179696,
+        "q1": 0.39289819999976316,
+        "q3": 0.39448152499608113,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.392825000002631,
+        "hd15iqr": 0.3949360999977216,
+        "ops": 2.5404806538770086,
+        "total": 1.1808788999915123,
+        "data": [0.3931177999911597, 0.392825000002631, 0.3949360999977216],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.7894006627613825
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4124326999881305,
+        "max": 0.4259567999979481,
+        "mean": 0.41706643333115306,
+        "stddev": 0.0077015917646078335,
+        "rounds": 3,
+        "median": 0.41280980000738055,
+        "iqr": 0.010143075007363223,
+        "q1": 0.412526974992943,
+        "q3": 0.4226700500003062,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4124326999881305,
+        "hd15iqr": 0.4259567999979481,
+        "ops": 2.397699551155186,
+        "total": 1.2511992999934591,
+        "data": [0.4124326999881305, 0.41280980000738055, 0.4259567999979481],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.5385808600197302
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4658838999894215,
+        "max": 0.4799359999888111,
+        "mean": 0.4747428666596534,
+        "stddev": 0.0077100018911547405,
+        "rounds": 3,
+        "median": 0.47840870000072755,
+        "iqr": 0.010539074999542208,
+        "q1": 0.469015099992248,
+        "q3": 0.4795541749917902,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4658838999894215,
+        "hd15iqr": 0.4799359999888111,
+        "ops": 2.1064034243128655,
+        "total": 1.4242285999789601,
+        "data": [0.4799359999888111, 0.47840870000072755, 0.4658838999894215],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5472969294984127
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3986145000089891,
+        "max": 0.40354800000204705,
+        "mean": 0.4017054666668021,
+        "stddev": 0.0026932870003119743,
+        "rounds": 3,
+        "median": 0.40295389998937026,
+        "iqr": 0.003700124994793441,
+        "q1": 0.3996993500040844,
+        "q3": 0.40339947499887785,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3986145000089891,
+        "hd15iqr": 0.40354800000204705,
+        "ops": 2.4893860875173455,
+        "total": 1.2051164000004064,
+        "data": [0.40354800000204705, 0.40295389998937026, 0.3986145000089891],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5232789763409844
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37836849999439437,
+        "max": 0.39881189999869093,
+        "mean": 0.38781593333017855,
+        "stddev": 0.010309297626213234,
+        "rounds": 3,
+        "median": 0.3862673999974504,
+        "iqr": 0.015332550003222423,
+        "q1": 0.3803432249951584,
+        "q3": 0.3956757749983808,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37836849999439437,
+        "hd15iqr": 0.39881189999869093,
+        "ops": 2.5785428448310306,
+        "total": 1.1634477999905357,
+        "data": [0.3862673999974504, 0.37836849999439437, 0.39881189999869093],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7516529692498617
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3548428999929456,
+        "max": 0.374416900012875,
+        "mean": 0.3640766999985014,
+        "stddev": 0.009833791737152197,
+        "rounds": 3,
+        "median": 0.36297029998968355,
+        "iqr": 0.014680500014947029,
+        "q1": 0.3568747499921301,
+        "q3": 0.3715552500070771,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3548428999929456,
+        "hd15iqr": 0.374416900012875,
+        "ops": 2.7466739838174656,
+        "total": 1.0922300999955041,
+        "data": [0.36297029998968355, 0.3548428999929456, 0.374416900012875],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.873384797390325
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4628223999898182,
+        "max": 0.4688453999988269,
+        "mean": 0.46602896666445304,
+        "stddev": 0.0030303935873937267,
+        "rounds": 3,
+        "median": 0.466419100004714,
+        "iqr": 0.0045172500067565124,
+        "q1": 0.46372157499354216,
+        "q3": 0.4682388250002987,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4628223999898182,
+        "hd15iqr": 0.4688453999988269,
+        "ops": 2.145789364033273,
+        "total": 1.3980868999933591,
+        "data": [0.466419100004714, 0.4628223999898182, 0.4688453999988269],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8847107545549513
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3856400000076974,
+        "max": 0.3956529999995837,
+        "mean": 0.3889912333349154,
+        "stddev": 0.0057692950559974044,
+        "rounds": 3,
+        "median": 0.3856806999974651,
+        "iqr": 0.007509749993914738,
+        "q1": 0.3856501750051393,
+        "q3": 0.39315992499905406,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3856400000076974,
+        "hd15iqr": 0.3956529999995837,
+        "ops": 2.5707520229357343,
+        "total": 1.1669737000047462,
+        "data": [0.3856400000076974, 0.3856806999974651, 0.3956529999995837],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5473587134096904
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4009628999920096,
+        "max": 0.4089628000074299,
+        "mean": 0.40513373333669733,
+        "stddev": 0.0040108856140196915,
+        "rounds": 3,
+        "median": 0.40547550001065247,
+        "iqr": 0.00599992501156521,
+        "q1": 0.40209104999667034,
+        "q3": 0.40809097500823555,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4009628999920096,
+        "hd15iqr": 0.4089628000074299,
+        "ops": 2.4683207487166294,
+        "total": 1.215401200010092,
+        "data": [0.40547550001065247, 0.4009628999920096, 0.4089628000074299],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5693780389855834
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3852564999979222,
+        "max": 0.39871080000011716,
+        "mean": 0.39114440000169753,
+        "stddev": 0.0068824101019396774,
+        "rounds": 3,
+        "median": 0.3894659000070533,
+        "iqr": 0.010090725001646206,
+        "q1": 0.386308850000205,
+        "q3": 0.3963995750018512,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3852564999979222,
+        "hd15iqr": 0.39871080000011716,
+        "ops": 2.556600580234972,
+        "total": 1.1734332000050927,
+        "data": [0.3894659000070533, 0.3852564999979222, 0.39871080000011716],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7844916059545242
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3999367000069469,
+        "max": 0.41343840000627097,
+        "mean": 0.4082878333380601,
+        "stddev": 0.007297718543537975,
+        "rounds": 3,
+        "median": 0.41148840000096243,
+        "iqr": 0.010126274999493035,
+        "q1": 0.4028246250054508,
+        "q3": 0.41295090000494383,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3999367000069469,
+        "hd15iqr": 0.41343840000627097,
+        "ops": 2.4492525085164747,
+        "total": 1.2248635000141803,
+        "data": [0.41148840000096243, 0.3999367000069469, 0.41343840000627097],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.914559800449005
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4904164000035962,
+        "max": 0.5225515000056475,
+        "mean": 0.5046246000032019,
+        "stddev": 0.0163871202570434,
+        "rounds": 3,
+        "median": 0.5009059000003617,
+        "iqr": 0.0241013250015385,
+        "q1": 0.4930387750027876,
+        "q3": 0.5171401000043261,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4904164000035962,
+        "hd15iqr": 0.5225515000056475,
+        "ops": 1.9816711273958008,
+        "total": 1.5138738000096055,
+        "data": [0.5225515000056475, 0.4904164000035962, 0.5009059000003617],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9503898932422628
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3654653999983566,
+        "max": 0.3991736000025412,
+        "mean": 0.38396419999965775,
+        "stddev": 0.017093150708477386,
+        "rounds": 3,
+        "median": 0.3872535999980755,
+        "iqr": 0.025281150003138464,
+        "q1": 0.3709124499982863,
+        "q3": 0.3961936000014248,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3654653999983566,
+        "hd15iqr": 0.3991736000025412,
+        "ops": 2.60440947359387,
+        "total": 1.1518925999989733,
+        "data": [0.3872535999980755, 0.3654653999983566, 0.3991736000025412],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5473587134096904
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40283049999561626,
+        "max": 0.41627809999044985,
+        "mean": 0.4101413999936388,
+        "stddev": 0.006800260703634523,
+        "rounds": 3,
+        "median": 0.41131559999485034,
+        "iqr": 0.010085699996125186,
+        "q1": 0.4049517749954248,
+        "q3": 0.41503747499154997,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40283049999561626,
+        "hd15iqr": 0.41627809999044985,
+        "ops": 2.4381835143087476,
+        "total": 1.2304241999809165,
+        "data": [0.41627809999044985, 0.40283049999561626, 0.41131559999485034],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5700269723121707
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.38007879999349825,
+        "max": 0.39307770000596065,
+        "mean": 0.38864603333058767,
+        "stddev": 0.0074209186825907264,
+        "rounds": 3,
+        "median": 0.3927815999923041,
+        "iqr": 0.0097491750093468,
+        "q1": 0.3832544999931997,
+        "q3": 0.3930036750025465,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.38007879999349825,
+        "hd15iqr": 0.39307770000596065,
+        "ops": 2.57303539529345,
+        "total": 1.165938099991763,
+        "data": [0.3927815999923041, 0.38007879999349825, 0.39307770000596065],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.805941607549476
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37978379998821765,
+        "max": 0.3913509999983944,
+        "mean": 0.38672076666262,
+        "stddev": 0.006118888219318238,
+        "rounds": 3,
+        "median": 0.389027500001248,
+        "iqr": 0.008675400007632561,
+        "q1": 0.38209472499147523,
+        "q3": 0.3907701249991078,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37978379998821765,
+        "hd15iqr": 0.3913509999983944,
+        "ops": 2.585845101182302,
+        "total": 1.16016229998786,
+        "data": [0.389027500001248, 0.37978379998821765, 0.3913509999983944],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9342463186419576
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4918896000017412,
+        "max": 0.49978339999506716,
+        "mean": 0.49552129999695654,
+        "stddev": 0.003984478975524397,
+        "rounds": 3,
+        "median": 0.49489089999406133,
+        "iqr": 0.005920349994994467,
+        "q1": 0.49263992499982123,
+        "q3": 0.4985602749948157,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4918896000017412,
+        "hd15iqr": 0.49978339999506716,
+        "ops": 2.0180767204278443,
+        "total": 1.4865638999908697,
+        "data": [0.49978339999506716, 0.4918896000017412, 0.49489089999406133],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9576816408745634
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.38129900000058115,
+        "max": 0.3924300999933621,
+        "mean": 0.38516669999808073,
+        "stddev": 0.00629471449857127,
+        "rounds": 3,
+        "median": 0.38177100000029895,
+        "iqr": 0.00834832499458571,
+        "q1": 0.3814170000005106,
+        "q3": 0.3897653249950963,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.38129900000058115,
+        "hd15iqr": 0.3924300999933621,
+        "ops": 2.5962784425678103,
+        "total": 1.1555000999942422,
+        "data": [0.3924300999933621, 0.38177100000029895, 0.38129900000058115],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5474494761579245
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.43629369999689516,
+        "max": 0.4520840000041062,
+        "mean": 0.4465551999989354,
+        "stddev": 0.008895629855423838,
+        "rounds": 3,
+        "median": 0.45128789999580476,
+        "iqr": 0.011842725005408283,
+        "q1": 0.44004224999662256,
+        "q3": 0.45188497500203084,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.43629369999689516,
+        "hd15iqr": 0.4520840000041062,
+        "ops": 2.2393648086560947,
+        "total": 1.3396655999968061,
+        "data": [0.4520840000041062, 0.43629369999689516, 0.45128789999580476],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.57801592707351
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41373549999843817,
+        "max": 0.4151687999983551,
+        "mean": 0.4144516666662336,
+        "stddev": 0.000716650488920788,
+        "rounds": 3,
+        "median": 0.41445070000190753,
+        "iqr": 0.0010749749999376945,
+        "q1": 0.4139142999993055,
+        "q3": 0.4149892749992432,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41373549999843817,
+        "hd15iqr": 0.4151687999983551,
+        "ops": 2.4128265861343983,
+        "total": 1.2433549999987008,
+        "data": [0.41373549999843817, 0.41445070000190753, 0.4151687999983551],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8240795563085308
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37638430000515655,
+        "max": 0.3951309000112815,
+        "mean": 0.3858220000062526,
+        "stddev": 0.009373963677476622,
+        "rounds": 3,
+        "median": 0.38595080000231974,
+        "iqr": 0.014059950004593702,
+        "q1": 0.37877592500444734,
+        "q3": 0.39283587500904105,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37638430000515655,
+        "hd15iqr": 0.3951309000112815,
+        "ops": 2.5918687891924104,
+        "total": 1.1574660000187578,
+        "data": [0.3951309000112815, 0.37638430000515655, 0.38595080000231974],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9495692741814015
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47259450001001824,
+        "max": 0.4839647999906447,
+        "mean": 0.47887276666491135,
+        "stddev": 0.005777221870913876,
+        "rounds": 3,
+        "median": 0.4800589999940712,
+        "iqr": 0.008527724985469831,
+        "q1": 0.4744606250060315,
+        "q3": 0.4829883499915013,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47259450001001824,
+        "hd15iqr": 0.4839647999906447,
+        "ops": 2.0882373557478675,
+        "total": 1.4366182999947341,
+        "data": [0.4800589999940712, 0.47259450001001824, 0.4839647999906447],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.96654581102435
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.40363909999723546,
+        "max": 0.4232382000045618,
+        "mean": 0.4139670666675859,
+        "stddev": 0.009842197559244259,
+        "rounds": 3,
+        "median": 0.41502390000096057,
+        "iqr": 0.014699325005494757,
+        "q1": 0.40648529999816674,
+        "q3": 0.4211846250036615,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.40363909999723546,
+        "hd15iqr": 0.4232382000045618,
+        "ops": 2.415651100098251,
+        "total": 1.2419012000027578,
+        "data": [0.4232382000045618, 0.40363909999723546, 0.41502390000096057],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.550320959412232
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4223935000045458,
+        "max": 0.4370061999943573,
+        "mean": 0.43212049999662366,
+        "stddev": 0.00842385834843436,
+        "rounds": 3,
+        "median": 0.43696179999096785,
+        "iqr": 0.010959524992358638,
+        "q1": 0.4260355750011513,
+        "q3": 0.43699509999350994,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4223935000045458,
+        "hd15iqr": 0.4370061999943573,
+        "ops": 2.314169311587424,
+        "total": 1.296361499989871,
+        "data": [0.4370061999943573, 0.4223935000045458, 0.43696179999096785],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.583083597105599
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.41159169998718426,
+        "max": 0.4323579000047175,
+        "mean": 0.4226279333330846,
+        "stddev": 0.010444544760796228,
+        "rounds": 3,
+        "median": 0.42393420000735205,
+        "iqr": 0.015574650013149949,
+        "q1": 0.4146773249922262,
+        "q3": 0.43025197500537615,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.41159169998718426,
+        "hd15iqr": 0.4323579000047175,
+        "ops": 2.366147434017033,
+        "total": 1.2678837999992538,
+        "data": [0.4323579000047175, 0.41159169998718426, 0.42393420000735205],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8389542717980512
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.38241479999851435,
+        "max": 0.41446189999987837,
+        "mean": 0.39894810000259895,
+        "stddev": 0.0160478562375871,
+        "rounds": 3,
+        "median": 0.3999676000094041,
+        "iqr": 0.02403532500102301,
+        "q1": 0.3868030000012368,
+        "q3": 0.4108383250022598,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.38241479999851435,
+        "hd15iqr": 0.41446189999987837,
+        "ops": 2.5065917095318553,
+        "total": 1.1968443000077968,
+        "data": [0.3999676000094041, 0.38241479999851435, 0.41446189999987837],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9548131085007137
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47525029999087565,
+        "max": 0.5094141000008676,
+        "mean": 0.4918596333300229,
+        "stddev": 0.01710149892675189,
+        "rounds": 3,
+        "median": 0.4909144999983255,
+        "iqr": 0.02562285000749398,
+        "q1": 0.4791663499927381,
+        "q3": 0.5047892000002321,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47525029999087565,
+        "hd15iqr": 0.5094141000008676,
+        "ops": 2.033100364894206,
+        "total": 1.4755788999900687,
+        "data": [0.4909144999983255, 0.47525029999087565, 0.5094141000008676],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9654348007512812
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3937455000123009,
+        "max": 0.4297346999956062,
+        "mean": 0.41603676666757866,
+        "stddev": 0.01947279286888524,
+        "rounds": 3,
+        "median": 0.4246300999948289,
+        "iqr": 0.026991899987478973,
+        "q1": 0.4014666500079329,
+        "q3": 0.4284585499954119,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3937455000123009,
+        "hd15iqr": 0.4297346999956062,
+        "ops": 2.403633717303209,
+        "total": 1.248110300002736,
+        "data": [0.4297346999956062, 0.3937455000123009, 0.4246300999948289],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5515113096178377
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4422338000003947,
+        "max": 0.45213440000952687,
+        "mean": 0.44759900000159786,
+        "stddev": 0.00500218913645169,
+        "rounds": 3,
+        "median": 0.44842879999487195,
+        "iqr": 0.0074254500068491325,
+        "q1": 0.443782549999014,
+        "q3": 0.45120800000586314,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4422338000003947,
+        "hd15iqr": 0.45213440000952687,
+        "ops": 2.234142614251663,
+        "total": 1.3427970000047935,
+        "data": [0.44842879999487195, 0.4422338000003947, 0.45213440000952687],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5896407928599916
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4259940999909304,
+        "max": 0.42806910000217613,
+        "mean": 0.4272681666673937,
+        "stddev": 0.0011154808967100411,
+        "rounds": 3,
+        "median": 0.4277413000090746,
+        "iqr": 0.00155625000843429,
+        "q1": 0.42643089999546646,
+        "q3": 0.42798715000390075,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4259940999909304,
+        "hd15iqr": 0.42806910000217613,
+        "ops": 2.3404505133153264,
+        "total": 1.2818045000021812,
+        "data": [0.4277413000090746, 0.42806910000217613, 0.4259940999909304],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.85086200281586
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.38030870001239236,
+        "max": 0.3920892000023741,
+        "mean": 0.38429610000457615,
+        "stddev": 0.006749634019933156,
+        "rounds": 3,
+        "median": 0.38049039999896195,
+        "iqr": 0.008835374992486322,
+        "q1": 0.38035412500903476,
+        "q3": 0.3891895000015211,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.38030870001239236,
+        "hd15iqr": 0.3920892000023741,
+        "ops": 2.602160157201939,
+        "total": 1.1528883000137284,
+        "data": [0.38030870001239236, 0.3920892000023741, 0.38049039999896195],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9608456890693229
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4588236000126926,
+        "max": 0.47106879999046214,
+        "mean": 0.4648732000011175,
+        "stddev": 0.006123905422530061,
+        "rounds": 3,
+        "median": 0.4647272000001976,
+        "iqr": 0.009183899983327137,
+        "q1": 0.4602995000095689,
+        "q3": 0.469483399992896,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4588236000126926,
+        "hd15iqr": 0.47106879999046214,
+        "ops": 2.151124220534968,
+        "total": 1.3946196000033524,
+        "data": [0.4647272000001976, 0.47106879999046214, 0.4588236000126926],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9747286445734673
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3989865999901667,
+        "max": 0.405582699997467,
+        "mean": 0.4031834666626916,
+        "stddev": 0.003647019062099606,
+        "rounds": 3,
+        "median": 0.4049811000004411,
+        "iqr": 0.004947075005475199,
+        "q1": 0.4004852249927353,
+        "q3": 0.4054322999982105,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3989865999901667,
+        "hd15iqr": 0.405582699997467,
+        "ops": 2.480260433984047,
+        "total": 1.2095503999880748,
+        "data": [0.4049811000004411, 0.3989865999901667, 0.405582699997467],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5588331480534403
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.42680419998941943,
+        "max": 0.43499039999733213,
+        "mean": 0.4311797333308884,
+        "stddev": 0.004122229180043605,
+        "rounds": 3,
+        "median": 0.4317446000059135,
+        "iqr": 0.006139650005934527,
+        "q1": 0.42803929999354295,
+        "q3": 0.4341789499994775,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.42680419998941943,
+        "hd15iqr": 0.43499039999733213,
+        "ops": 2.3192184666819617,
+        "total": 1.293539199992665,
+        "data": [0.42680419998941943, 0.43499039999733213, 0.4317446000059135],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5947106737762469
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4172383999975864,
+        "max": 0.4285721999913221,
+        "mean": 0.424045833327303,
+        "stddev": 0.0060013502167860855,
+        "rounds": 3,
+        "median": 0.42632689999300055,
+        "iqr": 0.008500349995301804,
+        "q1": 0.4195105249964399,
+        "q3": 0.42801087499174173,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4172383999975864,
+        "hd15iqr": 0.4285721999913221,
+        "ops": 2.3582356467305323,
+        "total": 1.272137499981909,
+        "data": [0.42632689999300055, 0.4172383999975864, 0.4285721999913221],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8626853725921764
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3670111000101315,
+        "max": 0.3803747000056319,
+        "mean": 0.37473290000343695,
+        "stddev": 0.006920350510068075,
+        "rounds": 3,
+        "median": 0.3768128999945475,
+        "iqr": 0.010022699996625306,
+        "q1": 0.3694615500062355,
+        "q3": 0.3794842500028608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3670111000101315,
+        "hd15iqr": 0.3803747000056319,
+        "ops": 2.668567398247734,
+        "total": 1.1241987000103109,
+        "data": [0.3670111000101315, 0.3803747000056319, 0.3768128999945475],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9660081210016527
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46869490000244696,
+        "max": 0.4759823000058532,
+        "mean": 0.47311330000229646,
+        "stddev": 0.003882915137341439,
+        "rounds": 3,
+        "median": 0.47466269999858923,
+        "iqr": 0.005465550002554664,
+        "q1": 0.4701868500014825,
+        "q3": 0.4756524000040372,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46869490000244696,
+        "hd15iqr": 0.4759823000058532,
+        "ops": 2.113658609882973,
+        "total": 1.4193399000068894,
+        "data": [0.46869490000244696, 0.47466269999858923, 0.4759823000058532],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.022350541196121
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46891800001321826,
+        "max": 0.4758490999956848,
+        "mean": 0.47198103333842784,
+        "stddev": 0.003534981717211195,
+        "rounds": 3,
+        "median": 0.4711760000063805,
+        "iqr": 0.0051983249868499115,
+        "q1": 0.4694825000115088,
+        "q3": 0.47468082499835873,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46891800001321826,
+        "hd15iqr": 0.4758490999956848,
+        "ops": 2.1187292059741796,
+        "total": 1.4159431000152836,
+        "data": [0.4758490999956848, 0.4711760000063805, 0.46891800001321826],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8830579206429097
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39410469999711495,
+        "max": 0.39856180000060704,
+        "mean": 0.39589509999980993,
+        "stddev": 0.0023542220318584187,
+        "rounds": 3,
+        "median": 0.39501880000170786,
+        "iqr": 0.0033428250026190653,
+        "q1": 0.3943332249982632,
+        "q3": 0.39767605000088224,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39410469999711495,
+        "hd15iqr": 0.39856180000060704,
+        "ops": 2.525921639344564,
+        "total": 1.1876852999994298,
+        "data": [0.39856180000060704, 0.39501880000170786, 0.39410469999711495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.882280833534474
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39394650000031106,
+        "max": 0.40684239999973215,
+        "mean": 0.39994890000283095,
+        "stddev": 0.0064939667075491645,
+        "rounds": 3,
+        "median": 0.3990578000084497,
+        "iqr": 0.009671924999565817,
+        "q1": 0.3952243250023457,
+        "q3": 0.40489625000191154,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39394650000031106,
+        "hd15iqr": 0.40684239999973215,
+        "ops": 2.500319415787671,
+        "total": 1.199846700008493,
+        "data": [0.39394650000031106, 0.3990578000084497, 0.40684239999973215],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.5522091216689786
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3699991000030423,
+        "max": 2.384307300002547,
+        "mean": 2.378035933332285,
+        "stddev": 0.00731565452980359,
+        "rounds": 3,
+        "median": 2.3798013999912655,
+        "iqr": 0.010731149999628542,
+        "q1": 2.372449675000098,
+        "q3": 2.3831808249997266,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3699991000030423,
+        "hd15iqr": 2.384307300002547,
+        "ops": 0.42051509230086526,
+        "total": 7.134107799996855,
+        "data": [2.3798013999912655, 2.384307300002547, 2.3699991000030423],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.5630617253950272
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3186095999990357,
+        "max": 2.3481374999973923,
+        "mean": 2.3332416333287256,
+        "stddev": 0.014765717916894645,
+        "rounds": 3,
+        "median": 2.3329777999897487,
+        "iqr": 0.02214592499876744,
+        "q1": 2.322201649996714,
+        "q3": 2.3443475749954814,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3186095999990357,
+        "hd15iqr": 2.3481374999973923,
+        "ops": 0.4285882720913681,
+        "total": 6.999724899986177,
+        "data": [2.3186095999990357, 2.3481374999973923, 2.3329777999897487],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.5765172699670182
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2827918999973917,
+        "max": 2.301516499996069,
+        "mean": 2.2893150666641304,
+        "stddev": 0.010575192457750085,
+        "rounds": 3,
+        "median": 2.2836367999989307,
+        "iqr": 0.014043449999007862,
+        "q1": 2.2830031249977765,
+        "q3": 2.2970465749967843,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2827918999973917,
+        "hd15iqr": 2.301516499996069,
+        "ops": 0.43681187205793715,
+        "total": 6.867945199992391,
+        "data": [2.2827918999973917, 2.301516499996069, 2.2836367999989307],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.5741926932531418
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3342158000014024,
+        "max": 2.356209100005799,
+        "mean": 2.3474751333366535,
+        "stddev": 0.011674138891921513,
+        "rounds": 3,
+        "median": 2.3520005000027595,
+        "iqr": 0.01649497500329744,
+        "q1": 2.3386619750017417,
+        "q3": 2.355156950005039,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3342158000014024,
+        "hd15iqr": 2.356209100005799,
+        "ops": 0.425989602956356,
+        "total": 7.042425400009961,
+        "data": [2.3342158000014024, 2.356209100005799, 2.3520005000027595],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.5836616386325133
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2448862999881385,
+        "max": 2.285991800003103,
+        "mean": 2.2682569666649215,
+        "stddev": 0.021124334212832146,
+        "rounds": 3,
+        "median": 2.273892800003523,
+        "iqr": 0.03082912501122337,
+        "q1": 2.2521379249919846,
+        "q3": 2.282967050003208,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2448862999881385,
+        "hd15iqr": 2.285991800003103,
+        "ops": 0.44086715689462935,
+        "total": 6.8047708999947645,
+        "data": [2.2448862999881385, 2.285991800003103, 2.273892800003523],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.5888086289921812
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2422053000045707,
+        "max": 2.258359300001757,
+        "mean": 2.2515940666683796,
+        "stddev": 0.008390478194309698,
+        "rounds": 3,
+        "median": 2.2542175999988103,
+        "iqr": 0.012115499997889856,
+        "q1": 2.2452083750031306,
+        "q3": 2.2573238750010205,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2422053000045707,
+        "hd15iqr": 2.258359300001757,
+        "ops": 0.44412979000236574,
+        "total": 6.754782200005138,
+        "data": [2.258359300001757, 2.2542175999988103, 2.2422053000045707],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.590056654709894
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.244777800005977,
+        "max": 2.3110471999971196,
+        "mean": 2.2714234333349546,
+        "stddev": 0.034989031172740416,
+        "rounds": 3,
+        "median": 2.2584453000017675,
+        "iqr": 0.04970204999335692,
+        "q1": 2.2481946750049246,
+        "q3": 2.2978967249982816,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.244777800005977,
+        "hd15iqr": 2.3110471999971196,
+        "ops": 0.440252568202036,
+        "total": 6.814270300004864,
+        "data": [2.244777800005977, 2.2584453000017675, 2.3110471999971196],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.590938494955057
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.271899300001678,
+        "max": 2.2901840999984415,
+        "mean": 2.279937566665467,
+        "stddev": 0.009340278849803584,
+        "rounds": 3,
+        "median": 2.277729299996281,
+        "iqr": 0.0137135999975726,
+        "q1": 2.273356800000329,
+        "q3": 2.2870703999979014,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.271899300001678,
+        "hd15iqr": 2.2901840999984415,
+        "ops": 0.43860850166285675,
+        "total": 6.839812699996401,
+        "data": [2.2901840999984415, 2.271899300001678, 2.277729299996281],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.5911951518439853
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2648078999918653,
+        "max": 2.2949981999990996,
+        "mean": 2.2776775999955134,
+        "stddev": 0.015579519785243355,
+        "rounds": 3,
+        "median": 2.2732266999955755,
+        "iqr": 0.022642725005425746,
+        "q1": 2.266912599992793,
+        "q3": 2.2895553249982186,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2648078999918653,
+        "hd15iqr": 2.2949981999990996,
+        "ops": 0.43904369960084333,
+        "total": 6.83303279998654,
+        "data": [2.2648078999918653, 2.2949981999990996, 2.2732266999955755],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.5145255841903142
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.5006980000034673,
+        "max": 2.5337384000013117,
+        "mean": 2.5207613333380627,
+        "stddev": 0.017623234365673694,
+        "rounds": 3,
+        "median": 2.527847600009409,
+        "iqr": 0.02478029999838327,
+        "q1": 2.5074854000049527,
+        "q3": 2.532265700003336,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.5006980000034673,
+        "hd15iqr": 2.5337384000013117,
+        "ops": 0.39670554557252435,
+        "total": 7.562284000014188,
+        "data": [2.5006980000034673, 2.5337384000013117, 2.527847600009409],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.5261153742579847
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4623073999973712,
+        "max": 2.47887730000366,
+        "mean": 2.4702514333330328,
+        "stddev": 0.008305965872618549,
+        "rounds": 3,
+        "median": 2.469569599998067,
+        "iqr": 0.012427425004716497,
+        "q1": 2.464122949997545,
+        "q3": 2.4765503750022617,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4623073999973712,
+        "hd15iqr": 2.47887730000366,
+        "ops": 0.40481709129128257,
+        "total": 7.410754299999098,
+        "data": [2.4623073999973712, 2.47887730000366, 2.469569599998067],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.5386009888996388
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4214187000034144,
+        "max": 2.4437278999976115,
+        "mean": 2.434474133333424,
+        "stddev": 0.011630331172145928,
+        "rounds": 3,
+        "median": 2.4382757999992464,
+        "iqr": 0.016731899995647836,
+        "q1": 2.4256329750023724,
+        "q3": 2.4423648749980202,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4214187000034144,
+        "hd15iqr": 2.4437278999976115,
+        "ops": 0.41076632785197914,
+        "total": 7.303422400000272,
+        "data": [2.4437278999976115, 2.4214187000034144, 2.4382757999992464],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.5397051309331307
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.446341599992593,
+        "max": 2.4656510000058915,
+        "mean": 2.4569444333319552,
+        "stddev": 0.00979337034264506,
+        "rounds": 3,
+        "median": 2.4588406999973813,
+        "iqr": 0.014482050009974046,
+        "q1": 2.44946637499379,
+        "q3": 2.463948425003764,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.446341599992593,
+        "hd15iqr": 2.4656510000058915,
+        "ops": 0.40700961178998346,
+        "total": 7.370833299995866,
+        "data": [2.4656510000058915, 2.446341599992593, 2.4588406999973813],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.5493502744478727
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.411830500001088,
+        "max": 2.4414233999996213,
+        "mean": 2.4251631999989818,
+        "stddev": 0.015012082626349992,
+        "rounds": 3,
+        "median": 2.422235699996236,
+        "iqr": 0.022194674998900155,
+        "q1": 2.414431799999875,
+        "q3": 2.436626474998775,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.411830500001088,
+        "hd15iqr": 2.4414233999996213,
+        "ops": 0.4123433837361625,
+        "total": 7.275489599996945,
+        "data": [2.4414233999996213, 2.411830500001088, 2.422235699996236],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.553706893909559
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4001359999965644,
+        "max": 2.4332248999999138,
+        "mean": 2.4206519666671134,
+        "stddev": 0.017917523819193034,
+        "rounds": 3,
+        "median": 2.4285950000048615,
+        "iqr": 0.024816675002512056,
+        "q1": 2.4072507499986386,
+        "q3": 2.4320674250011507,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4001359999965644,
+        "hd15iqr": 2.4332248999999138,
+        "ops": 0.41311184497821674,
+        "total": 7.26195590000134,
+        "data": [2.4332248999999138, 2.4001359999965644, 2.4285950000048615],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.5548775077128068
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3920751999976346,
+        "max": 2.4129392999893753,
+        "mean": 2.400915633329229,
+        "stddev": 0.010790152822566498,
+        "rounds": 3,
+        "median": 2.3977324000006774,
+        "iqr": 0.015648074993805494,
+        "q1": 2.3934894999983953,
+        "q3": 2.409137574992201,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3920751999976346,
+        "hd15iqr": 2.4129392999893753,
+        "ops": 0.4165077631708992,
+        "total": 7.202746899987687,
+        "data": [2.4129392999893753, 2.3920751999976346, 2.3977324000006774],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.5555507761328304
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.404997000005096,
+        "max": 2.4095633999968413,
+        "mean": 2.4076916000000588,
+        "stddev": 0.002391809377627454,
+        "rounds": 3,
+        "median": 2.4085143999982392,
+        "iqr": 0.003424799993808847,
+        "q1": 2.405876350003382,
+        "q3": 2.409301149997191,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.404997000005096,
+        "hd15iqr": 2.4095633999968413,
+        "ops": 0.41533558533824494,
+        "total": 7.223074800000177,
+        "data": [2.4085143999982392, 2.404997000005096, 2.4095633999968413],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.5558621319422046
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4184296000021277,
+        "max": 2.469888000006904,
+        "mean": 2.4408446666687573,
+        "stddev": 0.02636175586080046,
+        "rounds": 3,
+        "median": 2.43421639999724,
+        "iqr": 0.038593800003582146,
+        "q1": 2.4223763000009058,
+        "q3": 2.460970100004488,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4184296000021277,
+        "hd15iqr": 2.469888000006904,
+        "ops": 0.4096942397259515,
+        "total": 7.3225340000062715,
+        "data": [2.469888000006904, 2.43421639999724, 2.4184296000021277],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.5497943860636303
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7589951999980258,
+        "max": 0.7719958000088809,
+        "mean": 0.7649803666669565,
+        "stddev": 0.0065612489073096966,
+        "rounds": 3,
+        "median": 0.7639500999939628,
+        "iqr": 0.009750450008141343,
+        "q1": 0.76023392499701,
+        "q3": 0.7699843750051514,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7589951999980258,
+        "hd15iqr": 0.7719958000088809,
+        "ops": 1.3072230916945378,
+        "total": 2.2949411000008695,
+        "data": [0.7719958000088809, 0.7589951999980258, 0.7639500999939628],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.5527471512817037
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7586352000071201,
+        "max": 0.7749112000019522,
+        "mean": 0.7657201000013932,
+        "stddev": 0.008339910239792926,
+        "rounds": 3,
+        "median": 0.7636138999951072,
+        "iqr": 0.012206999996124068,
+        "q1": 0.7598798750041169,
+        "q3": 0.772086875000241,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7586352000071201,
+        "hd15iqr": 0.7749112000019522,
+        "ops": 1.305960232724961,
+        "total": 2.2971603000041796,
+        "data": [0.7636138999951072, 0.7586352000071201, 0.7749112000019522],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.598402406832683
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8595539999951143,
+        "max": 0.9041791000054218,
+        "mean": 0.8783039333308503,
+        "stddev": 0.023150088559919693,
+        "rounds": 3,
+        "median": 0.871178699992015,
+        "iqr": 0.03346882500773063,
+        "q1": 0.8624601749943395,
+        "q3": 0.8959290000020701,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8595539999951143,
+        "hd15iqr": 0.9041791000054218,
+        "ops": 1.1385580344694957,
+        "total": 2.634911799992551,
+        "data": [0.8595539999951143, 0.871178699992015, 0.9041791000054218],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.6253037040785268
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8702551000023959,
+        "max": 0.8759878999990178,
+        "mean": 0.8732739000018531,
+        "stddev": 0.002878528483681398,
+        "rounds": 3,
+        "median": 0.8735787000041455,
+        "iqr": 0.00429959999746643,
+        "q1": 0.8710860000028333,
+        "q3": 0.8753856000002997,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8702551000023959,
+        "hd15iqr": 0.8759878999990178,
+        "ops": 1.1451160970205088,
+        "total": 2.6198217000055593,
+        "data": [0.8735787000041455, 0.8759878999990178, 0.8702551000023959],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.6536228963317532
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8736091000027955,
+        "max": 0.9222813000087626,
+        "mean": 0.8901045666716527,
+        "stddev": 0.02786884203902014,
+        "rounds": 3,
+        "median": 0.8744233000034001,
+        "iqr": 0.03650415000447538,
+        "q1": 0.8738126500029466,
+        "q3": 0.910316800007422,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8736091000027955,
+        "hd15iqr": 0.9222813000087626,
+        "ops": 1.1234635091686775,
+        "total": 2.670313700014958,
+        "data": [0.9222813000087626, 0.8744233000034001, 0.8736091000027955],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.6575301311469472
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8613009999971837,
+        "max": 0.8875076999975136,
+        "mean": 0.8735592666683564,
+        "stddev": 0.013184850349004516,
+        "rounds": 3,
+        "median": 0.8718691000103718,
+        "iqr": 0.019655025000247406,
+        "q1": 0.8639430250004807,
+        "q3": 0.8835980500007281,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8613009999971837,
+        "hd15iqr": 0.8875076999975136,
+        "ops": 1.1447420205544525,
+        "total": 2.620677800005069,
+        "data": [0.8875076999975136, 0.8613009999971837, 0.8718691000103718],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.6605452140353805
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8449677999888081,
+        "max": 0.8781864999909885,
+        "mean": 0.8577849999952983,
+        "stddev": 0.017860898975229335,
+        "rounds": 3,
+        "median": 0.8502007000060985,
+        "iqr": 0.02491402500163531,
+        "q1": 0.8462760249931307,
+        "q3": 0.871190049994766,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8449677999888081,
+        "hd15iqr": 0.8781864999909885,
+        "ops": 1.165793293197574,
+        "total": 2.573354999985895,
+        "data": [0.8502007000060985, 0.8449677999888081, 0.8781864999909885],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.661262900192571
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8488180999993347,
+        "max": 0.8949349999893457,
+        "mean": 0.8671331333268123,
+        "stddev": 0.024478401116443692,
+        "rounds": 3,
+        "median": 0.8576462999917567,
+        "iqr": 0.034587674992508255,
+        "q1": 0.8510251499974402,
+        "q3": 0.8856128249899484,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8488180999993347,
+        "hd15iqr": 0.8949349999893457,
+        "ops": 1.1532254524324717,
+        "total": 2.601399399980437,
+        "data": [0.8488180999993347, 0.8576462999917567, 0.8949349999893457],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.661262900192571
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8416786000016145,
+        "max": 0.8441285000008065,
+        "mean": 0.8431942666696463,
+        "stddev": 0.0013244059216981966,
+        "rounds": 3,
+        "median": 0.8437757000065176,
+        "iqr": 0.0018374249993939884,
+        "q1": 0.8422028750028403,
+        "q3": 0.8440403000022343,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8416786000016145,
+        "hd15iqr": 0.8441285000008065,
+        "ops": 1.1859663182361135,
+        "total": 2.5295828000089386,
+        "data": [0.8437757000065176, 0.8416786000016145, 0.8441285000008065],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {
+        "compression_ratio": 1.663274350723787
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8239806999918073,
+        "max": 0.884503199995379,
+        "mean": 0.8553870666655712,
+        "stddev": 0.030326178925936382,
+        "rounds": 3,
+        "median": 0.8576773000095272,
+        "iqr": 0.04539187500267872,
+        "q1": 0.8324048499962373,
+        "q3": 0.877796724998916,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8239806999918073,
+        "hd15iqr": 0.884503199995379,
+        "ops": 1.1690613980149969,
+        "total": 2.5661611999967135,
+        "data": [0.884503199995379, 0.8239806999918073, 0.8576773000095272],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {
+        "compression_ratio": 1.664757158793406
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8133384999964619,
+        "max": 0.8356984999991255,
+        "mean": 0.8280633000006977,
+        "stddev": 0.012754968491201505,
+        "rounds": 3,
+        "median": 0.8351529000065057,
+        "iqr": 0.016770000001997687,
+        "q1": 0.8187920999989728,
+        "q3": 0.8355621000009705,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8133384999964619,
+        "hd15iqr": 0.8356984999991255,
+        "ops": 1.2076371456133335,
+        "total": 2.484189900002093,
+        "data": [0.8351529000065057, 0.8133384999964619, 0.8356984999991255],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {
+        "compression_ratio": 1.664757158793406
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8327602999925148,
+        "max": 0.8402580000110902,
+        "mean": 0.8367045666673221,
+        "stddev": 0.0037640987515771725,
+        "rounds": 3,
+        "median": 0.8370953999983612,
+        "iqr": 0.005623275013931561,
+        "q1": 0.8338440749939764,
+        "q3": 0.839467350007908,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8327602999925148,
+        "hd15iqr": 0.8402580000110902,
+        "ops": 1.1951649839597505,
+        "total": 2.510113700001966,
+        "data": [0.8370953999983612, 0.8327602999925148, 0.8402580000110902],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {
+        "compression_ratio": 1.6711663714166576
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8508419999998296,
+        "max": 0.8982039999973495,
+        "mean": 0.8707127999999406,
+        "stddev": 0.024583381236729474,
+        "rounds": 3,
+        "median": 0.8630924000026425,
+        "iqr": 0.035521499998139916,
+        "q1": 0.8539046000005328,
+        "q3": 0.8894260999986727,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8508419999998296,
+        "hd15iqr": 0.8982039999973495,
+        "ops": 1.148484322270292,
+        "total": 2.6121383999998216,
+        "data": [0.8508419999998296, 0.8630924000026425, 0.8982039999973495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {
+        "compression_ratio": 1.6733410275785785
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.843949900008738,
+        "max": 0.8619863000058103,
+        "mean": 0.8540045000069464,
+        "stddev": 0.00919512403894364,
+        "rounds": 3,
+        "median": 0.8560773000062909,
+        "iqr": 0.01352729999780422,
+        "q1": 0.8469817500081263,
+        "q3": 0.8605090500059305,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.843949900008738,
+        "hd15iqr": 0.8619863000058103,
+        "ops": 1.1709540172116963,
+        "total": 2.5620135000208393,
+        "data": [0.8560773000062909, 0.843949900008738, 0.8619863000058103],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {
+        "compression_ratio": 1.674362472261861
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8503887999977451,
+        "max": 0.8803069999994477,
+        "mean": 0.8645009999988057,
+        "stddev": 0.015030848002172277,
+        "rounds": 3,
+        "median": 0.8628071999992244,
+        "iqr": 0.022438650001276983,
+        "q1": 0.8534933999981149,
+        "q3": 0.8759320499993919,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8503887999977451,
+        "hd15iqr": 0.8803069999994477,
+        "ops": 1.1567366608036098,
+        "total": 2.593502999996417,
+        "data": [0.8628071999992244, 0.8803069999994477, 0.8503887999977451],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {
+        "compression_ratio": 1.6641104497936057
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.836247800005367,
+        "max": 0.8538817000080599,
+        "mean": 0.8474629333359189,
+        "stddev": 0.0097464073979944,
+        "rounds": 3,
+        "median": 0.8522592999943299,
+        "iqr": 0.01322542500201962,
+        "q1": 0.8402506750026077,
+        "q3": 0.8534761000046274,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.836247800005367,
+        "hd15iqr": 0.8538817000080599,
+        "ops": 1.1799926116693273,
+        "total": 2.542388800007757,
+        "data": [0.8538817000080599, 0.836247800005367, 0.8522592999943299],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {
+        "compression_ratio": 1.6881691423829503
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.888393699991866,
+        "max": 0.9024369000107981,
+        "mean": 0.8964279000016783,
+        "stddev": 0.0072373298235631975,
+        "rounds": 3,
+        "median": 0.8984531000023708,
+        "iqr": 0.010532400014199084,
+        "q1": 0.8909085499944922,
+        "q3": 0.9014409500086913,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.888393699991866,
+        "hd15iqr": 0.9024369000107981,
+        "ops": 1.1155386841464079,
+        "total": 2.689283700005035,
+        "data": [0.9024369000107981, 0.888393699991866, 0.8984531000023708],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {
+        "compression_ratio": 1.7225803023698523
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.108052099996712,
+        "max": 1.1774913999979617,
+        "mean": 1.1315604999981588,
+        "stddev": 0.039781031608017665,
+        "rounds": 3,
+        "median": 1.1091379999998026,
+        "iqr": 0.052079475000937236,
+        "q1": 1.1083235749974847,
+        "q3": 1.160403049998422,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.108052099996712,
+        "hd15iqr": 1.1774913999979617,
+        "ops": 0.8837353371751905,
+        "total": 3.3946814999944763,
+        "data": [1.1091379999998026, 1.108052099996712, 1.1774913999979617],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {
+        "compression_ratio": 1.7310443741463586
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0969687000033446,
+        "max": 1.1211505999963265,
+        "mean": 1.1106266333323827,
+        "stddev": 0.012391827230521154,
+        "rounds": 3,
+        "median": 1.1137605999974767,
+        "iqr": 0.018136424994736444,
+        "q1": 1.1011666750018776,
+        "q3": 1.119303099996614,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0969687000033446,
+        "hd15iqr": 1.1211505999963265,
+        "ops": 0.9003925981853572,
+        "total": 3.3318798999971477,
+        "data": [1.1137605999974767, 1.1211505999963265, 1.0969687000033446],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.5023993200597492
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9025400999962585,
+        "max": 0.9160241999925347,
+        "mean": 0.9105733999943671,
+        "stddev": 0.007103324423441848,
+        "rounds": 3,
+        "median": 0.9131558999943081,
+        "iqr": 0.01011307499720715,
+        "q1": 0.9051940499957709,
+        "q3": 0.9153071249929781,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9025400999962585,
+        "hd15iqr": 0.9160241999925347,
+        "ops": 1.0982091064884896,
+        "total": 2.7317201999831013,
+        "data": [0.9131558999943081, 0.9025400999962585, 0.9160241999925347],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.5076649593950835
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9166471000062302,
+        "max": 0.9198168000002624,
+        "mean": 0.9178006000001915,
+        "stddev": 0.0017521238507731847,
+        "rounds": 3,
+        "median": 0.9169378999940818,
+        "iqr": 0.0023772749955242034,
+        "q1": 0.9167198000031931,
+        "q3": 0.9190970749987173,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9166471000062302,
+        "hd15iqr": 0.9198168000002624,
+        "ops": 1.0895612837906092,
+        "total": 2.7534018000005744,
+        "data": [0.9169378999940818, 0.9198168000002624, 0.9166471000062302],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.548161316260799
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0090253999951528,
+        "max": 1.0248648999986472,
+        "mean": 1.0155557333346223,
+        "stddev": 0.008277310920487311,
+        "rounds": 3,
+        "median": 1.012776900010067,
+        "iqr": 0.011879625002620742,
+        "q1": 1.0099632749988814,
+        "q3": 1.0218429000015021,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0090253999951528,
+        "hd15iqr": 1.0248648999986472,
+        "ops": 0.98468254097336,
+        "total": 3.046667200003867,
+        "data": [1.0090253999951528, 1.012776900010067, 1.0248648999986472],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.598136083337712
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0543892999994569,
+        "max": 1.0857412999903318,
+        "mean": 1.0715963666637738,
+        "stddev": 0.015898725461200237,
+        "rounds": 3,
+        "median": 1.074658500001533,
+        "iqr": 0.023513999993156176,
+        "q1": 1.0594565999999759,
+        "q3": 1.082970599993132,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0543892999994569,
+        "hd15iqr": 1.0857412999903318,
+        "ops": 0.9331871879272263,
+        "total": 3.2147890999913216,
+        "data": [1.074658500001533, 1.0543892999994569, 1.0857412999903318],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.637260157270635
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0223551000090083,
+        "max": 1.0423432999959914,
+        "mean": 1.0348555000042932,
+        "stddev": 0.010896176108014863,
+        "rounds": 3,
+        "median": 1.0398681000078795,
+        "iqr": 0.014991149990237318,
+        "q1": 1.0267333500087261,
+        "q3": 1.0417244999989634,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0223551000090083,
+        "hd15iqr": 1.0423432999959914,
+        "ops": 0.9663184860068401,
+        "total": 3.1045665000128793,
+        "data": [1.0398681000078795, 1.0223551000090083, 1.0423432999959914],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.642812171538915
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.011935899994569,
+        "max": 1.026461700006621,
+        "mean": 1.017635599996235,
+        "stddev": 0.00775116115549318,
+        "rounds": 3,
+        "median": 1.0145091999875149,
+        "iqr": 0.010894350009039044,
+        "q1": 1.0125792249928054,
+        "q3": 1.0234735750018444,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.011935899994569,
+        "hd15iqr": 1.026461700006621,
+        "ops": 0.9826700245192875,
+        "total": 3.0529067999887047,
+        "data": [1.026461700006621, 1.011935899994569, 1.0145091999875149],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.6658630251831235
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.017977700001211,
+        "max": 1.0421695999975782,
+        "mean": 1.0296146333324334,
+        "stddev": 0.012122049961132933,
+        "rounds": 3,
+        "median": 1.0286965999985114,
+        "iqr": 0.018143924997275462,
+        "q1": 1.020657425000536,
+        "q3": 1.0388013499978115,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.017977700001211,
+        "hd15iqr": 1.0421695999975782,
+        "ops": 0.9712371674083699,
+        "total": 3.0888438999973005,
+        "data": [1.0421695999975782, 1.0286965999985114, 1.017977700001211],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.6673541640340295
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0051786999974865,
+        "max": 1.0302384999959031,
+        "mean": 1.0166165999980876,
+        "stddev": 0.012671850140410994,
+        "rounds": 3,
+        "median": 1.0144326000008732,
+        "iqr": 0.018794849998812424,
+        "q1": 1.0074921749983332,
+        "q3": 1.0262870249971456,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0051786999974865,
+        "hd15iqr": 1.0302384999959031,
+        "ops": 0.9836549983561955,
+        "total": 3.049849799994263,
+        "data": [1.0144326000008732, 1.0051786999974865, 1.0302384999959031],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.677869784969957
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0496689999999944,
+        "max": 1.0732026000041515,
+        "mean": 1.0612615666662653,
+        "stddev": 0.011770669227144016,
+        "rounds": 3,
+        "median": 1.06091309999465,
+        "iqr": 0.01765020000311779,
+        "q1": 1.0524800249986583,
+        "q3": 1.0701302250017761,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0496689999999944,
+        "hd15iqr": 1.0732026000041515,
+        "ops": 0.9422747712812158,
+        "total": 3.183784699998796,
+        "data": [1.0732026000041515, 1.0496689999999944, 1.06091309999465],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {
+        "compression_ratio": 1.6855267611029494
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0304772999952547,
+        "max": 1.0398101000027964,
+        "mean": 1.0363053333373198,
+        "stddev": 0.005081679351661381,
+        "rounds": 3,
+        "median": 1.038628600013908,
+        "iqr": 0.006999600005656248,
+        "q1": 1.032515124999918,
+        "q3": 1.0395147250055743,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0304772999952547,
+        "hd15iqr": 1.0398101000027964,
+        "ops": 0.9649665671212924,
+        "total": 3.108916000011959,
+        "data": [1.0304772999952547, 1.038628600013908, 1.0398101000027964],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {
+        "compression_ratio": 1.688452589200499
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0453135999996448,
+        "max": 1.0675323000032222,
+        "mean": 1.0567113666669077,
+        "stddev": 0.011120575973438266,
+        "rounds": 3,
+        "median": 1.0572881999978563,
+        "iqr": 0.016664025002683047,
+        "q1": 1.0483072499991977,
+        "q3": 1.0649712750018807,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0453135999996448,
+        "hd15iqr": 1.0675323000032222,
+        "ops": 0.9463322072083057,
+        "total": 3.1701341000007233,
+        "data": [1.0675323000032222, 1.0572881999978563, 1.0453135999996448],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {
+        "compression_ratio": 1.6887607429394678
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0281255000008969,
+        "max": 1.0431686999945669,
+        "mean": 1.0360807666632657,
+        "stddev": 0.007559012292804792,
+        "rounds": 3,
+        "median": 1.0369480999943335,
+        "iqr": 0.01128239999525249,
+        "q1": 1.030331149999256,
+        "q3": 1.0416135499945085,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0281255000008969,
+        "hd15iqr": 1.0431686999945669,
+        "ops": 0.9651757200556236,
+        "total": 3.108242299989797,
+        "data": [1.0369480999943335, 1.0281255000008969, 1.0431686999945669],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {
+        "compression_ratio": 1.6918236999511338
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.02845410000009,
+        "max": 1.0682545000017853,
+        "mean": 1.0457490333355963,
+        "stddev": 0.020405396425121337,
+        "rounds": 3,
+        "median": 1.0405385000049137,
+        "iqr": 0.029850300001271535,
+        "q1": 1.0314752000012959,
+        "q3": 1.0613255000025674,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.02845410000009,
+        "hd15iqr": 1.0682545000017853,
+        "ops": 0.9562523780780634,
+        "total": 3.137247100006789,
+        "data": [1.0682545000017853, 1.02845410000009, 1.0405385000049137],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {
+        "compression_ratio": 1.6965483613528114
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0389998000027845,
+        "max": 1.066568800000823,
+        "mean": 1.04983493333566,
+        "stddev": 0.014700637109222288,
+        "rounds": 3,
+        "median": 1.0439362000033725,
+        "iqr": 0.020676749998528976,
+        "q1": 1.0402339000029315,
+        "q3": 1.0609106500014605,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0389998000027845,
+        "hd15iqr": 1.066568800000823,
+        "ops": 0.9525306962521064,
+        "total": 3.14950480000698,
+        "data": [1.066568800000823, 1.0439362000033725, 1.0389998000027845],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {
+        "compression_ratio": 1.6996524046622166
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0263462000002619,
+        "max": 1.053112499997951,
+        "mean": 1.04033913333357,
+        "stddev": 0.01342476111655409,
+        "rounds": 3,
+        "median": 1.041558700002497,
+        "iqr": 0.020074724998266902,
+        "q1": 1.0301493250008207,
+        "q3": 1.0502240499990876,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0263462000002619,
+        "hd15iqr": 1.053112499997951,
+        "ops": 0.9612250159192697,
+        "total": 3.12101740000071,
+        "data": [1.041558700002497, 1.0263462000002619, 1.053112499997951],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {
+        "compression_ratio": 1.7101923446300407
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0143069000041578,
+        "max": 1.0321312000014586,
+        "mean": 1.023453899998761,
+        "stddev": 0.008921428201820708,
+        "rounds": 3,
+        "median": 1.0239235999906668,
+        "iqr": 0.01336822499797563,
+        "q1": 1.016711075000785,
+        "q3": 1.0300792999987607,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0143069000041578,
+        "hd15iqr": 1.0321312000014586,
+        "ops": 0.9770835794374427,
+        "total": 3.0703616999962833,
+        "data": [1.0239235999906668, 1.0143069000041578, 1.0321312000014586],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {
+        "compression_ratio": 1.7233089931008847
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0390787000069395,
+        "max": 1.0623200999980327,
+        "mean": 1.0500416666667054,
+        "stddev": 0.011676408172442757,
+        "rounds": 3,
+        "median": 1.0487261999951443,
+        "iqr": 0.017431049993319903,
+        "q1": 1.0414905750039907,
+        "q3": 1.0589216249973106,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0390787000069395,
+        "hd15iqr": 1.0623200999980327,
+        "ops": 0.95234316098564,
+        "total": 3.1501250000001164,
+        "data": [1.0487261999951443, 1.0390787000069395, 1.0623200999980327],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {
+        "compression_ratio": 1.737628250569937
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.09651770000346,
+        "max": 1.117480400003842,
+        "mean": 1.1100744666716007,
+        "stddev": 0.011757264174586286,
+        "rounds": 3,
+        "median": 1.1162253000074998,
+        "iqr": 0.01572202500028652,
+        "q1": 1.10144460000447,
+        "q3": 1.1171666250047565,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.09651770000346,
+        "hd15iqr": 1.117480400003842,
+        "ops": 0.9008404661340935,
+        "total": 3.330223400014802,
+        "data": [1.117480400003842, 1.09651770000346, 1.1162253000074998],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {
+        "compression_ratio": 1.740952197857343
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1307013999903575,
+        "max": 1.1495700999948895,
+        "mean": 1.1381609666617198,
+        "stddev": 0.01003525124634655,
+        "rounds": 3,
+        "median": 1.1342113999999128,
+        "iqr": 0.014151525003399001,
+        "q1": 1.1315788999927463,
+        "q3": 1.1457304249961453,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1307013999903575,
+        "hd15iqr": 1.1495700999948895,
+        "ops": 0.8786103453653374,
+        "total": 3.4144828999851597,
+        "data": [1.1307013999903575, 1.1342113999999128, 1.1495700999948895],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.7119813000026625,
+        "max": 2.7770696000079624,
+        "mean": 2.7369811666673436,
+        "stddev": 0.03506950716285645,
+        "rounds": 3,
+        "median": 2.7218925999914063,
+        "iqr": 0.04881622500397498,
+        "q1": 2.7144591249998484,
+        "q3": 2.7632753500038234,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.7119813000026625,
+        "hd15iqr": 2.7770696000079624,
+        "ops": 0.3653660508075908,
+        "total": 8.210943500002031,
+        "data": [2.7119813000026625, 2.7218925999914063, 2.7770696000079624],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.6577596999995876,
+        "max": 2.700793399999384,
+        "mean": 2.681259766667305,
+        "stddev": 0.021789315706847386,
+        "rounds": 3,
+        "median": 2.685226200002944,
+        "iqr": 0.03227527499984717,
+        "q1": 2.6646263250004267,
+        "q3": 2.696901600000274,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.6577596999995876,
+        "hd15iqr": 2.700793399999384,
+        "ops": 0.37295901442737067,
+        "total": 8.043779300001916,
+        "data": [2.700793399999384, 2.6577596999995876, 2.685226200002944],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4481547999894246,
+        "max": 2.5102059000055306,
+        "mean": 2.472357800002404,
+        "stddev": 0.033199793954300935,
+        "rounds": 3,
+        "median": 2.4587127000122564,
+        "iqr": 0.04653832501207944,
+        "q1": 2.4507942749951326,
+        "q3": 2.497332600007212,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4481547999894246,
+        "hd15iqr": 2.5102059000055306,
+        "ops": 0.4044722005848133,
+        "total": 7.417073400007212,
+        "data": [2.5102059000055306, 2.4587127000122564, 2.4481547999894246],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.1656643000023905,
+        "max": 2.2213354999985313,
+        "mean": 2.1981158666700744,
+        "stddev": 0.02896104404432839,
+        "rounds": 3,
+        "median": 2.207347800009302,
+        "iqr": 0.04175339999710559,
+        "q1": 2.1760851750041184,
+        "q3": 2.217838575001224,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.1656643000023905,
+        "hd15iqr": 2.2213354999985313,
+        "ops": 0.4549350719691132,
+        "total": 6.594347600010224,
+        "data": [2.207347800009302, 2.1656643000023905, 2.2213354999985313],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2254146000050241,
+        "max": 1.2547151000035228,
+        "mean": 1.2396872666674124,
+        "stddev": 0.014664840011719575,
+        "rounds": 3,
+        "median": 1.23893209999369,
+        "iqr": 0.02197537499887403,
+        "q1": 1.2287939750021906,
+        "q3": 1.2507693500010646,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2254146000050241,
+        "hd15iqr": 1.2547151000035228,
+        "ops": 0.8066550547770397,
+        "total": 3.719061800002237,
+        "data": [1.23893209999369, 1.2547151000035228, 1.2254146000050241],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0689368000021204,
+        "max": 1.1306130000011763,
+        "mean": 1.105563666666664,
+        "stddev": 0.032427116277690626,
+        "rounds": 3,
+        "median": 1.117141199996695,
+        "iqr": 0.04625714999929187,
+        "q1": 1.080987900000764,
+        "q3": 1.127245050000056,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0689368000021204,
+        "hd15iqr": 1.1306130000011763,
+        "ops": 0.9045159769179606,
+        "total": 3.3166909999999916,
+        "data": [1.1306130000011763, 1.0689368000021204, 1.117141199996695],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8073931999970227,
+        "max": 1.8326715000002878,
+        "mean": 1.8238534333358984,
+        "stddev": 0.014267100138929413,
+        "rounds": 3,
+        "median": 1.8314956000103848,
+        "iqr": 0.018958725002448773,
+        "q1": 1.8134188000003633,
+        "q3": 1.832377525002812,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8073931999970227,
+        "hd15iqr": 1.8326715000002878,
+        "ops": 0.5482896715943678,
+        "total": 5.471560300007695,
+        "data": [1.8073931999970227, 1.8326715000002878, 1.8314956000103848],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9601722999941558,
+        "max": 2.029823099990608,
+        "mean": 1.989156233331111,
+        "stddev": 0.036265364789295526,
+        "rounds": 3,
+        "median": 1.977473300008569,
+        "iqr": 0.052238099997339305,
+        "q1": 1.964497549997759,
+        "q3": 2.0167356499950984,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9601722999941558,
+        "hd15iqr": 2.029823099990608,
+        "ops": 0.5027257202041716,
+        "total": 5.967468699993333,
+        "data": [1.977473300008569, 2.029823099990608, 1.9601722999941558],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2609929000027478,
+        "max": 1.318357800002559,
+        "mean": 1.285033133336886,
+        "stddev": 0.029788143022230686,
+        "rounds": 3,
+        "median": 1.2757487000053516,
+        "iqr": 0.043023674999858486,
+        "q1": 1.2646818500033987,
+        "q3": 1.3077055250032572,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2609929000027478,
+        "hd15iqr": 1.318357800002559,
+        "ops": 0.7781900513360838,
+        "total": 3.8550994000106584,
+        "data": [1.2609929000027478, 1.2757487000053516, 1.318357800002559],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1593470000079833,
+        "max": 1.3217338000104064,
+        "mean": 1.2421479000040563,
+        "stddev": 0.08124112488424308,
+        "rounds": 3,
+        "median": 1.2453628999937791,
+        "iqr": 0.12179010000181734,
+        "q1": 1.1808509750044323,
+        "q3": 1.3026410750062496,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1593470000079833,
+        "hd15iqr": 1.3217338000104064,
+        "ops": 0.8050571111513649,
+        "total": 3.726443700012169,
+        "data": [1.2453628999937791, 1.3217338000104064, 1.1593470000079833],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1037137000093935,
+        "max": 1.1292303999944124,
+        "mean": 1.1145322333371344,
+        "stddev": 0.013193337735770562,
+        "rounds": 3,
+        "median": 1.1106526000075974,
+        "iqr": 0.0191375249887642,
+        "q1": 1.1054484250089445,
+        "q3": 1.1245859499977087,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1037137000093935,
+        "hd15iqr": 1.1292303999944124,
+        "ops": 0.8972373970789504,
+        "total": 3.3435967000114033,
+        "data": [1.1106526000075974, 1.1292303999944124, 1.1037137000093935],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2836404999980005,
+        "max": 2.3801647999935085,
+        "mean": 2.3195166999988337,
+        "stddev": 0.052815437084098665,
+        "rounds": 3,
+        "median": 2.2947448000049917,
+        "iqr": 0.07239322499663103,
+        "q1": 2.2864165749997483,
+        "q3": 2.3588097999963793,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2836404999980005,
+        "hd15iqr": 2.3801647999935085,
+        "ops": 0.4311242941257991,
+        "total": 6.958550099996501,
+        "data": [2.3801647999935085, 2.2947448000049917, 2.2836404999980005],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.777691999988747,
+        "max": 2.839851800003089,
+        "mean": 2.8086149333345625,
+        "stddev": 0.031081089106626953,
+        "rounds": 3,
+        "median": 2.808301000011852,
+        "iqr": 0.046619850010756636,
+        "q1": 2.785344249994523,
+        "q3": 2.8319641000052798,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.777691999988747,
+        "hd15iqr": 2.839851800003089,
+        "ops": 0.3560473841149658,
+        "total": 8.425844800003688,
+        "data": [2.777691999988747, 2.808301000011852, 2.839851800003089],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3398901000036858,
+        "max": 1.4099141999904532,
+        "mean": 1.3765558999972807,
+        "stddev": 0.035129023782746856,
+        "rounds": 3,
+        "median": 1.3798633999977028,
+        "iqr": 0.05251807499007555,
+        "q1": 1.34988342500219,
+        "q3": 1.4024014999922656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3398901000036858,
+        "hd15iqr": 1.4099141999904532,
+        "ops": 0.7264507020760839,
+        "total": 4.129667699991842,
+        "data": [1.4099141999904532, 1.3798633999977028, 1.3398901000036858],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2318369999993593,
+        "max": 1.32575089999591,
+        "mean": 1.2763817333325278,
+        "stddev": 0.04714245985159017,
+        "rounds": 3,
+        "median": 1.2715573000023142,
+        "iqr": 0.07043542499741307,
+        "q1": 1.241767075000098,
+        "q3": 1.312202499997511,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2318369999993593,
+        "hd15iqr": 1.32575089999591,
+        "ops": 0.7834646750929929,
+        "total": 3.8291451999975834,
+        "data": [1.2318369999993593, 1.32575089999591, 1.2715573000023142],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1013684999925317,
+        "max": 1.1753926000092179,
+        "mean": 1.148103333330558,
+        "stddev": 0.040663120795728216,
+        "rounds": 3,
+        "median": 1.1675488999899244,
+        "iqr": 0.0555180750125146,
+        "q1": 1.11791359999188,
+        "q3": 1.1734316750043945,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1013684999925317,
+        "hd15iqr": 1.1753926000092179,
+        "ops": 0.8710017391022445,
+        "total": 3.444309999991674,
+        "data": [1.1013684999925317, 1.1675488999899244, 1.1753926000092179],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.403817800004617,
+        "max": 4.4753521000093315,
+        "mean": 4.438797266673646,
+        "stddev": 0.03579316072089642,
+        "rounds": 3,
+        "median": 4.437221900006989,
+        "iqr": 0.053650725003535626,
+        "q1": 4.41216882500521,
+        "q3": 4.465819550008746,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.403817800004617,
+        "hd15iqr": 4.4753521000093315,
+        "ops": 0.22528625209084663,
+        "total": 13.316391800020938,
+        "data": [4.437221900006989, 4.4753521000093315, 4.403817800004617],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.956360099997255,
+        "max": 6.0082094999961555,
+        "mean": 5.9794808999965126,
+        "stddev": 0.02637566370150223,
+        "rounds": 3,
+        "median": 5.973873099996126,
+        "iqr": 0.03888704999917536,
+        "q1": 5.960738349996973,
+        "q3": 5.999625399996148,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.956360099997255,
+        "hd15iqr": 6.0082094999961555,
+        "ops": 0.16723859758471396,
+        "total": 17.938442699989537,
+        "data": [6.0082094999961555, 5.956360099997255, 5.973873099996126],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.2190355000057025,
+        "max": 2.274786900001345,
+        "mean": 2.2501149333353774,
+        "stddev": 0.0284226383742507,
+        "rounds": 3,
+        "median": 2.256522399999085,
+        "iqr": 0.041813549996732036,
+        "q1": 2.228407225004048,
+        "q3": 2.27022077500078,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.2190355000057025,
+        "hd15iqr": 2.274786900001345,
+        "ops": 0.4444217427230198,
+        "total": 6.750344800006133,
+        "data": [2.2190355000057025, 2.274786900001345, 2.256522399999085],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5750190999970073,
+        "max": 1.5960131000028923,
+        "mean": 1.5876831666682847,
+        "stddev": 0.011147894101434552,
+        "rounds": 3,
+        "median": 1.5920173000049544,
+        "iqr": 0.01574550000441377,
+        "q1": 1.579268649998994,
+        "q3": 1.5950141500034078,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5750190999970073,
+        "hd15iqr": 1.5960131000028923,
+        "ops": 0.6298485875481543,
+        "total": 4.763049500004854,
+        "data": [1.5750190999970073, 1.5960131000028923, 1.5920173000049544],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3211600000067847,
+        "max": 1.350953600005596,
+        "mean": 1.332341433337812,
+        "stddev": 0.01622733800300534,
+        "rounds": 3,
+        "median": 1.3249107000010554,
+        "iqr": 0.022345199999108445,
+        "q1": 1.3220976750053524,
+        "q3": 1.3444428750044608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3211600000067847,
+        "hd15iqr": 1.350953600005596,
+        "ops": 0.7505583591247907,
+        "total": 3.997024300013436,
+        "data": [1.3249107000010554, 1.3211600000067847, 1.350953600005596],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.625159099989105,
+        "max": 8.639421700005187,
+        "mean": 8.633541499996985,
+        "stddev": 0.007453267299210028,
+        "rounds": 3,
+        "median": 8.636043699996662,
+        "iqr": 0.01069695001206128,
+        "q1": 8.627880249990994,
+        "q3": 8.638577200003056,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.625159099989105,
+        "hd15iqr": 8.639421700005187,
+        "ops": 0.11582732300532166,
+        "total": 25.900624499990954,
+        "data": [8.639421700005187, 8.625159099989105, 8.636043699996662],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.145430699994904,
+        "max": 9.161710799991852,
+        "mean": 9.152047733330013,
+        "stddev": 0.008556819108075056,
+        "rounds": 3,
+        "median": 9.149001700003282,
+        "iqr": 0.012210074997710763,
+        "q1": 9.146323449996999,
+        "q3": 9.15853352499471,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.145430699994904,
+        "hd15iqr": 9.161710799991852,
+        "ops": 0.10926516438044687,
+        "total": 27.456143199990038,
+        "data": [9.149001700003282, 9.145430699994904, 9.161710799991852],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.344740600005025,
+        "max": 4.42894269998942,
+        "mean": 4.375919866666663,
+        "stddev": 0.04615576306166515,
+        "rounds": 3,
+        "median": 4.354076300005545,
+        "iqr": 0.06315157498829649,
+        "q1": 4.347074525005155,
+        "q3": 4.4102260999934515,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.344740600005025,
+        "hd15iqr": 4.42894269998942,
+        "ops": 0.22852338033368635,
+        "total": 13.12775959999999,
+        "data": [4.344740600005025, 4.354076300005545, 4.42894269998942],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.512558499991428,
+        "max": 1.609662400005618,
+        "mean": 1.5542049666643531,
+        "stddev": 0.05000348937551211,
+        "rounds": 3,
+        "median": 1.540393999996013,
+        "iqr": 0.0728279250106425,
+        "q1": 1.5195173749925743,
+        "q3": 1.5923453000032168,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.512558499991428,
+        "hd15iqr": 1.609662400005618,
+        "ops": 0.6434157794169245,
+        "total": 4.662614899993059,
+        "data": [1.540393999996013, 1.512558499991428, 1.609662400005618],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2608852999983355,
+        "max": 1.326951499999268,
+        "mean": 1.2941382666613208,
+        "stddev": 0.03303529505980934,
+        "rounds": 3,
+        "median": 1.294577999986359,
+        "iqr": 0.04954965000069933,
+        "q1": 1.2693084749953414,
+        "q3": 1.3188581249960407,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2608852999983355,
+        "hd15iqr": 1.326951499999268,
+        "ops": 0.7727149608054226,
+        "total": 3.8824147999839624,
+        "data": [1.294577999986359, 1.326951499999268, 1.2608852999983355],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 10.468164000005345,
+        "max": 10.521944400010398,
+        "mean": 10.49048443333595,
+        "stddev": 0.028030896498029836,
+        "rounds": 3,
+        "median": 10.48134489999211,
+        "iqr": 0.0403353000037896,
+        "q1": 10.471459225002036,
+        "q3": 10.511794525005826,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 10.468164000005345,
+        "hd15iqr": 10.521944400010398,
+        "ops": 0.09532448252077547,
+        "total": 31.471453300007852,
+        "data": [10.521944400010398, 10.48134489999211, 10.468164000005345],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 12.13976150000235,
+        "max": 12.17800790000183,
+        "mean": 12.161075666668088,
+        "stddev": 0.019496096609951993,
+        "rounds": 3,
+        "median": 12.165457600000082,
+        "iqr": 0.028684799999609822,
+        "q1": 12.146185525001783,
+        "q3": 12.174870325001393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 12.13976150000235,
+        "hd15iqr": 12.17800790000183,
+        "ops": 0.08222956812454253,
+        "total": 36.48322700000426,
+        "data": [12.13976150000235, 12.17800790000183, 12.165457600000082],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.094801800005371,
+        "max": 6.274619499992696,
+        "mean": 6.184959433332551,
+        "stddev": 0.08990988258597608,
+        "rounds": 3,
+        "median": 6.185456999999587,
+        "iqr": 0.13486327499049366,
+        "q1": 6.117465600003925,
+        "q3": 6.252328874994419,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.094801800005371,
+        "hd15iqr": 6.274619499992696,
+        "ops": 0.16168254792597478,
+        "total": 18.554878299997654,
+        "data": [6.274619499992696, 6.185456999999587, 6.094801800005371],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8693862999934936,
+        "max": 1.9192920999921625,
+        "mean": 1.9006836999954733,
+        "stddev": 0.02726545908704792,
+        "rounds": 3,
+        "median": 1.9133727000007639,
+        "iqr": 0.037429349999001715,
+        "q1": 1.8803828999953112,
+        "q3": 1.9178122499943129,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8693862999934936,
+        "hd15iqr": 1.9192920999921625,
+        "ops": 0.5261264670194108,
+        "total": 5.70205109998642,
+        "data": [1.9192920999921625, 1.9133727000007639, 1.8693862999934936],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4287662999995518,
+        "max": 1.4698040000075707,
+        "mean": 1.4560711666660306,
+        "stddev": 0.023646844861777448,
+        "rounds": 3,
+        "median": 1.4696431999909692,
+        "iqr": 0.030778275006014155,
+        "q1": 1.4389855249974062,
+        "q3": 1.4697638000034203,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4287662999995518,
+        "hd15iqr": 1.4698040000075707,
+        "ops": 0.6867796182584277,
+        "total": 4.368213499998092,
+        "data": [1.4287662999995518, 1.4698040000075707, 1.4696431999909692],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 13.648655999990297,
+        "max": 13.76291140000103,
+        "mean": 13.707088533332959,
+        "stddev": 0.05717238737377999,
+        "rounds": 3,
+        "median": 13.709698200007551,
+        "iqr": 0.0856915500080504,
+        "q1": 13.66391654999461,
+        "q3": 13.74960810000266,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 13.648655999990297,
+        "hd15iqr": 13.76291140000103,
+        "ops": 0.07295495302070863,
+        "total": 41.12126559999888,
+        "data": [13.709698200007551, 13.76291140000103, 13.648655999990297],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 20.16494459999376,
+        "max": 20.223760299995774,
+        "mean": 20.203162499999355,
+        "stddev": 0.03313114222196103,
+        "rounds": 3,
+        "median": 20.220782600008533,
+        "iqr": 0.04411177500151098,
+        "q1": 20.178904099997453,
+        "q3": 20.223015874998964,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 20.16494459999376,
+        "hd15iqr": 20.223760299995774,
+        "ops": 0.04949720124262882,
+        "total": 60.60948749999807,
+        "data": [20.16494459999376, 20.220782600008533, 20.223760299995774],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 14.100529799994547,
+        "max": 14.184497599999304,
+        "mean": 14.134759166665996,
+        "stddev": 0.04407999796904712,
+        "rounds": 3,
+        "median": 14.119250100004137,
+        "iqr": 0.06297585000356776,
+        "q1": 14.105209874996945,
+        "q3": 14.168185725000512,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 14.100529799994547,
+        "hd15iqr": 14.184497599999304,
+        "ops": 0.07074757965160808,
+        "total": 42.40427749999799,
+        "data": [14.100529799994547, 14.119250100004137, 14.184497599999304],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9796910000004573,
+        "max": 2.002333999989787,
+        "mean": 1.9896485999973568,
+        "stddev": 0.011565337510894818,
+        "rounds": 3,
+        "median": 1.9869208000018261,
+        "iqr": 0.016982249991997378,
+        "q1": 1.9814984500007995,
+        "q3": 1.9984806999927969,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9796910000004573,
+        "hd15iqr": 2.002333999989787,
+        "ops": 0.5026013136195651,
+        "total": 5.9689457999920705,
+        "data": [1.9796910000004573, 1.9869208000018261, 2.002333999989787],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4828851000056602,
+        "max": 1.5251797000091756,
+        "mean": 1.5008150000066962,
+        "stddev": 0.02186923148302821,
+        "rounds": 3,
+        "median": 1.4943802000052528,
+        "iqr": 0.03172095000263653,
+        "q1": 1.4857588750055584,
+        "q3": 1.517479825008195,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4828851000056602,
+        "hd15iqr": 1.5251797000091756,
+        "ops": 0.666304641142005,
+        "total": 4.502445000020089,
+        "data": [1.4828851000056602, 1.4943802000052528, 1.5251797000091756],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 19.308182799999486,
+        "max": 20.420877500000643,
+        "mean": 19.995214633333187,
+        "stddev": 0.6006310651346644,
+        "rounds": 3,
+        "median": 20.25658359999943,
+        "iqr": 0.8345210250008677,
+        "q1": 19.545282999999472,
+        "q3": 20.37980402500034,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 19.308182799999486,
+        "hd15iqr": 20.420877500000643,
+        "ops": 0.05001196627981886,
+        "total": 59.98564389999956,
+        "data": [19.308182799999486, 20.25658359999943, 20.420877500000643],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 29.158568099999684,
+        "max": 29.218136800001957,
+        "mean": 29.180964066666395,
+        "stddev": 0.03241715795500034,
+        "rounds": 3,
+        "median": 29.166187299997546,
+        "iqr": 0.04467652500170516,
+        "q1": 29.16047289999915,
+        "q3": 29.205149425000855,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 29.158568099999684,
+        "hd15iqr": 29.218136800001957,
+        "ops": 0.034268915780692334,
+        "total": 87.54289219999919,
+        "data": [29.218136800001957, 29.158568099999684, 29.166187299997546],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 19.595232200008468,
+        "max": 19.69546880001144,
+        "mean": 19.62950163334123,
+        "stddev": 0.05714371110706696,
+        "rounds": 3,
+        "median": 19.597803900003782,
+        "iqr": 0.0751774500022293,
+        "q1": 19.595875125007296,
+        "q3": 19.671052575009526,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 19.595232200008468,
+        "hd15iqr": 19.69546880001144,
+        "ops": 0.0509437284083399,
+        "total": 58.88850490002369,
+        "data": [19.69546880001144, 19.595232200008468, 19.597803900003782],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9817372999968939,
+        "max": 2.0086329999903683,
+        "mean": 1.998762699998527,
+        "stddev": 0.014806797818817573,
+        "rounds": 3,
+        "median": 2.0059178000083193,
+        "iqr": 0.020171774995105807,
+        "q1": 1.9877824249997502,
+        "q3": 2.007954199994856,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9817372999968939,
+        "hd15iqr": 2.0086329999903683,
+        "ops": 0.5003095164827405,
+        "total": 5.996288099995581,
+        "data": [2.0059178000083193, 1.9817372999968939, 2.0086329999903683],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.477567000009003,
+        "max": 1.5539181000058306,
+        "mean": 1.5159409666715267,
+        "stddev": 0.03817709686709008,
+        "rounds": 3,
+        "median": 1.5163377999997465,
+        "iqr": 0.05726332499762066,
+        "q1": 1.487259700006689,
+        "q3": 1.5445230250043096,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.477567000009003,
+        "hd15iqr": 1.5539181000058306,
+        "ops": 0.65965629400177,
+        "total": 4.54782290001458,
+        "data": [1.477567000009003, 1.5163377999997465, 1.5539181000058306],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 28.277398800011724,
+        "max": 28.29512560000876,
+        "mean": 28.286878533341223,
+        "stddev": 0.008927455396604325,
+        "rounds": 3,
+        "median": 28.288111200003186,
+        "iqr": 0.01329509999777656,
+        "q1": 28.28007690000959,
+        "q3": 28.293372000007366,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 28.277398800011724,
+        "hd15iqr": 28.29512560000876,
+        "ops": 0.03535208025237986,
+        "total": 84.86063560002367,
+        "data": [28.288111200003186, 28.277398800011724, 28.29512560000876],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 90.17021950001072,
+        "max": 90.79531479999423,
+        "mean": 90.49300660000397,
+        "stddev": 0.31305043127964,
+        "rounds": 3,
+        "median": 90.51348550000694,
+        "iqr": 0.46882147498763516,
+        "q1": 90.25603600000977,
+        "q3": 90.7248574749974,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 90.17021950001072,
+        "hd15iqr": 90.79531479999423,
+        "ops": 0.011050577691823053,
+        "total": 271.4790198000119,
+        "data": [90.17021950001072, 90.51348550000694, 90.79531479999423],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 30.365446900003008,
+        "max": 30.49247949999699,
+        "mean": 30.439828633335612,
+        "stddev": 0.06624570393632921,
+        "rounds": 3,
+        "median": 30.461559500006842,
+        "iqr": 0.09527444999548607,
+        "q1": 30.389475050003966,
+        "q3": 30.484749499999452,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 30.365446900003008,
+        "hd15iqr": 30.49247949999699,
+        "ops": 0.03285169611319259,
+        "total": 91.31948590000684,
+        "data": [30.461559500006842, 30.49247949999699, 30.365446900003008],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.0281383999972604,
+        "max": 2.0446894000051543,
+        "mean": 2.037776600001962,
+        "stddev": 0.008605507201292396,
+        "rounds": 3,
+        "median": 2.040502000003471,
+        "iqr": 0.012413250005920418,
+        "q1": 2.031229299998813,
+        "q3": 2.0436425500047335,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.0281383999972604,
+        "hd15iqr": 2.0446894000051543,
+        "ops": 0.49073092703048865,
+        "total": 6.113329800005886,
+        "data": [2.0281383999972604, 2.0446894000051543, 2.040502000003471],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.50821050000377,
+        "max": 1.5397092000057455,
+        "mean": 1.5205234333358628,
+        "stddev": 0.016836534798478922,
+        "rounds": 3,
+        "median": 1.5136505999980727,
+        "iqr": 0.02362402500148164,
+        "q1": 1.5095705250023457,
+        "q3": 1.5331945500038273,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.50821050000377,
+        "hd15iqr": 1.5397092000057455,
+        "ops": 0.6576682595454046,
+        "total": 4.561570300007588,
+        "data": [1.50821050000377, 1.5136505999980727, 1.5397092000057455],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 56.51999990000331,
+        "max": 56.857611900006304,
+        "mean": 56.65600133333646,
+        "stddev": 0.17811199965021712,
+        "rounds": 3,
+        "median": 56.59039219999977,
+        "iqr": 0.25320900000224356,
+        "q1": 56.53759797500243,
+        "q3": 56.79080697500467,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 56.51999990000331,
+        "hd15iqr": 56.857611900006304,
+        "ops": 0.017650380832852718,
+        "total": 169.9680040000094,
+        "data": [56.51999990000331, 56.59039219999977, 56.857611900006304],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 181.32249269999738,
+        "max": 182.5354520999972,
+        "mean": 182.0016560666651,
+        "stddev": 0.6194080825375281,
+        "rounds": 3,
+        "median": 182.14702340000076,
+        "iqr": 0.9097195499998634,
+        "q1": 181.52862537499823,
+        "q3": 182.4383449249981,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 181.32249269999738,
+        "hd15iqr": 182.5354520999972,
+        "ops": 0.005494455498985743,
+        "total": 546.0049681999953,
+        "data": [182.5354520999972, 181.32249269999738, 182.14702340000076],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 107.58925199999067,
+        "max": 107.9588911000028,
+        "mean": 107.81355723333157,
+        "stddev": 0.19706756107919549,
+        "rounds": 3,
+        "median": 107.89252860000124,
+        "iqr": 0.27722932500910247,
+        "q1": 107.66507114999331,
+        "q3": 107.94230047500241,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 107.58925199999067,
+        "hd15iqr": 107.9588911000028,
+        "ops": 0.00927527136346857,
+        "total": 323.4406716999947,
+        "data": [107.58925199999067, 107.89252860000124, 107.9588911000028],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.207957800012082,
+        "max": 2.2573649999976624,
+        "mean": 2.229964199999813,
+        "stddev": 0.0251414501611514,
+        "rounds": 3,
+        "median": 2.2245697999896947,
+        "iqr": 0.03705539998918539,
+        "q1": 2.212110800006485,
+        "q3": 2.2491661999956705,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.207957800012082,
+        "hd15iqr": 2.2573649999976624,
+        "ops": 0.448437692407835,
+        "total": 6.689892599999439,
+        "data": [2.2573649999976624, 2.207957800012082, 2.2245697999896947],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.1996457999921404,
+        "max": 2.2244153000065126,
+        "mean": 2.2083698666635123,
+        "stddev": 0.013913440990488829,
+        "rounds": 3,
+        "median": 2.2010484999918845,
+        "iqr": 0.018577125010779127,
+        "q1": 2.1999964749920764,
+        "q3": 2.2185736000028555,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.1996457999921404,
+        "hd15iqr": 2.2244153000065126,
+        "ops": 0.45282269745458775,
+        "total": 6.625109599990537,
+        "data": [2.1996457999921404, 2.2244153000065126, 2.2010484999918845],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.113585500002955,
+        "max": 2.1647094000072684,
+        "mean": 2.1363035000055484,
+        "stddev": 0.026032238526734582,
+        "rounds": 3,
+        "median": 2.130615600006422,
+        "iqr": 0.038342925003234996,
+        "q1": 2.117843025003822,
+        "q3": 2.156185950007057,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.113585500002955,
+        "hd15iqr": 2.1647094000072684,
+        "ops": 0.46809828285044836,
+        "total": 6.4089105000166455,
+        "data": [2.130615600006422, 2.113585500002955, 2.1647094000072684],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.004377500008559,
+        "max": 2.0122030999918934,
+        "mean": 2.0082439000010104,
+        "stddev": 0.003913625257299567,
+        "rounds": 3,
+        "median": 2.0081511000025785,
+        "iqr": 0.005869199987500906,
+        "q1": 2.0053209000070638,
+        "q3": 2.0111900999945647,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.004377500008559,
+        "hd15iqr": 2.0122030999918934,
+        "ops": 0.4979474853624587,
+        "total": 6.024731700003031,
+        "data": [2.004377500008559, 2.0081511000025785, 2.0122030999918934],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.0004593999910867,
+        "max": 2.0646050999930594,
+        "mean": 2.0255665999963335,
+        "stddev": 0.034267018352567596,
+        "rounds": 3,
+        "median": 2.011635300004855,
+        "iqr": 0.048109275001479546,
+        "q1": 2.0032533749945287,
+        "q3": 2.0513626499960083,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.0004593999910867,
+        "hd15iqr": 2.0646050999930594,
+        "ops": 0.4936890250865166,
+        "total": 6.076699799989001,
+        "data": [2.0004593999910867, 2.011635300004855, 2.0646050999930594],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7258235000044806,
+        "max": 1.769499200003338,
+        "mean": 1.742975700001504,
+        "stddev": 0.02329715949279382,
+        "rounds": 3,
+        "median": 1.7336043999966932,
+        "iqr": 0.03275677499914309,
+        "q1": 1.7277687250025338,
+        "q3": 1.7605255000016768,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7258235000044806,
+        "hd15iqr": 1.769499200003338,
+        "ops": 0.5737314639550839,
+        "total": 5.228927100004512,
+        "data": [1.769499200003338, 1.7336043999966932, 1.7258235000044806],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.731200700000045,
+        "max": 1.766900499991607,
+        "mean": 1.7454945666637893,
+        "stddev": 0.018882665305381286,
+        "rounds": 3,
+        "median": 1.738382499999716,
+        "iqr": 0.026774849993671523,
+        "q1": 1.7329961499999627,
+        "q3": 1.7597709999936342,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.731200700000045,
+        "hd15iqr": 1.766900499991607,
+        "ops": 0.5729035306659974,
+        "total": 5.236483699991368,
+        "data": [1.731200700000045, 1.738382499999716, 1.766900499991607],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7010551999992458,
+        "max": 1.7421479000040563,
+        "mean": 1.7185430333338445,
+        "stddev": 0.021218295667727153,
+        "rounds": 3,
+        "median": 1.7124259999982314,
+        "iqr": 0.03081952500360785,
+        "q1": 1.7038978999989922,
+        "q3": 1.7347174250026,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7010551999992458,
+        "hd15iqr": 1.7421479000040563,
+        "ops": 0.581888251037901,
+        "total": 5.1556291000015335,
+        "data": [1.7421479000040563, 1.7124259999982314, 1.7010551999992458],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6911175999994157,
+        "max": 1.710551399999531,
+        "mean": 1.6989043333305744,
+        "stddev": 0.010275931866273982,
+        "rounds": 3,
+        "median": 1.6950439999927767,
+        "iqr": 0.014575350000086473,
+        "q1": 1.692099199997756,
+        "q3": 1.7066745499978424,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6911175999994157,
+        "hd15iqr": 1.710551399999531,
+        "ops": 0.5886146620390185,
+        "total": 5.096712999991723,
+        "data": [1.710551399999531, 1.6950439999927767, 1.6911175999994157],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6061449999979232,
+        "max": 1.6265258999919752,
+        "mean": 1.6155944333295338,
+        "stddev": 0.010270958486779962,
+        "rounds": 3,
+        "median": 1.614112399998703,
+        "iqr": 0.015285674995539011,
+        "q1": 1.6081368499981181,
+        "q3": 1.6234225249936571,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6061449999979232,
+        "hd15iqr": 1.6265258999919752,
+        "ops": 0.6189672230666998,
+        "total": 4.846783299988601,
+        "data": [1.6265258999919752, 1.614112399998703, 1.6061449999979232],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5957916999905137,
+        "max": 1.614457300005597,
+        "mean": 1.6062379666642908,
+        "stddev": 0.009529983212536158,
+        "rounds": 3,
+        "median": 1.6084648999967612,
+        "iqr": 0.013999200011312496,
+        "q1": 1.5989599999920756,
+        "q3": 1.612959200003388,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5957916999905137,
+        "hd15iqr": 1.614457300005597,
+        "ops": 0.6225727574331478,
+        "total": 4.818713899992872,
+        "data": [1.6084648999967612, 1.5957916999905137, 1.614457300005597],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6084432000061497,
+        "max": 1.6921278999943752,
+        "mean": 1.652695133331387,
+        "stddev": 0.04204997655788557,
+        "rounds": 3,
+        "median": 1.657514299993636,
+        "iqr": 0.0627635249911691,
+        "q1": 1.6207109750030213,
+        "q3": 1.6834744999941904,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6084432000061497,
+        "hd15iqr": 1.6921278999943752,
+        "ops": 0.6050722724549144,
+        "total": 4.958085399994161,
+        "data": [1.6084432000061497, 1.657514299993636, 1.6921278999943752],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6188122000021394,
+        "max": 1.6587347999884514,
+        "mean": 1.640322633330167,
+        "stddev": 0.020140827681215088,
+        "rounds": 3,
+        "median": 1.64342089999991,
+        "iqr": 0.029941949989733985,
+        "q1": 1.624964375001582,
+        "q3": 1.654906324991316,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6188122000021394,
+        "hd15iqr": 1.6587347999884514,
+        "ops": 0.6096361652767113,
+        "total": 4.920967899990501,
+        "data": [1.6188122000021394, 1.64342089999991, 1.6587347999884514],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.617661299998872,
+        "max": 1.6511169000004884,
+        "mean": 1.6321183333348017,
+        "stddev": 0.017183958700078647,
+        "rounds": 3,
+        "median": 1.6275768000050448,
+        "iqr": 0.025091700001212303,
+        "q1": 1.6201401750004152,
+        "q3": 1.6452318750016275,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.617661299998872,
+        "hd15iqr": 1.6511169000004884,
+        "ops": 0.612700672234203,
+        "total": 4.896355000004405,
+        "data": [1.617661299998872, 1.6275768000050448, 1.6511169000004884],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3948890000028769,
+        "max": 1.4434970000002068,
+        "mean": 1.4249265000010685,
+        "stddev": 0.026254589744820332,
+        "rounds": 3,
+        "median": 1.436393500000122,
+        "iqr": 0.036455999997997424,
+        "q1": 1.4052651250021881,
+        "q3": 1.4417211250001856,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3948890000028769,
+        "hd15iqr": 1.4434970000002068,
+        "ops": 0.7017905835839604,
+        "total": 4.274779500003206,
+        "data": [1.4434970000002068, 1.3948890000028769, 1.436393500000122],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.424003599997377,
+        "max": 1.4416155999933835,
+        "mean": 1.4330335666648655,
+        "stddev": 0.008814540213304045,
+        "rounds": 3,
+        "median": 1.4334815000038361,
+        "iqr": 0.013208999997004867,
+        "q1": 1.4263730749989918,
+        "q3": 1.4395820749959967,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.424003599997377,
+        "hd15iqr": 1.4416155999933835,
+        "ops": 0.697820360431141,
+        "total": 4.299100699994597,
+        "data": [1.4416155999933835, 1.424003599997377, 1.4334815000038361],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4437677999958396,
+        "max": 1.6278122999938205,
+        "mean": 1.5187284666656826,
+        "stddev": 0.09665085292934053,
+        "rounds": 3,
+        "median": 1.484605300007388,
+        "iqr": 0.13803337499848567,
+        "q1": 1.4539771749987267,
+        "q3": 1.5920105499972124,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4437677999958396,
+        "hd15iqr": 1.6278122999938205,
+        "ops": 0.6584455496481648,
+        "total": 4.556185399997048,
+        "data": [1.6278122999938205, 1.484605300007388, 1.4437677999958396],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4712709000014002,
+        "max": 1.5683499999868218,
+        "mean": 1.5135892666633783,
+        "stddev": 0.04972119547636226,
+        "rounds": 3,
+        "median": 1.5011469000019133,
+        "iqr": 0.07280932498906623,
+        "q1": 1.4787399000015284,
+        "q3": 1.5515492249905947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4712709000014002,
+        "hd15iqr": 1.5683499999868218,
+        "ops": 0.6606812178342433,
+        "total": 4.540767799990135,
+        "data": [1.5011469000019133, 1.5683499999868218, 1.4712709000014002],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5181848000065656,
+        "max": 1.5532395000045653,
+        "mean": 1.540698333332936,
+        "stddev": 0.019539551440856624,
+        "rounds": 3,
+        "median": 1.550670699987677,
+        "iqr": 0.02629102499849978,
+        "q1": 1.5263062750018435,
+        "q3": 1.5525973000003432,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5181848000065656,
+        "hd15iqr": 1.5532395000045653,
+        "ops": 0.6490563261899147,
+        "total": 4.622094999998808,
+        "data": [1.550670699987677, 1.5532395000045653, 1.5181848000065656],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6765965000085998,
+        "max": 1.7075670000049286,
+        "mean": 1.695967966671257,
+        "stddev": 0.016884934331995297,
+        "rounds": 3,
+        "median": 1.7037404000002425,
+        "iqr": 0.023227874997246545,
+        "q1": 1.6833824750065105,
+        "q3": 1.706610350003757,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6765965000085998,
+        "hd15iqr": 1.7075670000049286,
+        "ops": 0.5896337782621799,
+        "total": 5.087903900013771,
+        "data": [1.7075670000049286, 1.6765965000085998, 1.7037404000002425],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.673499399999855,
+        "max": 1.7758457999880193,
+        "mean": 1.7145566666634597,
+        "stddev": 0.0540896729429409,
+        "rounds": 3,
+        "median": 1.694324800002505,
+        "iqr": 0.07675979999112315,
+        "q1": 1.6787057500005176,
+        "q3": 1.7554655499916407,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.673499399999855,
+        "hd15iqr": 1.7758457999880193,
+        "ops": 0.5832411488306231,
+        "total": 5.143669999990379,
+        "data": [1.673499399999855, 1.694324800002505, 1.7758457999880193],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6614214000001084,
+        "max": 1.6880032000044594,
+        "mean": 1.6787102666712599,
+        "stddev": 0.014986635223643676,
+        "rounds": 3,
+        "median": 1.686706200009212,
+        "iqr": 0.019936350003263215,
+        "q1": 1.6677426000023843,
+        "q3": 1.6876789500056475,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6614214000001084,
+        "hd15iqr": 1.6880032000044594,
+        "ops": 0.5956954096569119,
+        "total": 5.03613080001378,
+        "data": [1.6614214000001084, 1.6880032000044594, 1.686706200009212],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7069511000008788,
+        "max": 1.720316399994772,
+        "mean": 1.715299333334163,
+        "stddev": 0.007278757760260208,
+        "rounds": 3,
+        "median": 1.7186305000068387,
+        "iqr": 0.010023974995419849,
+        "q1": 1.7098709500023688,
+        "q3": 1.7198949249977886,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7069511000008788,
+        "hd15iqr": 1.720316399994772,
+        "ops": 0.5829886251143238,
+        "total": 5.145898000002489,
+        "data": [1.720316399994772, 1.7186305000068387, 1.7069511000008788],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.674652600006084,
+        "max": 1.6853086999908555,
+        "mean": 1.6797084999998333,
+        "stddev": 0.005348860961610017,
+        "rounds": 3,
+        "median": 1.6791642000025604,
+        "iqr": 0.007992074988578679,
+        "q1": 1.675780500005203,
+        "q3": 1.6837725749937817,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.674652600006084,
+        "hd15iqr": 1.6853086999908555,
+        "ops": 0.5953413940574208,
+        "total": 5.0391254999995,
+        "data": [1.6791642000025604, 1.674652600006084, 1.6853086999908555],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6891825999919092,
+        "max": 1.6983945999963908,
+        "mean": 1.692638233328277,
+        "stddev": 0.005018492444798296,
+        "rounds": 3,
+        "median": 1.6903374999965308,
+        "iqr": 0.006909000003361143,
+        "q1": 1.6894713249930646,
+        "q3": 1.6963803249964258,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6891825999919092,
+        "hd15iqr": 1.6983945999963908,
+        "ops": 0.5907936972649347,
+        "total": 5.077914699984831,
+        "data": [1.6983945999963908, 1.6903374999965308, 1.6891825999919092],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3694407000002684,
+        "max": 1.3905671999964397,
+        "mean": 1.380092866665412,
+        "stddev": 0.010564372628940107,
+        "rounds": 3,
+        "median": 1.380270699999528,
+        "iqr": 0.0158448749971285,
+        "q1": 1.3721482000000833,
+        "q3": 1.3879930749972118,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3694407000002684,
+        "hd15iqr": 1.3905671999964397,
+        "ops": 0.7245889201762237,
+        "total": 4.140278599996236,
+        "data": [1.3905671999964397, 1.3694407000002684, 1.380270699999528],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3676588000089396,
+        "max": 1.3845836999971652,
+        "mean": 1.3783224333359005,
+        "stddev": 0.009281631542853146,
+        "rounds": 3,
+        "median": 1.382724800001597,
+        "iqr": 0.012693674991169246,
+        "q1": 1.371425300007104,
+        "q3": 1.3841189749982732,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3676588000089396,
+        "hd15iqr": 1.3845836999971652,
+        "ops": 0.7255196431648715,
+        "total": 4.134967300007702,
+        "data": [1.3676588000089396, 1.382724800001597, 1.3845836999971652],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3786988999927416,
+        "max": 1.4039669000048889,
+        "mean": 1.3874362666683737,
+        "stddev": 0.014323728917052017,
+        "rounds": 3,
+        "median": 1.3796430000074906,
+        "iqr": 0.01895100000911043,
+        "q1": 1.378934924996429,
+        "q3": 1.3978859250055393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3786988999927416,
+        "hd15iqr": 1.4039669000048889,
+        "ops": 0.7207538277785418,
+        "total": 4.162308800005121,
+        "data": [1.4039669000048889, 1.3796430000074906, 1.3786988999927416],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3586464999971213,
+        "max": 1.3707095999998273,
+        "mean": 1.3630165000019285,
+        "stddev": 0.0066829514880691904,
+        "rounds": 3,
+        "median": 1.3596934000088368,
+        "iqr": 0.009047325002029538,
+        "q1": 1.3589082250000502,
+        "q3": 1.3679555500020797,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3586464999971213,
+        "hd15iqr": 1.3707095999998273,
+        "ops": 0.7336668338193889,
+        "total": 4.089049500005785,
+        "data": [1.3586464999971213, 1.3707095999998273, 1.3596934000088368],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3482631000078982,
+        "max": 1.384254000004148,
+        "mean": 1.3680457000009483,
+        "stddev": 0.01825973537453647,
+        "rounds": 3,
+        "median": 1.3716199999907985,
+        "iqr": 0.026993174997187452,
+        "q1": 1.3541023250036233,
+        "q3": 1.3810955000008107,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3482631000078982,
+        "hd15iqr": 1.384254000004148,
+        "ops": 0.7309697329550517,
+        "total": 4.104137100002845,
+        "data": [1.3716199999907985, 1.3482631000078982, 1.384254000004148],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3864230000035604,
+        "max": 1.4785989999945741,
+        "mean": 1.42088503332828,
+        "stddev": 0.050295059863535274,
+        "rounds": 3,
+        "median": 1.397633099986706,
+        "iqr": 0.06913199999326025,
+        "q1": 1.3892255249993468,
+        "q3": 1.458357524992607,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3864230000035604,
+        "hd15iqr": 1.4785989999945741,
+        "ops": 0.7037867079629945,
+        "total": 4.2626550999848405,
+        "data": [1.4785989999945741, 1.3864230000035604, 1.397633099986706],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3809333999961382,
+        "max": 1.3998341999977129,
+        "mean": 1.3910483999983019,
+        "stddev": 0.009520248928487638,
+        "rounds": 3,
+        "median": 1.3923776000010548,
+        "iqr": 0.01417560000118101,
+        "q1": 1.3837944499973673,
+        "q3": 1.3979700499985483,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3809333999961382,
+        "hd15iqr": 1.3998341999977129,
+        "ops": 0.7188822473763103,
+        "total": 4.173145199994906,
+        "data": [1.3923776000010548, 1.3809333999961382, 1.3998341999977129],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4117370000021765,
+        "max": 1.416276799995103,
+        "mean": 1.4133624666671192,
+        "stddev": 0.002529491836371077,
+        "rounds": 3,
+        "median": 1.412073600004078,
+        "iqr": 0.003404849994694814,
+        "q1": 1.4118211500026518,
+        "q3": 1.4152259999973467,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4117370000021765,
+        "hd15iqr": 1.416276799995103,
+        "ops": 0.7075325852950672,
+        "total": 4.240087400001357,
+        "data": [1.412073600004078, 1.4117370000021765, 1.416276799995103],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.398462199998903,
+        "max": 1.4400595000042813,
+        "mean": 1.4184341333360255,
+        "stddev": 0.02084788294455185,
+        "rounds": 3,
+        "median": 1.4167807000048924,
+        "iqr": 0.03119797500403365,
+        "q1": 1.4030418250004004,
+        "q3": 1.434239800004434,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.398462199998903,
+        "hd15iqr": 1.4400595000042813,
+        "ops": 0.7050027748895838,
+        "total": 4.255302400008077,
+        "data": [1.4400595000042813, 1.4167807000048924, 1.398462199998903],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.417471700013266,
+        "max": 1.430602300009923,
+        "mean": 1.4228538333409233,
+        "stddev": 0.0068777041358155586,
+        "rounds": 3,
+        "median": 1.420487499999581,
+        "iqr": 0.009847949997492833,
+        "q1": 1.4182256500098447,
+        "q3": 1.4280736000073375,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.417471700013266,
+        "hd15iqr": 1.430602300009923,
+        "ops": 0.7028128796982301,
+        "total": 4.26856150002277,
+        "data": [1.430602300009923, 1.417471700013266, 1.420487499999581],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4339489999983925,
+        "max": 1.5104942000034498,
+        "mean": 1.482381499998155,
+        "stddev": 0.042124370794291204,
+        "rounds": 3,
+        "median": 1.5027012999926228,
+        "iqr": 0.05740890000379295,
+        "q1": 1.45113707499695,
+        "q3": 1.508545975000743,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4339489999983925,
+        "hd15iqr": 1.5104942000034498,
+        "ops": 0.6745901780353064,
+        "total": 4.447144499994465,
+        "data": [1.5027012999926228, 1.5104942000034498, 1.4339489999983925],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3329948999889893,
+        "max": 1.371703199998592,
+        "mean": 1.3549596333274774,
+        "stddev": 0.019875325366763653,
+        "rounds": 3,
+        "median": 1.3601807999948505,
+        "iqr": 0.02903122500720201,
+        "q1": 1.3397913749904546,
+        "q3": 1.3688225999976567,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3329948999889893,
+        "hd15iqr": 1.371703199998592,
+        "ops": 0.7380293666345056,
+        "total": 4.064878899982432,
+        "data": [1.371703199998592, 1.3601807999948505, 1.3329948999889893],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4042788999940967,
+        "max": 1.4196162000007462,
+        "mean": 1.409696499996547,
+        "stddev": 0.00860289899933757,
+        "rounds": 3,
+        "median": 1.405194399994798,
+        "iqr": 0.011502975004987093,
+        "q1": 1.404507774994272,
+        "q3": 1.4160107499992591,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4042788999940967,
+        "hd15iqr": 1.4196162000007462,
+        "ops": 0.7093725493412586,
+        "total": 4.229089499989641,
+        "data": [1.405194399994798, 1.4196162000007462, 1.4042788999940967],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3923032000020612,
+        "max": 1.4296406999928877,
+        "mean": 1.4097289666630484,
+        "stddev": 0.018792478524671117,
+        "rounds": 3,
+        "median": 1.407242999994196,
+        "iqr": 0.028003124993119854,
+        "q1": 1.396038150000095,
+        "q3": 1.4240412749932148,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3923032000020612,
+        "hd15iqr": 1.4296406999928877,
+        "ops": 0.7093562121853021,
+        "total": 4.229186899989145,
+        "data": [1.4296406999928877, 1.407242999994196, 1.3923032000020612],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4551084999984596,
+        "max": 1.4709895999985747,
+        "mean": 1.4606116333355506,
+        "stddev": 0.008993071459192049,
+        "rounds": 3,
+        "median": 1.4557368000096176,
+        "iqr": 0.011910825000086334,
+        "q1": 1.455265575001249,
+        "q3": 1.4671764000013354,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4551084999984596,
+        "hd15iqr": 1.4709895999985747,
+        "ops": 0.6846446907425576,
+        "total": 4.381834900006652,
+        "data": [1.4709895999985747, 1.4557368000096176, 1.4551084999984596],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2235012000019196,
+        "max": 1.2936846000084188,
+        "mean": 1.268194266667706,
+        "stddev": 0.03883279714987683,
+        "rounds": 3,
+        "median": 1.2873969999927795,
+        "iqr": 0.052637550004874356,
+        "q1": 1.2394751499996346,
+        "q3": 1.292112700004509,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2235012000019196,
+        "hd15iqr": 1.2936846000084188,
+        "ops": 0.7885227258025614,
+        "total": 3.804582800003118,
+        "data": [1.2235012000019196, 1.2873969999927795, 1.2936846000084188],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2520285000064177,
+        "max": 1.2622408000024734,
+        "mean": 1.258630733335546,
+        "stddev": 0.005726042595296373,
+        "rounds": 3,
+        "median": 1.2616228999977466,
+        "iqr": 0.007659224997041747,
+        "q1": 1.25442710000425,
+        "q3": 1.2620863250012917,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2520285000064177,
+        "hd15iqr": 1.2622408000024734,
+        "ops": 0.794514207792989,
+        "total": 3.7758922000066377,
+        "data": [1.2622408000024734, 1.2616228999977466, 1.2520285000064177],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2438971000083257,
+        "max": 1.24966349999886,
+        "mean": 1.247543633338258,
+        "stddev": 0.003171888325925386,
+        "rounds": 3,
+        "median": 1.2490703000075882,
+        "iqr": 0.004324799992900807,
+        "q1": 1.2451904000081413,
+        "q3": 1.249515200001042,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2438971000083257,
+        "hd15iqr": 1.24966349999886,
+        "ops": 0.8015751700196131,
+        "total": 3.742630900014774,
+        "data": [1.2490703000075882, 1.24966349999886, 1.2438971000083257],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2547876000026008,
+        "max": 1.2743640999979107,
+        "mean": 1.2616238666669233,
+        "stddev": 0.011043208538165422,
+        "rounds": 3,
+        "median": 1.2557199000002583,
+        "iqr": 0.014682374996482395,
+        "q1": 1.2550206750020152,
+        "q3": 1.2697030499984976,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2547876000026008,
+        "hd15iqr": 1.2743640999979107,
+        "ops": 0.7926292664721809,
+        "total": 3.78487160000077,
+        "data": [1.2743640999979107, 1.2547876000026008, 1.2557199000002583],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2626613000029465,
+        "max": 1.3521946000109892,
+        "mean": 1.2949445000025055,
+        "stddev": 0.049714811923855004,
+        "rounds": 3,
+        "median": 1.269977599993581,
+        "iqr": 0.06714997500603204,
+        "q1": 1.2644903750006051,
+        "q3": 1.3316403500066372,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2626613000029465,
+        "hd15iqr": 1.3521946000109892,
+        "ops": 0.7722338679364753,
+        "total": 3.8848335000075167,
+        "data": [1.3521946000109892, 1.269977599993581, 1.2626613000029465],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.253133500009426,
+        "max": 1.2737936999910744,
+        "mean": 1.261326433334034,
+        "stddev": 0.010973304420181924,
+        "rounds": 3,
+        "median": 1.2570521000016015,
+        "iqr": 0.015495149986236356,
+        "q1": 1.2541131500074698,
+        "q3": 1.2696082999937062,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.253133500009426,
+        "hd15iqr": 1.2737936999910744,
+        "ops": 0.7928161763459789,
+        "total": 3.783979300002102,
+        "data": [1.2570521000016015, 1.2737936999910744, 1.253133500009426],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2748656000039773,
+        "max": 1.3656238999974448,
+        "mean": 1.3058840999971533,
+        "stddev": 0.05174893293585986,
+        "rounds": 3,
+        "median": 1.2771627999900375,
+        "iqr": 0.06806872499510064,
+        "q1": 1.2754399000004923,
+        "q3": 1.343508624995593,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2748656000039773,
+        "hd15iqr": 1.3656238999974448,
+        "ops": 0.7657647412983893,
+        "total": 3.9176522999914596,
+        "data": [1.3656238999974448, 1.2748656000039773, 1.2771627999900375],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.266056499996921,
+        "max": 1.3184760000003735,
+        "mean": 1.2846000999998068,
+        "stddev": 0.029381296134907822,
+        "rounds": 3,
+        "median": 1.269267800002126,
+        "iqr": 0.03931462500258931,
+        "q1": 1.2668593249982223,
+        "q3": 1.3061739500008116,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.266056499996921,
+        "hd15iqr": 1.3184760000003735,
+        "ops": 0.7784523759574286,
+        "total": 3.8538002999994205,
+        "data": [1.3184760000003735, 1.269267800002126, 1.266056499996921],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2741070999909425,
+        "max": 1.295543500003987,
+        "mean": 1.2813134999984566,
+        "stddev": 0.012323880439168365,
+        "rounds": 3,
+        "median": 1.27428990000044,
+        "iqr": 0.016077300009783357,
+        "q1": 1.2741527999933169,
+        "q3": 1.2902301000031002,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2741070999909425,
+        "hd15iqr": 1.295543500003987,
+        "ops": 0.7804491250589373,
+        "total": 3.8439404999953695,
+        "data": [1.295543500003987, 1.2741070999909425, 1.27428990000044],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2729378000076395,
+        "max": 1.2792155999923125,
+        "mean": 1.2758649666648125,
+        "stddev": 0.0031602509674942755,
+        "rounds": 3,
+        "median": 1.2754414999944856,
+        "iqr": 0.004708349988504779,
+        "q1": 1.273563725004351,
+        "q3": 1.2782720749928558,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2729378000076395,
+        "hd15iqr": 1.2792155999923125,
+        "ops": 0.7837820036818316,
+        "total": 3.8275948999944376,
+        "data": [1.2792155999923125, 1.2729378000076395, 1.2754414999944856],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3004415000032168,
+        "max": 1.309114599993336,
+        "mean": 1.3058697666662435,
+        "stddev": 0.004730877477699344,
+        "rounds": 3,
+        "median": 1.3080532000021776,
+        "iqr": 0.00650482499258942,
+        "q1": 1.302344425002957,
+        "q3": 1.3088492499955464,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3004415000032168,
+        "hd15iqr": 1.309114599993336,
+        "ops": 0.7657731463933813,
+        "total": 3.9176092999987304,
+        "data": [1.309114599993336, 1.3004415000032168, 1.3080532000021776],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.246036800002912,
+        "max": 1.4300753999996232,
+        "mean": 1.3143712333355022,
+        "stddev": 0.10074954242631888,
+        "rounds": 3,
+        "median": 1.2670015000039712,
+        "iqr": 0.13802894999753335,
+        "q1": 1.2512779750031768,
+        "q3": 1.3893069250007102,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.246036800002912,
+        "hd15iqr": 1.4300753999996232,
+        "ops": 0.760820059536972,
+        "total": 3.9431137000065064,
+        "data": [1.2670015000039712, 1.246036800002912, 1.4300753999996232],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2582078999985242,
+        "max": 1.278046399995219,
+        "mean": 1.270720033334025,
+        "stddev": 0.010888556035121259,
+        "rounds": 3,
+        "median": 1.2759058000083314,
+        "iqr": 0.014878874997521052,
+        "q1": 1.262632375000976,
+        "q3": 1.277511249998497,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2582078999985242,
+        "hd15iqr": 1.278046399995219,
+        "ops": 0.786955406200901,
+        "total": 3.8121601000020746,
+        "data": [1.2582078999985242, 1.278046399995219, 1.2759058000083314],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2847962000087136,
+        "max": 1.3264307999925222,
+        "mean": 1.2992463333309086,
+        "stddev": 0.02355806471577229,
+        "rounds": 3,
+        "median": 1.2865119999914896,
+        "iqr": 0.03122594998785644,
+        "q1": 1.2852251500044076,
+        "q3": 1.316451099992264,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2847962000087136,
+        "hd15iqr": 1.3264307999925222,
+        "ops": 0.7696769845301594,
+        "total": 3.8977389999927254,
+        "data": [1.2847962000087136, 1.3264307999925222, 1.2865119999914896],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3035285000078147,
+        "max": 1.3161342999956105,
+        "mean": 1.3087709333340172,
+        "stddev": 0.006565083167253642,
+        "rounds": 3,
+        "median": 1.3066499999986263,
+        "iqr": 0.009454349990846822,
+        "q1": 1.3043088750055176,
+        "q3": 1.3137632249963644,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3035285000078147,
+        "hd15iqr": 1.3161342999956105,
+        "ops": 0.7640756487864219,
+        "total": 3.9263128000020515,
+        "data": [1.3035285000078147, 1.3066499999986263, 1.3161342999956105],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3055001000029733,
+        "max": 1.3127517999964766,
+        "mean": 1.3101620000040082,
+        "stddev": 0.004045613307407053,
+        "rounds": 3,
+        "median": 1.3122341000125743,
+        "iqr": 0.00543877499512746,
+        "q1": 1.3071836000053736,
+        "q3": 1.312622375000501,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3055001000029733,
+        "hd15iqr": 1.3127517999964766,
+        "ops": 0.7632643902028458,
+        "total": 3.9304860000120243,
+        "data": [1.3127517999964766, 1.3122341000125743, 1.3055001000029733],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3077343000040855,
+        "max": 1.3275322999979835,
+        "mean": 1.3198343999974895,
+        "stddev": 0.010607767178948586,
+        "rounds": 3,
+        "median": 1.3242365999903996,
+        "iqr": 0.014848499995423481,
+        "q1": 1.311859875000664,
+        "q3": 1.3267083749960875,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3077343000040855,
+        "hd15iqr": 1.3275322999979835,
+        "ops": 0.7576708108243747,
+        "total": 3.9595031999924686,
+        "data": [1.3242365999903996, 1.3077343000040855, 1.3275322999979835],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3182224000047427,
+        "max": 1.389952199999243,
+        "mean": 1.3447899000020698,
+        "stddev": 0.03931432298906423,
+        "rounds": 3,
+        "median": 1.3261951000022236,
+        "iqr": 0.053797349995875265,
+        "q1": 1.320215575004113,
+        "q3": 1.3740129249999882,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3182224000047427,
+        "hd15iqr": 1.389952199999243,
+        "ops": 0.743610581845135,
+        "total": 4.034369700006209,
+        "data": [1.3182224000047427, 1.389952199999243, 1.3261951000022236],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.305723700003,
+        "max": 1.3575855999952182,
+        "mean": 1.3268588333351847,
+        "stddev": 0.02722891367870987,
+        "rounds": 3,
+        "median": 1.3172672000073362,
+        "iqr": 0.03889642499416368,
+        "q1": 1.308609575004084,
+        "q3": 1.3475059999982477,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.305723700003,
+        "hd15iqr": 1.3575855999952182,
+        "ops": 0.7536596771838988,
+        "total": 3.9805765000055544,
+        "data": [1.305723700003, 1.3575855999952182, 1.3172672000073362],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3283903999981703,
+        "max": 1.3784682999976212,
+        "mean": 1.3460164999996778,
+        "stddev": 0.02813894191999751,
+        "rounds": 3,
+        "median": 1.3311908000032417,
+        "iqr": 0.03755842499958817,
+        "q1": 1.3290904999994382,
+        "q3": 1.3666489249990263,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3283903999981703,
+        "hd15iqr": 1.3784682999976212,
+        "ops": 0.7429329432441871,
+        "total": 4.038049499999033,
+        "data": [1.3283903999981703, 1.3311908000032417, 1.3784682999976212],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3435482000058983,
+        "max": 1.3560482999891974,
+        "mean": 1.3498073333321372,
+        "stddev": 0.006250069793131965,
+        "rounds": 3,
+        "median": 1.349825500001316,
+        "iqr": 0.009375074987474363,
+        "q1": 1.3451175250047527,
+        "q3": 1.354492599992227,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3435482000058983,
+        "hd15iqr": 1.3560482999891974,
+        "ops": 0.7408464714229978,
+        "total": 4.049421999996412,
+        "data": [1.3435482000058983, 1.3560482999891974, 1.349825500001316],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0900908000039635,
+        "max": 1.1229228000011062,
+        "mean": 1.1053893666685326,
+        "stddev": 0.016529701380270392,
+        "rounds": 3,
+        "median": 1.103154500000528,
+        "iqr": 0.024623999997857027,
+        "q1": 1.0933567250031047,
+        "q3": 1.1179807250009617,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0900908000039635,
+        "hd15iqr": 1.1229228000011062,
+        "ops": 0.9046586027997,
+        "total": 3.316168100005598,
+        "data": [1.0900908000039635, 1.103154500000528, 1.1229228000011062],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1271074999967823,
+        "max": 1.148129200009862,
+        "mean": 1.1371047333377646,
+        "stddev": 0.010548429935179631,
+        "rounds": 3,
+        "median": 1.1360775000066496,
+        "iqr": 0.01576627500980976,
+        "q1": 1.1293499999992491,
+        "q3": 1.1451162750090589,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1271074999967823,
+        "hd15iqr": 1.148129200009862,
+        "ops": 0.8794264685405727,
+        "total": 3.411314200013294,
+        "data": [1.1271074999967823, 1.148129200009862, 1.1360775000066496],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5906094999954803,
+        "max": 0.6026855999953113,
+        "mean": 0.5949427666637348,
+        "stddev": 0.00672137682511609,
+        "rounds": 3,
+        "median": 0.5915332000004128,
+        "iqr": 0.009057074999873294,
+        "q1": 0.5908404249967134,
+        "q3": 0.5998974999965867,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5906094999954803,
+        "hd15iqr": 0.6026855999953113,
+        "ops": 1.6808339491338096,
+        "total": 1.7848282999912044,
+        "data": [0.5906094999954803, 0.5915332000004128, 0.6026855999953113],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5353054000006523,
+        "max": 0.541673500003526,
+        "mean": 0.5393863000014486,
+        "stddev": 0.0035427664579680334,
+        "rounds": 3,
+        "median": 0.5411800000001676,
+        "iqr": 0.004776075002155267,
+        "q1": 0.5367740500005311,
+        "q3": 0.5415501250026864,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5353054000006523,
+        "hd15iqr": 0.541673500003526,
+        "ops": 1.8539588417379422,
+        "total": 1.618158900004346,
+        "data": [0.5411800000001676, 0.5353054000006523, 0.541673500003526],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0158276999864029,
+        "max": 1.029041400004644,
+        "mean": 1.0214413666641728,
+        "stddev": 0.006827130175412967,
+        "rounds": 3,
+        "median": 1.0194550000014715,
+        "iqr": 0.009910275013680803,
+        "q1": 1.01673452499017,
+        "q3": 1.0266448000038508,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0158276999864029,
+        "hd15iqr": 1.029041400004644,
+        "ops": 0.9790087151706064,
+        "total": 3.0643240999925183,
+        "data": [1.0194550000014715, 1.0158276999864029, 1.029041400004644],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1811914999998407,
+        "max": 1.204586100007873,
+        "mean": 1.192621366668997,
+        "stddev": 0.011706467834053911,
+        "rounds": 3,
+        "median": 1.1920864999992773,
+        "iqr": 0.017545950006024214,
+        "q1": 1.1839152499996999,
+        "q3": 1.201461200005724,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1811914999998407,
+        "hd15iqr": 1.204586100007873,
+        "ops": 0.8384890862663392,
+        "total": 3.577864100006991,
+        "data": [1.1920864999992773, 1.204586100007873, 1.1811914999998407],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6289393000042764,
+        "max": 0.6401224000001093,
+        "mean": 0.6335799333319301,
+        "stddev": 0.005829078736863189,
+        "rounds": 3,
+        "median": 0.6316780999914045,
+        "iqr": 0.008387324996874668,
+        "q1": 0.6296240000010584,
+        "q3": 0.6380113249979331,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6289393000042764,
+        "hd15iqr": 0.6401224000001093,
+        "ops": 1.5783328154682952,
+        "total": 1.9007397999957902,
+        "data": [0.6401224000001093, 0.6289393000042764, 0.6316780999914045],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5816875999880722,
+        "max": 0.5917915000027278,
+        "mean": 0.5871601666634282,
+        "stddev": 0.005104209441314978,
+        "rounds": 3,
+        "median": 0.5880013999994844,
+        "iqr": 0.007577925010991748,
+        "q1": 0.5832660499909252,
+        "q3": 0.590843975001917,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5816875999880722,
+        "hd15iqr": 0.5917915000027278,
+        "ops": 1.703112807673174,
+        "total": 1.7614804999902844,
+        "data": [0.5816875999880722, 0.5880013999994844, 0.5917915000027278],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5386214999889489,
+        "max": 0.542992900009267,
+        "mean": 0.5401878333359491,
+        "stddev": 0.002434775087088528,
+        "rounds": 3,
+        "median": 0.5389491000096314,
+        "iqr": 0.0032785500152385794,
+        "q1": 0.5387033999941195,
+        "q3": 0.5419819500093581,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5386214999889489,
+        "hd15iqr": 0.542992900009267,
+        "ops": 1.8512079285911802,
+        "total": 1.6205635000078473,
+        "data": [0.5389491000096314, 0.542992900009267, 0.5386214999889489],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1198636000044644,
+        "max": 1.149579899996752,
+        "mean": 1.1350890333317996,
+        "stddev": 0.014871762250789929,
+        "rounds": 3,
+        "median": 1.1358235999941826,
+        "iqr": 0.02228722499421565,
+        "q1": 1.123853600001894,
+        "q3": 1.1461408249961096,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1198636000044644,
+        "hd15iqr": 1.149579899996752,
+        "ops": 0.8809881609592545,
+        "total": 3.405267099995399,
+        "data": [1.1358235999941826, 1.149579899996752, 1.1198636000044644],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3920397000038065,
+        "max": 1.474917400002596,
+        "mean": 1.4243678666680353,
+        "stddev": 0.04434176295292452,
+        "rounds": 3,
+        "median": 1.4061464999977034,
+        "iqr": 0.0621582749990921,
+        "q1": 1.3955664000022807,
+        "q3": 1.4577246750013728,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3920397000038065,
+        "hd15iqr": 1.474917400002596,
+        "ops": 0.7020658240060264,
+        "total": 4.273103600004106,
+        "data": [1.3920397000038065, 1.4061464999977034, 1.474917400002596],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6910340999893378,
+        "max": 0.7051451000006637,
+        "mean": 0.6964174666597197,
+        "stddev": 0.00762680601580919,
+        "rounds": 3,
+        "median": 0.6930731999891577,
+        "iqr": 0.01058325000849436,
+        "q1": 0.6915438749892928,
+        "q3": 0.7021271249977872,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6910340999893378,
+        "hd15iqr": 0.7051451000006637,
+        "ops": 1.4359203320910032,
+        "total": 2.0892523999791592,
+        "data": [0.6910340999893378, 0.6930731999891577, 0.7051451000006637],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0115604999882635,
+        "max": 1.0240535000048112,
+        "mean": 1.0190031333283212,
+        "stddev": 0.006581106836663392,
+        "rounds": 3,
+        "median": 1.0213953999918886,
+        "iqr": 0.009369750012410805,
+        "q1": 1.0140192249891697,
+        "q3": 1.0233889750015805,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0115604999882635,
+        "hd15iqr": 1.0240535000048112,
+        "ops": 0.9813512513290787,
+        "total": 3.0570093999849632,
+        "data": [1.0115604999882635, 1.0240535000048112, 1.0213953999918886],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3697755999892252,
+        "max": 1.3999195000069449,
+        "mean": 1.3815223999990849,
+        "stddev": 0.016134854961143048,
+        "rounds": 3,
+        "median": 1.3748721000010846,
+        "iqr": 0.022607925013289787,
+        "q1": 1.37104972499219,
+        "q3": 1.3936576500054798,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3697755999892252,
+        "hd15iqr": 1.3999195000069449,
+        "ops": 0.7238391502017357,
+        "total": 4.144567199997255,
+        "data": [1.3999195000069449, 1.3748721000010846, 1.3697755999892252],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5994544999994105,
+        "max": 0.6116015000006882,
+        "mean": 0.6058393666656533,
+        "stddev": 0.0060973969740462566,
+        "rounds": 3,
+        "median": 0.6064620999968611,
+        "iqr": 0.009110250000958331,
+        "q1": 0.6012063999987731,
+        "q3": 0.6103166499997315,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5994544999994105,
+        "hd15iqr": 0.6116015000006882,
+        "ops": 1.6506025442085106,
+        "total": 1.8175180999969598,
+        "data": [0.5994544999994105, 0.6116015000006882, 0.6064620999968611],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5414839000004577,
+        "max": 0.5488410999969346,
+        "mean": 0.5448772333329543,
+        "stddev": 0.003711634297555539,
+        "rounds": 3,
+        "median": 0.5443067000014707,
+        "iqr": 0.005517899997357745,
+        "q1": 0.5421896000007109,
+        "q3": 0.5477074999980687,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5414839000004577,
+        "hd15iqr": 0.5488410999969346,
+        "ops": 1.835275799436709,
+        "total": 1.634631699998863,
+        "data": [0.5443067000014707, 0.5488410999969346, 0.5414839000004577],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3595784999924945,
+        "max": 1.3914702000038233,
+        "mean": 1.3792340666647458,
+        "stddev": 0.01719174585788785,
+        "rounds": 3,
+        "median": 1.3866534999979194,
+        "iqr": 0.023918775008496596,
+        "q1": 1.3663472499938507,
+        "q3": 1.3902660250023473,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3595784999924945,
+        "hd15iqr": 1.3914702000038233,
+        "ops": 0.7250400959267147,
+        "total": 4.137702199994237,
+        "data": [1.3595784999924945, 1.3914702000038233, 1.3866534999979194],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7589792000071611,
+        "max": 1.8898740000004182,
+        "mean": 1.81967256666879,
+        "stddev": 0.0659633585043208,
+        "rounds": 3,
+        "median": 1.8101644999987911,
+        "iqr": 0.09817109999494278,
+        "q1": 1.7717755250050686,
+        "q3": 1.8699466250000114,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7589792000071611,
+        "hd15iqr": 1.8898740000004182,
+        "ops": 0.5495494180201136,
+        "total": 5.45901770000637,
+        "data": [1.7589792000071611, 1.8101644999987911, 1.8898740000004182],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1322165000019595,
+        "max": 1.1711920000088867,
+        "mean": 1.1484223333391128,
+        "stddev": 0.020299885004878986,
+        "rounds": 3,
+        "median": 1.1418585000064922,
+        "iqr": 0.029231625005195383,
+        "q1": 1.1346270000030927,
+        "q3": 1.163858625008288,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1322165000019595,
+        "hd15iqr": 1.1711920000088867,
+        "ops": 0.8707597988733246,
+        "total": 3.4452670000173384,
+        "data": [1.1322165000019595, 1.1711920000088867, 1.1418585000064922],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6197625000058906,
+        "max": 0.6560732000070857,
+        "mean": 0.6379292333391883,
+        "stddev": 0.018155360706551302,
+        "rounds": 3,
+        "median": 0.6379520000045886,
+        "iqr": 0.027233025000896305,
+        "q1": 0.6243098750055651,
+        "q3": 0.6515429000064614,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6197625000058906,
+        "hd15iqr": 0.6560732000070857,
+        "ops": 1.5675719934726646,
+        "total": 1.913787700017565,
+        "data": [0.6560732000070857, 0.6197625000058906, 0.6379520000045886],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5625440000003437,
+        "max": 0.5808952999941539,
+        "mean": 0.5692495666638328,
+        "stddev": 0.010124054913312374,
+        "rounds": 3,
+        "median": 0.5643093999970006,
+        "iqr": 0.013763474995357683,
+        "q1": 0.5629853499995079,
+        "q3": 0.5767488249948656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5625440000003437,
+        "hd15iqr": 0.5808952999941539,
+        "ops": 1.7566987461415928,
+        "total": 1.7077486999914981,
+        "data": [0.5625440000003437, 0.5643093999970006, 0.5808952999941539],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7114300000102958,
+        "max": 1.7474335999868345,
+        "mean": 1.7308072000014363,
+        "stddev": 0.018158743853068364,
+        "rounds": 3,
+        "median": 1.7335580000071786,
+        "iqr": 0.02700269998240401,
+        "q1": 1.7169620000095165,
+        "q3": 1.7439646999919205,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7114300000102958,
+        "hd15iqr": 1.7474335999868345,
+        "ops": 0.5777651028948633,
+        "total": 5.192421600004309,
+        "data": [1.7114300000102958, 1.7335580000071786, 1.7474335999868345],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7729423000128008,
+        "max": 1.8072484999865992,
+        "mean": 1.7896814666649636,
+        "stddev": 0.01716807681650389,
+        "rounds": 3,
+        "median": 1.788853599995491,
+        "iqr": 0.025729649980348768,
+        "q1": 1.7769201250084734,
+        "q3": 1.8026497749888222,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7729423000128008,
+        "hd15iqr": 1.8072484999865992,
+        "ops": 0.5587586498638109,
+        "total": 5.369044399994891,
+        "data": [1.8072484999865992, 1.788853599995491, 1.7729423000128008],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5405229000025429,
+        "max": 1.6955788000050234,
+        "mean": 1.60000393333515,
+        "stddev": 0.08359220439208775,
+        "rounds": 3,
+        "median": 1.5639100999978837,
+        "iqr": 0.11629192500186036,
+        "q1": 1.546369700001378,
+        "q3": 1.6626616250032384,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5405229000025429,
+        "hd15iqr": 1.6955788000050234,
+        "ops": 0.6249984635447342,
+        "total": 4.80001180000545,
+        "data": [1.5639100999978837, 1.6955788000050234, 1.5405229000025429],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6272787999914726,
+        "max": 0.6405955999944126,
+        "mean": 0.6343454666639445,
+        "stddev": 0.006695844651985934,
+        "rounds": 3,
+        "median": 0.6351620000059484,
+        "iqr": 0.009987600002205,
+        "q1": 0.6292495999950916,
+        "q3": 0.6392371999972966,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6272787999914726,
+        "hd15iqr": 0.6405955999944126,
+        "ops": 1.576428070431482,
+        "total": 1.9030363999918336,
+        "data": [0.6405955999944126, 0.6351620000059484, 0.6272787999914726],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.554074200001196,
+        "max": 0.5922721999959322,
+        "mean": 0.5699425333295949,
+        "stddev": 0.01990184469533997,
+        "rounds": 3,
+        "median": 0.5634811999916565,
+        "iqr": 0.028648499996052124,
+        "q1": 0.5564259499988111,
+        "q3": 0.5850744499948632,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.554074200001196,
+        "hd15iqr": 0.5922721999959322,
+        "ops": 1.7545628576937686,
+        "total": 1.7098275999887846,
+        "data": [0.554074200001196, 0.5634811999916565, 0.5922721999959322],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.0165039999992587,
+        "max": 2.0711919000023045,
+        "mean": 2.0390010666645444,
+        "stddev": 0.02860364375234507,
+        "rounds": 3,
+        "median": 2.0293072999920696,
+        "iqr": 0.04101592500228435,
+        "q1": 2.0197048249974614,
+        "q3": 2.0607207499997457,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.0165039999992587,
+        "hd15iqr": 2.0711919000023045,
+        "ops": 0.4904362319122414,
+        "total": 6.117003199993633,
+        "data": [2.0711919000023045, 2.0293072999920696, 2.0165039999992587],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.246251199991093,
+        "max": 2.2895583999925293,
+        "mean": 2.2731204999921224,
+        "stddev": 0.023462501411205844,
+        "rounds": 3,
+        "median": 2.2835518999927444,
+        "iqr": 0.032480400001077214,
+        "q1": 2.255576374991506,
+        "q3": 2.288056774992583,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.246251199991093,
+        "hd15iqr": 2.2895583999925293,
+        "ops": 0.439923884371051,
+        "total": 6.819361499976367,
+        "data": [2.2895583999925293, 2.246251199991093, 2.2835518999927444],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.0469435999984853,
+        "max": 2.165356299999985,
+        "mean": 2.1016837999971663,
+        "stddev": 0.059709558430239874,
+        "rounds": 3,
+        "median": 2.092751499993028,
+        "iqr": 0.08880952500112471,
+        "q1": 2.058395574997121,
+        "q3": 2.1472050999982457,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.0469435999984853,
+        "hd15iqr": 2.165356299999985,
+        "ops": 0.4758089680290386,
+        "total": 6.305051399991498,
+        "data": [2.092751499993028, 2.165356299999985, 2.0469435999984853],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6717102999973577,
+        "max": 0.6980448000103934,
+        "mean": 0.6838769333359475,
+        "stddev": 0.013280819774492489,
+        "rounds": 3,
+        "median": 0.6818757000000915,
+        "iqr": 0.01975087500977679,
+        "q1": 0.6742516499980411,
+        "q3": 0.6940025250078179,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6717102999973577,
+        "hd15iqr": 0.6980448000103934,
+        "ops": 1.4622513953234335,
+        "total": 2.0516308000078425,
+        "data": [0.6980448000103934, 0.6818757000000915, 0.6717102999973577],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5995322999951895,
+        "max": 0.6031669999938458,
+        "mean": 0.6016483999943981,
+        "stddev": 0.0018895808284759255,
+        "rounds": 3,
+        "median": 0.6022458999941591,
+        "iqr": 0.002726024998992216,
+        "q1": 0.6002106999949319,
+        "q3": 0.6029367249939241,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5995322999951895,
+        "hd15iqr": 0.6031669999938458,
+        "ops": 1.6621003230612943,
+        "total": 1.8049451999831945,
+        "data": [0.5995322999951895, 0.6022458999941591, 0.6031669999938458],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4699976999982027,
+        "max": 2.487558799999533,
+        "mean": 2.476406633334894,
+        "stddev": 0.009693902986759201,
+        "rounds": 3,
+        "median": 2.471663400006946,
+        "iqr": 0.013170825000997866,
+        "q1": 2.4704141250003886,
+        "q3": 2.4835849500013865,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4699976999982027,
+        "hd15iqr": 2.487558799999533,
+        "ops": 0.40381090348370346,
+        "total": 7.429219900004682,
+        "data": [2.4699976999982027, 2.487558799999533, 2.471663400006946],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.3750051999959396,
+        "max": 3.4427040000009583,
+        "mean": 3.3978290666661146,
+        "stddev": 0.03886475313593434,
+        "rounds": 3,
+        "median": 3.3757780000014463,
+        "iqr": 0.05077410000376403,
+        "q1": 3.3751983999973163,
+        "q3": 3.4259725000010803,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.3750051999959396,
+        "hd15iqr": 3.4427040000009583,
+        "ops": 0.29430556404686387,
+        "total": 10.193487199998344,
+        "data": [3.3757780000014463, 3.3750051999959396, 3.4427040000009583],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.743095400001039,
+        "max": 2.7752183999982662,
+        "mean": 2.753872533333682,
+        "stddev": 0.01848635646596525,
+        "rounds": 3,
+        "median": 2.7433038000017405,
+        "iqr": 0.02409224999792059,
+        "q1": 2.743147500001214,
+        "q3": 2.767239749999135,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.743095400001039,
+        "hd15iqr": 2.7752183999982662,
+        "ops": 0.3631250131934962,
+        "total": 8.261617600001046,
+        "data": [2.7433038000017405, 2.743095400001039, 2.7752183999982662],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6700138000014704,
+        "max": 0.6863703999988502,
+        "mean": 0.6805811666660398,
+        "stddev": 0.009165561055965022,
+        "rounds": 3,
+        "median": 0.6853592999977991,
+        "iqr": 0.012267449998034863,
+        "q1": 0.6738501750005526,
+        "q3": 0.6861176249985874,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6700138000014704,
+        "hd15iqr": 0.6863703999988502,
+        "ops": 1.4693324602246869,
+        "total": 2.0417434999981197,
+        "data": [0.6700138000014704, 0.6853592999977991, 0.6863703999988502],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5954196000093361,
+        "max": 0.6035816999938106,
+        "mean": 0.6006486999976914,
+        "stddev": 0.004539716447081207,
+        "rounds": 3,
+        "median": 0.6029447999899276,
+        "iqr": 0.00612157498835586,
+        "q1": 0.597300900004484,
+        "q3": 0.6034224749928399,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5954196000093361,
+        "hd15iqr": 0.6035816999938106,
+        "ops": 1.664866668326833,
+        "total": 1.8019460999930743,
+        "data": [0.6035816999938106, 0.5954196000093361, 0.6029447999899276],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.3306023000041023,
+        "max": 3.4739622000051895,
+        "mean": 3.384067066668649,
+        "stddev": 0.07831598779286607,
+        "rounds": 3,
+        "median": 3.347636699996656,
+        "iqr": 0.10751992500081542,
+        "q1": 3.3348609000022407,
+        "q3": 3.442380825003056,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.3306023000041023,
+        "hd15iqr": 3.4739622000051895,
+        "ops": 0.29550241774150837,
+        "total": 10.152201200005948,
+        "data": [3.3306023000041023, 3.347636699996656, 3.4739622000051895],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.691711099992972,
+        "max": 4.707823000004282,
+        "mean": 4.701948333332742,
+        "stddev": 0.008897882975442972,
+        "rounds": 3,
+        "median": 4.706310900000972,
+        "iqr": 0.012083925008482765,
+        "q1": 4.695361049994972,
+        "q3": 4.707444975003455,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.691711099992972,
+        "hd15iqr": 4.707823000004282,
+        "ops": 0.2126777942051949,
+        "total": 14.105844999998226,
+        "data": [4.707823000004282, 4.706310900000972, 4.691711099992972],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.963197000004584,
+        "max": 4.02674419998948,
+        "mean": 4.003704733331688,
+        "stddev": 0.035191148202392136,
+        "rounds": 3,
+        "median": 4.021173000000999,
+        "iqr": 0.047660399988672,
+        "q1": 3.977691000003688,
+        "q3": 4.02535139999236,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.963197000004584,
+        "hd15iqr": 4.02674419998948,
+        "ops": 0.24976866842222123,
+        "total": 12.011114199995063,
+        "data": [3.963197000004584, 4.021173000000999, 4.02674419998948],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.680576500002644,
+        "max": 0.6897409999946831,
+        "mean": 0.686042600000898,
+        "stddev": 0.004831209735187522,
+        "rounds": 3,
+        "median": 0.687810300005367,
+        "iqr": 0.006873374994029291,
+        "q1": 0.6823849500033248,
+        "q3": 0.6892583249973541,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.680576500002644,
+        "hd15iqr": 0.6897409999946831,
+        "ops": 1.4576354296346772,
+        "total": 2.058127800002694,
+        "data": [0.6897409999946831, 0.680576500002644, 0.687810300005367],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6041661000053864,
+        "max": 0.6077204000030179,
+        "mean": 0.6057446000001315,
+        "stddev": 0.0018101512618127948,
+        "rounds": 3,
+        "median": 0.6053472999919904,
+        "iqr": 0.0026657249982235953,
+        "q1": 0.6044614000020374,
+        "q3": 0.607127125000261,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6041661000053864,
+        "hd15iqr": 0.6077204000030179,
+        "ops": 1.6508607753164994,
+        "total": 1.8172338000003947,
+        "data": [0.6053472999919904, 0.6041661000053864, 0.6077204000030179],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.732438999999431,
+        "max": 4.778338800009806,
+        "mean": 4.754554466669409,
+        "stddev": 0.02299536360270969,
+        "rounds": 3,
+        "median": 4.75288559999899,
+        "iqr": 0.03442485000778106,
+        "q1": 4.737550649999321,
+        "q3": 4.771975500007102,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.732438999999431,
+        "hd15iqr": 4.778338800009806,
+        "ops": 0.21032464913594845,
+        "total": 14.263663400008227,
+        "data": [4.75288559999899, 4.778338800009806, 4.732438999999431],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 12.979302699997788,
+        "max": 13.055747399994289,
+        "mean": 13.020504399998268,
+        "stddev": 0.03856912779278398,
+        "rounds": 3,
+        "median": 13.02646310000273,
+        "iqr": 0.05733352499737521,
+        "q1": 12.991092799999024,
+        "q3": 13.048426324996399,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 12.979302699997788,
+        "hd15iqr": 13.055747399994289,
+        "ops": 0.07680194017676711,
+        "total": 39.061513199994806,
+        "data": [12.979302699997788, 13.055747399994289, 13.02646310000273],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.594001499994192,
+        "max": 5.7986899000097765,
+        "mean": 5.662716233336444,
+        "stddev": 0.11775889928095014,
+        "rounds": 3,
+        "median": 5.595457300005364,
+        "iqr": 0.15351630001168814,
+        "q1": 5.594365449996985,
+        "q3": 5.747881750008673,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.594001499994192,
+        "hd15iqr": 5.7986899000097765,
+        "ops": 0.17659369793474622,
+        "total": 16.988148700009333,
+        "data": [5.7986899000097765, 5.594001499994192, 5.595457300005364],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6924023000028683,
+        "max": 0.6958700999966823,
+        "mean": 0.6943624999985332,
+        "stddev": 0.0017776513346512896,
+        "rounds": 3,
+        "median": 0.694815099996049,
+        "iqr": 0.002600849995360477,
+        "q1": 0.6930055000011635,
+        "q3": 0.6956063499965239,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6924023000028683,
+        "hd15iqr": 0.6958700999966823,
+        "ops": 1.4401699400559687,
+        "total": 2.0830874999955995,
+        "data": [0.6924023000028683, 0.6958700999966823, 0.694815099996049],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.612149299995508,
+        "max": 0.6322222000017064,
+        "mean": 0.6201385666693872,
+        "stddev": 0.010644397935769738,
+        "rounds": 3,
+        "median": 0.616044200010947,
+        "iqr": 0.015054675004648743,
+        "q1": 0.6131230249993678,
+        "q3": 0.6281777000040165,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.612149299995508,
+        "hd15iqr": 0.6322222000017064,
+        "ops": 1.6125428311462,
+        "total": 1.8604157000081614,
+        "data": [0.612149299995508, 0.6322222000017064, 0.616044200010947],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.331853199997568,
+        "max": 9.35911400000623,
+        "mean": 9.341940866671697,
+        "stddev": 0.01494793238628136,
+        "rounds": 3,
+        "median": 9.334855400011293,
+        "iqr": 0.020445600006496534,
+        "q1": 9.332603750000999,
+        "q3": 9.353049350007495,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.331853199997568,
+        "hd15iqr": 9.35911400000623,
+        "ops": 0.10704413721645355,
+        "total": 28.02582260001509,
+        "data": [9.35911400000623, 9.331853199997568, 9.334855400011293],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 25.568837099999655,
+        "max": 26.100440700000036,
+        "mean": 25.86050346666404,
+        "stddev": 0.2695505969377928,
+        "rounds": 3,
+        "median": 25.91223259999242,
+        "iqr": 0.3987027000002854,
+        "q1": 25.654685974997847,
+        "q3": 26.053388674998132,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 25.568837099999655,
+        "hd15iqr": 26.100440700000036,
+        "ops": 0.03866900740308744,
+        "total": 77.58151039999211,
+        "data": [25.91223259999242, 26.100440700000036, 25.568837099999655],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 31.101520700001856,
+        "max": 31.484841400000732,
+        "mean": 31.30830006666656,
+        "stddev": 0.19344106016221307,
+        "rounds": 3,
+        "median": 31.338538099997095,
+        "iqr": 0.28749052499915706,
+        "q1": 31.160775050000666,
+        "q3": 31.448265574999823,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 31.101520700001856,
+        "hd15iqr": 31.484841400000732,
+        "ops": 0.031940411899421005,
+        "total": 93.92490019999968,
+        "data": [31.101520700001856, 31.338538099997095, 31.484841400000732],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.157669199994416,
+        "max": 1.1710505000082776,
+        "mean": 1.1637366000019636,
+        "stddev": 0.006777176344203914,
+        "rounds": 3,
+        "median": 1.1624901000031969,
+        "iqr": 0.010035975010396214,
+        "q1": 1.1588744249966112,
+        "q3": 1.1689104000070074,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.157669199994416,
+        "hd15iqr": 1.1710505000082776,
+        "ops": 0.8593009792751322,
+        "total": 3.4912098000058904,
+        "data": [1.1624901000031969, 1.1710505000082776, 1.157669199994416],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1534661000041524,
+        "max": 1.1911282000073697,
+        "mean": 1.1754072666711484,
+        "stddev": 0.019586396329596897,
+        "rounds": 3,
+        "median": 1.1816275000019232,
+        "iqr": 0.02824657500241301,
+        "q1": 1.160506450003595,
+        "q3": 1.188753025006008,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1534661000041524,
+        "hd15iqr": 1.1911282000073697,
+        "ops": 0.850768944820363,
+        "total": 3.5262218000134453,
+        "data": [1.1911282000073697, 1.1534661000041524, 1.1816275000019232],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.099116700002924,
+        "max": 9.16260599999805,
+        "mean": 9.140324199999062,
+        "stddev": 0.03572617239160076,
+        "rounds": 3,
+        "median": 9.159249899996212,
+        "iqr": 0.04761697499634465,
+        "q1": 9.114150000001246,
+        "q3": 9.16176697499759,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.099116700002924,
+        "hd15iqr": 9.16260599999805,
+        "ops": 0.1094053097153931,
+        "total": 27.420972599997185,
+        "data": [9.159249899996212, 9.16260599999805, 9.099116700002924],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.749622200004524,
+        "max": 9.787359499998274,
+        "mean": 9.770514766666262,
+        "stddev": 0.019191525960785803,
+        "rounds": 3,
+        "median": 9.774562599995988,
+        "iqr": 0.02830297499531298,
+        "q1": 9.75585730000239,
+        "q3": 9.784160274997703,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.749622200004524,
+        "hd15iqr": 9.787359499998274,
+        "ops": 0.10234875274040489,
+        "total": 29.311544299998786,
+        "data": [9.749622200004524, 9.774562599995988, 9.787359499998274],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 13.794579400011571,
+        "max": 13.847675299999537,
+        "mean": 13.819872933338047,
+        "stddev": 0.026636710240008535,
+        "rounds": 3,
+        "median": 13.817364100003033,
+        "iqr": 0.03982192499097437,
+        "q1": 13.800275575009437,
+        "q3": 13.840097500000411,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 13.794579400011571,
+        "hd15iqr": 13.847675299999537,
+        "ops": 0.07235956544778885,
+        "total": 41.45961880001414,
+        "data": [13.794579400011571, 13.847675299999537, 13.817364100003033],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 14.29409259998647,
+        "max": 14.341086100001121,
+        "mean": 14.320216766665302,
+        "stddev": 0.023933391234922496,
+        "rounds": 3,
+        "median": 14.325471600008314,
+        "iqr": 0.03524512501098798,
+        "q1": 14.301937349991931,
+        "q3": 14.337182475002919,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 14.29409259998647,
+        "hd15iqr": 14.341086100001121,
+        "ops": 0.06983134517403443,
+        "total": 42.960650299995905,
+        "data": [14.29409259998647, 14.325471600008314, 14.341086100001121],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 19.012108199996874,
+        "max": 19.031885799995507,
+        "mean": 19.020673933332244,
+        "stddev": 0.01015085620123914,
+        "rounds": 3,
+        "median": 19.018027800004347,
+        "iqr": 0.014833199998975033,
+        "q1": 19.013588099998742,
+        "q3": 19.028421299997717,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 19.012108199996874,
+        "hd15iqr": 19.031885799995507,
+        "ops": 0.052574372680222345,
+        "total": 57.06202179999673,
+        "data": [19.012108199996874, 19.018027800004347, 19.031885799995507],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 22.844277999989572,
+        "max": 22.904651500008185,
+        "mean": 22.877523166665924,
+        "stddev": 0.030648027891728304,
+        "rounds": 3,
+        "median": 22.883640000000014,
+        "iqr": 0.04528012501396006,
+        "q1": 22.854118499992182,
+        "q3": 22.899398625006143,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 22.844277999989572,
+        "hd15iqr": 22.904651500008185,
+        "ops": 0.043711025564911965,
+        "total": 68.63256949999777,
+        "data": [22.904651500008185, 22.883640000000014, 22.844277999989572],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 24.56349929999851,
+        "max": 24.652423499996075,
+        "mean": 24.620587233332724,
+        "stddev": 0.04954910027986198,
+        "rounds": 3,
+        "median": 24.645838900003582,
+        "iqr": 0.06669314999817288,
+        "q1": 24.58408419999978,
+        "q3": 24.650777349997952,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 24.56349929999851,
+        "hd15iqr": 24.652423499996075,
+        "ops": 0.040616415462509534,
+        "total": 73.86176169999817,
+        "data": [24.652423499996075, 24.645838900003582, 24.56349929999851],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 34.385181099991314,
+        "max": 35.05481220000365,
+        "mean": 34.663644433327136,
+        "stddev": 0.34875230393062523,
+        "rounds": 3,
+        "median": 34.55093999998644,
+        "iqr": 0.502223325009254,
+        "q1": 34.426620824990096,
+        "q3": 34.92884414999935,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 34.385181099991314,
+        "hd15iqr": 35.05481220000365,
+        "ops": 0.028848668867563057,
+        "total": 103.9909332999814,
+        "data": [35.05481220000365, 34.55093999998644, 34.385181099991314],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 42.70141049999802,
+        "max": 42.86218290000397,
+        "mean": 42.802467666668235,
+        "stddev": 0.08799890760567972,
+        "rounds": 3,
+        "median": 42.843809600002714,
+        "iqr": 0.12057930000446504,
+        "q1": 42.73701027499919,
+        "q3": 42.85758957500366,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 42.70141049999802,
+        "hd15iqr": 42.86218290000397,
+        "ops": 0.02336313896169904,
+        "total": 128.4074030000047,
+        "data": [42.86218290000397, 42.843809600002714, 42.70141049999802],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.89402350000455,
+        "max": 8.933496400000877,
+        "mean": 8.911865200003376,
+        "stddev": 0.020007440896075666,
+        "rounds": 3,
+        "median": 8.908075700004702,
+        "iqr": 0.02960467499724473,
+        "q1": 8.897536550004588,
+        "q3": 8.927141225001833,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.89402350000455,
+        "hd15iqr": 8.933496400000877,
+        "ops": 0.1122099557789116,
+        "total": 26.73559560001013,
+        "data": [8.908075700004702, 8.933496400000877, 8.89402350000455],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.605641100002686,
+        "max": 9.628266200001235,
+        "mean": 9.614594800004852,
+        "stddev": 0.012027730767383588,
+        "rounds": 3,
+        "median": 9.609877100010635,
+        "iqr": 0.01696882499891217,
+        "q1": 9.606700100004673,
+        "q3": 9.623668925003585,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.605641100002686,
+        "hd15iqr": 9.628266200001235,
+        "ops": 0.1040085433449047,
+        "total": 28.843784400014556,
+        "data": [9.628266200001235, 9.609877100010635, 9.605641100002686],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 13.099021400004858,
+        "max": 13.141950899997028,
+        "mean": 13.115946533333044,
+        "stddev": 0.02285956803766863,
+        "rounds": 3,
+        "median": 13.106867299997248,
+        "iqr": 0.03219712499412708,
+        "q1": 13.100982875002956,
+        "q3": 13.133179999997083,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 13.099021400004858,
+        "hd15iqr": 13.141950899997028,
+        "ops": 0.07624306773884648,
+        "total": 39.34783959999913,
+        "data": [13.141950899997028, 13.106867299997248, 13.099021400004858],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 14.136786100003519,
+        "max": 14.198373899998842,
+        "mean": 14.17011736666609,
+        "stddev": 0.031105931361117625,
+        "rounds": 3,
+        "median": 14.175192099995911,
+        "iqr": 0.046190849996492034,
+        "q1": 14.146387600001617,
+        "q3": 14.19257844999811,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 14.136786100003519,
+        "hd15iqr": 14.198373899998842,
+        "ops": 0.0705710456818381,
+        "total": 42.51035209999827,
+        "data": [14.175192099995911, 14.136786100003519, 14.198373899998842],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 17.839360600002692,
+        "max": 17.926865399989765,
+        "mean": 17.880313166664564,
+        "stddev": 0.044020332861641503,
+        "rounds": 3,
+        "median": 17.874713500001235,
+        "iqr": 0.06562859999030479,
+        "q1": 17.848198825002328,
+        "q3": 17.913827424992633,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 17.839360600002692,
+        "hd15iqr": 17.926865399989765,
+        "ops": 0.05592743206893967,
+        "total": 53.64093949999369,
+        "data": [17.874713500001235, 17.839360600002692, 17.926865399989765],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 20.292161700010183,
+        "max": 20.333677700007684,
+        "mean": 20.31492183334194,
+        "stddev": 0.02104566885602676,
+        "rounds": 3,
+        "median": 20.318926100007957,
+        "iqr": 0.031136999998125248,
+        "q1": 20.298852800009627,
+        "q3": 20.329989800007752,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 20.292161700010183,
+        "hd15iqr": 20.333677700007684,
+        "ops": 0.049224900209005294,
+        "total": 60.944765500025824,
+        "data": [20.292161700010183, 20.333677700007684, 20.318926100007957],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 21.788034099998185,
+        "max": 21.84738870000001,
+        "mean": 21.824908399998094,
+        "stddev": 0.03218901306813877,
+        "rounds": 3,
+        "median": 21.839302399996086,
+        "iqr": 0.044515950001368765,
+        "q1": 21.80085117499766,
+        "q3": 21.84536712499903,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 21.788034099998185,
+        "hd15iqr": 21.84738870000001,
+        "ops": 0.04581920719539365,
+        "total": 65.47472519999428,
+        "data": [21.84738870000001, 21.839302399996086, 21.788034099998185],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 29.070927900000243,
+        "max": 29.22639350000827,
+        "mean": 29.133510766672163,
+        "stddev": 0.08204236488768839,
+        "rounds": 3,
+        "median": 29.10321090000798,
+        "iqr": 0.11659920000602142,
+        "q1": 29.078998650002177,
+        "q3": 29.1955978500082,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 29.070927900000243,
+        "hd15iqr": 29.22639350000827,
+        "ops": 0.03432473374077418,
+        "total": 87.4005323000165,
+        "data": [29.070927900000243, 29.22639350000827, 29.10321090000798],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 36.19962719999603,
+        "max": 36.448188600013964,
+        "mean": 36.36136960000052,
+        "stddev": 0.1401992485514187,
+        "rounds": 3,
+        "median": 36.436292999991565,
+        "iqr": 0.18642105001345044,
+        "q1": 36.258793649994914,
+        "q3": 36.445214700008364,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 36.19962719999603,
+        "hd15iqr": 36.448188600013964,
+        "ops": 0.027501714346865134,
+        "total": 109.08410880000156,
+        "data": [36.19962719999603, 36.448188600013964, 36.436292999991565],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.586308600002667,
+        "max": 1.6164068999933079,
+        "mean": 1.6048449333320605,
+        "stddev": 0.01621598774043582,
+        "rounds": 3,
+        "median": 1.6118193000002066,
+        "iqr": 0.022573724992980715,
+        "q1": 1.5926862750020518,
+        "q3": 1.6152599999950326,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.586308600002667,
+        "hd15iqr": 1.6164068999933079,
+        "ops": 0.6231131614216143,
+        "total": 4.814534799996181,
+        "data": [1.586308600002667, 1.6164068999933079, 1.6118193000002066],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6546725999942282,
+        "max": 1.750153599990881,
+        "mean": 1.6897866333262452,
+        "stddev": 0.05251131612820685,
+        "rounds": 3,
+        "median": 1.6645336999936262,
+        "iqr": 0.07161074999748962,
+        "q1": 1.6571378749940777,
+        "q3": 1.7287486249915673,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6546725999942282,
+        "hd15iqr": 1.750153599990881,
+        "ops": 0.5917906913676783,
+        "total": 5.0693598999787355,
+        "data": [1.6645336999936262, 1.6546725999942282, 1.750153599990881],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.922504799993476,
+        "max": 3.9713110999873606,
+        "mean": 3.9461116999931014,
+        "stddev": 0.024442090171422546,
+        "rounds": 3,
+        "median": 3.9445191999984672,
+        "iqr": 0.03660472499541356,
+        "q1": 3.9280083999947237,
+        "q3": 3.9646131249901373,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.922504799993476,
+        "hd15iqr": 3.9713110999873606,
+        "ops": 0.2534140125840199,
+        "total": 11.838335099979304,
+        "data": [3.9445191999984672, 3.922504799993476, 3.9713110999873606],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.005664099997375,
+        "max": 5.023228899997775,
+        "mean": 5.01316443333053,
+        "stddev": 0.009058787699232115,
+        "rounds": 3,
+        "median": 5.01060029999644,
+        "iqr": 0.013173600000300212,
+        "q1": 5.0068981499971414,
+        "q3": 5.020071749997442,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.005664099997375,
+        "hd15iqr": 5.023228899997775,
+        "ops": 0.199474805444521,
+        "total": 15.039493299991591,
+        "data": [5.005664099997375, 5.01060029999644, 5.023228899997775],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.829766399998334,
+        "max": 5.869320800004061,
+        "mean": 5.846569133335531,
+        "stddev": 0.020437220843078537,
+        "rounds": 3,
+        "median": 5.840620200004196,
+        "iqr": 0.029665800004295306,
+        "q1": 5.8324798499998,
+        "q3": 5.862145650004095,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.829766399998334,
+        "hd15iqr": 5.869320800004061,
+        "ops": 0.1710404815532369,
+        "total": 17.53970740000659,
+        "data": [5.869320800004061, 5.840620200004196, 5.829766399998334],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.395928700003424,
+        "max": 6.410835899994709,
+        "mean": 6.40372863333323,
+        "stddev": 0.0074776997285328885,
+        "rounds": 3,
+        "median": 6.404421300001559,
+        "iqr": 0.011180399993463652,
+        "q1": 6.3980518500029575,
+        "q3": 6.409232249996421,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.395928700003424,
+        "hd15iqr": 6.410835899994709,
+        "ops": 0.1561590219164996,
+        "total": 19.21118589999969,
+        "data": [6.395928700003424, 6.410835899994709, 6.404421300001559],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.335864900000161,
+        "max": 7.456358099996578,
+        "mean": 7.400499233330872,
+        "stddev": 0.06072404320148335,
+        "rounds": 3,
+        "median": 7.409274699995876,
+        "iqr": 0.09036989999731304,
+        "q1": 7.3542173499990895,
+        "q3": 7.4445872499964025,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.335864900000161,
+        "hd15iqr": 7.456358099996578,
+        "ops": 0.1351260189983038,
+        "total": 22.201497699992615,
+        "data": [7.335864900000161, 7.409274699995876, 7.456358099996578],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.281398399994941,
+        "max": 8.42603180000151,
+        "mean": 8.35461723333477,
+        "stddev": 0.07233357887617448,
+        "rounds": 3,
+        "median": 8.356421500007855,
+        "iqr": 0.10847505000492674,
+        "q1": 8.30015417499817,
+        "q3": 8.408629225003097,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.281398399994941,
+        "hd15iqr": 8.42603180000151,
+        "ops": 0.11969429263737164,
+        "total": 25.063851700004307,
+        "data": [8.281398399994941, 8.356421500007855, 8.42603180000151],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.354698200011626,
+        "max": 8.39465640000708,
+        "mean": 8.38057826667015,
+        "stddev": 0.022441672382305582,
+        "rounds": 3,
+        "median": 8.392380199991749,
+        "iqr": 0.029968649996590102,
+        "q1": 8.364118700006657,
+        "q3": 8.394087350003247,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.354698200011626,
+        "hd15iqr": 8.39465640000708,
+        "ops": 0.11932350825682692,
+        "total": 25.141734800010454,
+        "data": [8.39465640000708, 8.354698200011626, 8.392380199991749],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.009599700002582,
+        "max": 9.0154901999922,
+        "mean": 9.011755766667193,
+        "stddev": 0.0032469876066767776,
+        "rounds": 3,
+        "median": 9.010177400006796,
+        "iqr": 0.0044178749922139104,
+        "q1": 9.009744125003635,
+        "q3": 9.01416199999585,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.009599700002582,
+        "hd15iqr": 9.0154901999922,
+        "ops": 0.11096616751408353,
+        "total": 27.03526730000158,
+        "data": [9.010177400006796, 9.0154901999922, 9.009599700002582],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 10.863857000003918,
+        "max": 10.917098699996131,
+        "mean": 10.89333859999897,
+        "stddev": 0.027078059867438845,
+        "rounds": 3,
+        "median": 10.89906009999686,
+        "iqr": 0.03993127499416005,
+        "q1": 10.872657775002153,
+        "q3": 10.912589049996313,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 10.863857000003918,
+        "hd15iqr": 10.917098699996131,
+        "ops": 0.09179922122315143,
+        "total": 32.68001579999691,
+        "data": [10.89906009999686, 10.863857000003918, 10.917098699996131],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 10.905546000009053,
+        "max": 10.979952399997273,
+        "mean": 10.944245266669895,
+        "stddev": 0.03729333366991572,
+        "rounds": 3,
+        "median": 10.94723740000336,
+        "iqr": 0.055804799991165055,
+        "q1": 10.91596885000763,
+        "q3": 10.971773649998795,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 10.905546000009053,
+        "hd15iqr": 10.979952399997273,
+        "ops": 0.09137222125727076,
+        "total": 32.83273580000969,
+        "data": [10.905546000009053, 10.979952399997273, 10.94723740000336],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 18.867532400006894,
+        "max": 18.969734199999948,
+        "mean": 18.914335600003444,
+        "stddev": 0.051640223240458964,
+        "rounds": 3,
+        "median": 18.905740200003493,
+        "iqr": 0.07665134999479051,
+        "q1": 18.877084350006044,
+        "q3": 18.953735700000834,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 18.867532400006894,
+        "hd15iqr": 18.969734199999948,
+        "ops": 0.05286995119193179,
+        "total": 56.743006800010335,
+        "data": [18.969734199999948, 18.867532400006894, 18.905740200003493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 20.528106199999456,
+        "max": 20.94621239999833,
+        "mean": 20.676213933329564,
+        "stddev": 0.2341926808735743,
+        "rounds": 3,
+        "median": 20.554323199990904,
+        "iqr": 0.31357964999915566,
+        "q1": 20.534660449997318,
+        "q3": 20.848240099996474,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 20.528106199999456,
+        "hd15iqr": 20.94621239999833,
+        "ops": 0.04836475397403506,
+        "total": 62.02864179998869,
+        "data": [20.554323199990904, 20.528106199999456, 20.94621239999833],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 22.818817799998214,
+        "max": 23.126956599997357,
+        "mean": 22.927649266663746,
+        "stddev": 0.17284904354156308,
+        "rounds": 3,
+        "median": 22.837173399995663,
+        "iqr": 0.23110409999935655,
+        "q1": 22.823406699997577,
+        "q3": 23.054510799996933,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 22.818817799998214,
+        "hd15iqr": 23.126956599997357,
+        "ops": 0.043615461330960614,
+        "total": 68.78294779999123,
+        "data": [22.837173399995663, 22.818817799998214, 23.126956599997357],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 33.619046099993284,
+        "max": 33.91784830001416,
+        "mean": 33.79190666667031,
+        "stddev": 0.15482806080672276,
+        "rounds": 3,
+        "median": 33.838825600003474,
+        "iqr": 0.22410165001565474,
+        "q1": 33.67399097499583,
+        "q3": 33.898092625011486,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 33.619046099993284,
+        "hd15iqr": 33.91784830001416,
+        "ops": 0.02959288476569811,
+        "total": 101.37572000001092,
+        "data": [33.838825600003474, 33.91784830001416, 33.619046099993284],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 37.544709599998896,
+        "max": 37.552661399997305,
+        "mean": 37.547804233331895,
+        "stddev": 0.004258834771927747,
+        "rounds": 3,
+        "median": 37.54604169999948,
+        "iqr": 0.005963849998806836,
+        "q1": 37.54504262499904,
+        "q3": 37.55100647499785,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 37.544709599998896,
+        "hd15iqr": 37.552661399997305,
+        "ops": 0.026632715825025025,
+        "total": 112.64341269999568,
+        "data": [37.54604169999948, 37.552661399997305, 37.544709599998896],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 58.82669950000127,
+        "max": 58.88214100000914,
+        "mean": 58.86058150000463,
+        "stddev": 0.02970392205495616,
+        "rounds": 3,
+        "median": 58.87290400000347,
+        "iqr": 0.04158112500590505,
+        "q1": 58.83825062500182,
+        "q3": 58.879831750007725,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 58.82669950000127,
+        "hd15iqr": 58.88214100000914,
+        "ops": 0.01698929868710049,
+        "total": 176.58174450001388,
+        "data": [58.82669950000127, 58.87290400000347, 58.88214100000914],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 80.09296730000642,
+        "max": 80.42031349999888,
+        "mean": 80.20929570000347,
+        "stddev": 0.18306677884426162,
+        "rounds": 3,
+        "median": 80.11460630000511,
+        "iqr": 0.24550964999434655,
+        "q1": 80.09837705000609,
+        "q3": 80.34388670000044,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 80.09296730000642,
+        "hd15iqr": 80.42031349999888,
+        "ops": 0.012467382879662372,
+        "total": 240.6278871000104,
+        "data": [80.09296730000642, 80.11460630000511, 80.42031349999888],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3246917000069516,
+        "max": 1.3339005000016186,
+        "mean": 1.3283679666686414,
+        "stddev": 0.004876965634658888,
+        "rounds": 3,
+        "median": 1.3265116999973543,
+        "iqr": 0.0069065999960002955,
+        "q1": 1.3251467000045523,
+        "q3": 1.3320533000005526,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3246917000069516,
+        "hd15iqr": 1.3339005000016186,
+        "ops": 0.7528034588999147,
+        "total": 3.9851039000059245,
+        "data": [1.3246917000069516, 1.3339005000016186, 1.3265116999973543],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4252127000072505,
+        "max": 1.4398663000029046,
+        "mean": 1.4308230333360068,
+        "stddev": 0.007907007758074592,
+        "rounds": 3,
+        "median": 1.427390099997865,
+        "iqr": 0.010990199996740557,
+        "q1": 1.4257570500049042,
+        "q3": 1.4367472500016447,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4252127000072505,
+        "hd15iqr": 1.4398663000029046,
+        "ops": 0.6988984498442621,
+        "total": 4.29246910000802,
+        "data": [1.427390099997865, 1.4398663000029046, 1.4252127000072505],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.0640191999991657,
+        "max": 3.0782104000099935,
+        "mean": 3.0723033333391263,
+        "stddev": 0.00738819151746992,
+        "rounds": 3,
+        "median": 3.0746804000082193,
+        "iqr": 0.010643400008120807,
+        "q1": 3.066684500001429,
+        "q3": 3.07732790000955,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.0640191999991657,
+        "hd15iqr": 3.0782104000099935,
+        "ops": 0.32548869414959497,
+        "total": 9.216910000017378,
+        "data": [3.0782104000099935, 3.0746804000082193, 3.0640191999991657],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.1096996999986,
+        "max": 4.185332899985951,
+        "mean": 4.147283799994814,
+        "stddev": 0.037818744080523284,
+        "rounds": 3,
+        "median": 4.146818799999892,
+        "iqr": 0.05672489999051322,
+        "q1": 4.118979474998923,
+        "q3": 4.1757043749894365,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.1096996999986,
+        "hd15iqr": 4.185332899985951,
+        "ops": 0.2411216710082031,
+        "total": 12.441851399984444,
+        "data": [4.185332899985951, 4.146818799999892, 4.1096996999986],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.380458900006488,
+        "max": 5.410567200000514,
+        "mean": 5.392536933334971,
+        "stddev": 0.015912235650802714,
+        "rounds": 3,
+        "median": 5.386584699997911,
+        "iqr": 0.022581224995519733,
+        "q1": 5.381990350004344,
+        "q3": 5.4045715749998635,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.380458900006488,
+        "hd15iqr": 5.410567200000514,
+        "ops": 0.18544147446043693,
+        "total": 16.177610800004913,
+        "data": [5.380458900006488, 5.386584699997911, 5.410567200000514],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.111027600010857,
+        "max": 6.124816499999724,
+        "mean": 6.115853100001307,
+        "stddev": 0.0077701417672196935,
+        "rounds": 3,
+        "median": 6.111715199993341,
+        "iqr": 0.010341674991650507,
+        "q1": 6.111199500006478,
+        "q3": 6.1215411749981286,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.111027600010857,
+        "hd15iqr": 6.124816499999724,
+        "ops": 0.16350948651788028,
+        "total": 18.347559300003923,
+        "data": [6.111715199993341, 6.124816499999724, 6.111027600010857],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.526910599990515,
+        "max": 6.5995842999982415,
+        "mean": 6.560648133328262,
+        "stddev": 0.03661469663394062,
+        "rounds": 3,
+        "median": 6.55544949999603,
+        "iqr": 0.05450527500579483,
+        "q1": 6.534045324991894,
+        "q3": 6.5885505999976886,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.526910599990515,
+        "hd15iqr": 6.5995842999982415,
+        "ops": 0.15242396477871967,
+        "total": 19.681944399984786,
+        "data": [6.526910599990515, 6.55544949999603, 6.5995842999982415],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.871023200001218,
+        "max": 7.901355399997556,
+        "mean": 7.883246866670864,
+        "stddev": 0.015999510331033875,
+        "rounds": 3,
+        "median": 7.877362000013818,
+        "iqr": 0.02274914999725297,
+        "q1": 7.872607900004368,
+        "q3": 7.895357050001621,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.871023200001218,
+        "hd15iqr": 7.901355399997556,
+        "ops": 0.12685128563306114,
+        "total": 23.649740600012592,
+        "data": [7.871023200001218, 7.877362000013818, 7.901355399997556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.411678999997093,
+        "max": 8.490033099995344,
+        "mean": 8.437813233331932,
+        "stddev": 0.045223737641293144,
+        "rounds": 3,
+        "median": 8.41172760000336,
+        "iqr": 0.05876557499868795,
+        "q1": 8.41169114999866,
+        "q3": 8.470456724997348,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.411678999997093,
+        "hd15iqr": 8.490033099995344,
+        "ops": 0.11851411880624418,
+        "total": 25.313439699995797,
+        "data": [8.411678999997093, 8.490033099995344, 8.41172760000336],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 10.541876400006004,
+        "max": 10.578396600001724,
+        "mean": 10.558366833337155,
+        "stddev": 0.018515572156043023,
+        "rounds": 3,
+        "median": 10.55482750000374,
+        "iqr": 0.02739014999679057,
+        "q1": 10.545114175005438,
+        "q3": 10.572504325002228,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 10.541876400006004,
+        "hd15iqr": 10.578396600001724,
+        "ops": 0.09471161741061923,
+        "total": 31.675100500011467,
+        "data": [10.578396600001724, 10.541876400006004, 10.55482750000374],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 12.875708899999154,
+        "max": 12.889316300002974,
+        "mean": 12.883177133335266,
+        "stddev": 0.0069003729879472476,
+        "rounds": 3,
+        "median": 12.88450620000367,
+        "iqr": 0.010205550002865493,
+        "q1": 12.877908225000283,
+        "q3": 12.888113775003148,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 12.875708899999154,
+        "hd15iqr": 12.889316300002974,
+        "ops": 0.07762060473518574,
+        "total": 38.6495314000058,
+        "data": [12.88450620000367, 12.875708899999154, 12.889316300002974],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 15.733015699996031,
+        "max": 15.834720600003493,
+        "mean": 15.771047866665564,
+        "stddev": 0.05548919413443753,
+        "rounds": 3,
+        "median": 15.745407299997169,
+        "iqr": 0.0762786750055966,
+        "q1": 15.736113599996315,
+        "q3": 15.812392275001912,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 15.733015699996031,
+        "hd15iqr": 15.834720600003493,
+        "ops": 0.06340732768389142,
+        "total": 47.31314359999669,
+        "data": [15.745407299997169, 15.733015699996031, 15.834720600003493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 34.41486950000399,
+        "max": 34.79031309999118,
+        "mean": 34.556197566664196,
+        "stddev": 0.20419747714079287,
+        "rounds": 3,
+        "median": 34.46341009999742,
+        "iqr": 0.28158269999039476,
+        "q1": 34.427004650002345,
+        "q3": 34.70858734999274,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 34.41486950000399,
+        "hd15iqr": 34.79031309999118,
+        "ops": 0.028938369103569537,
+        "total": 103.66859269999259,
+        "data": [34.41486950000399, 34.46341009999742, 34.79031309999118],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 40.26098690000072,
+        "max": 40.303671799993026,
+        "mean": 40.27782216666674,
+        "stddev": 0.02272541037149093,
+        "rounds": 3,
+        "median": 40.26880780000647,
+        "iqr": 0.03201367499423213,
+        "q1": 40.262942125002155,
+        "q3": 40.29495579999639,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 40.26098690000072,
+        "hd15iqr": 40.303671799993026,
+        "ops": 0.024827558845214415,
+        "total": 120.83346650000021,
+        "data": [40.26098690000072, 40.303671799993026, 40.26880780000647],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 47.994518999999855,
+        "max": 48.35369190000347,
+        "mean": 48.22825660000186,
+        "stddev": 0.20260388486720904,
+        "rounds": 3,
+        "median": 48.336558900002274,
+        "iqr": 0.26937967500271043,
+        "q1": 48.08002897500046,
+        "q3": 48.34940865000317,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 47.994518999999855,
+        "hd15iqr": 48.35369190000347,
+        "ops": 0.020734732509488252,
+        "total": 144.6847698000056,
+        "data": [48.336558900002274, 48.35369190000347, 47.994518999999855],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 63.2221322000114,
+        "max": 64.04307240000344,
+        "mean": 63.50797953333434,
+        "stddev": 0.46376524763127763,
+        "rounds": 3,
+        "median": 63.25873399998818,
+        "iqr": 0.615705149994028,
+        "q1": 63.231282650005596,
+        "q3": 63.846987799999624,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 63.2221322000114,
+        "hd15iqr": 64.04307240000344,
+        "ops": 0.015746052816482937,
+        "total": 190.52393860000302,
+        "data": [63.25873399998818, 63.2221322000114, 64.04307240000344],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 77.31474839999282,
+        "max": 77.40302969999902,
+        "mean": 77.37129923333123,
+        "stddev": 0.04909618044149563,
+        "rounds": 3,
+        "median": 77.39611960000184,
+        "iqr": 0.06621097500465112,
+        "q1": 77.33509119999508,
+        "q3": 77.40130217499973,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 77.31474839999282,
+        "hd15iqr": 77.40302969999902,
+        "ops": 0.012924689256984898,
+        "total": 232.1138976999937,
+        "data": [77.39611960000184, 77.31474839999282, 77.40302969999902],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 102.48175930000434,
+        "max": 103.03000329999486,
+        "mean": 102.74085396666972,
+        "stddev": 0.27535492209587,
+        "rounds": 3,
+        "median": 102.71079930000997,
+        "iqr": 0.41118299999288865,
+        "q1": 102.53901930000575,
+        "q3": 102.95020229999864,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 102.48175930000434,
+        "hd15iqr": 103.03000329999486,
+        "ops": 0.009733226476046337,
+        "total": 308.22256190000917,
+        "data": [102.71079930000997, 102.48175930000434, 103.03000329999486],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 116.11821299999428,
+        "max": 116.8281743999978,
+        "mean": 116.53346376666256,
+        "stddev": 0.37001181086784,
+        "rounds": 3,
+        "median": 116.65400389999559,
+        "iqr": 0.5324710500026413,
+        "q1": 116.25216072499461,
+        "q3": 116.78463177499725,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 116.11821299999428,
+        "hd15iqr": 116.8281743999978,
+        "ops": 0.008581226093153134,
+        "total": 349.6003912999877,
+        "data": [116.11821299999428, 116.65400389999559, 116.8281743999978],
+        "iterations": 1
+      }
+    }
+  ],
+  "datetime": "2025-05-02T14:18:30.070225+00:00",
+  "version": "5.1.0"
+}

--- a/example_results/0002_zarr-python-v3.json
+++ b/example_results/0002_zarr-python-v3.json
@@ -1,0 +1,18131 @@
+{
+  "machine_info": {
+    "node": "FLDSMDFR-2",
+    "processor": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "machine": "AMD64",
+    "python_compiler": "MSC v.1942 64 bit (AMD64)",
+    "python_implementation": "CPython",
+    "python_implementation_version": "3.13.2",
+    "python_version": "3.13.2",
+    "python_build": ["main", "Feb 17 2025 13:52:56"],
+    "release": "11",
+    "system": "Windows",
+    "cpu": {
+      "python_version": "3.13.2.final.0 (64 bit)",
+      "cpuinfo_version": [9, 0, 0],
+      "cpuinfo_version_string": "9.0.0",
+      "arch": "X86_64",
+      "bits": 64,
+      "count": 24,
+      "arch_string_raw": "AMD64",
+      "vendor_id_raw": "GenuineIntel",
+      "brand_raw": "13th Gen Intel(R) Core(TM) i7-13700K",
+      "hz_actual_friendly": "3.4000 GHz",
+      "hz_actual": [3400000000, 0],
+      "l2_cache_size": 25165824,
+      "stepping": 1,
+      "model": 183,
+      "family": 6,
+      "l3_cache_size": 31457280,
+      "hz_advertised_friendly": "3.4180 GHz",
+      "hz_advertised": [3418000000, 0],
+      "flags": [
+        "3dnow",
+        "3dnowprefetch",
+        "abm",
+        "acpi",
+        "adx",
+        "aes",
+        "apic",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "clflush",
+        "clflushopt",
+        "clwb",
+        "cmov",
+        "cx16",
+        "cx8",
+        "de",
+        "dts",
+        "erms",
+        "est",
+        "f16c",
+        "fma",
+        "fpu",
+        "fxsr",
+        "gfni",
+        "ht",
+        "hypervisor",
+        "ia64",
+        "intel_pt",
+        "invpcid",
+        "lahf_lm",
+        "mca",
+        "mce",
+        "mmx",
+        "monitor",
+        "movbe",
+        "msr",
+        "mtrr",
+        "osxsave",
+        "pae",
+        "pat",
+        "pbe",
+        "pcid",
+        "pclmulqdq",
+        "pdcm",
+        "pge",
+        "pni",
+        "popcnt",
+        "pse",
+        "pse36",
+        "rdpid",
+        "rdrnd",
+        "rdseed",
+        "sep",
+        "serial",
+        "sha",
+        "smap",
+        "smep",
+        "ss",
+        "sse",
+        "sse2",
+        "sse4_1",
+        "sse4_2",
+        "ssse3",
+        "tm",
+        "tm2",
+        "tsc",
+        "tscdeadline",
+        "umip",
+        "vaes",
+        "vme",
+        "vpclmulqdq",
+        "x2apic",
+        "xsave",
+        "xtpr"
+      ],
+      "l2_cache_line_size": 2048,
+      "l2_cache_associativity": 7
+    }
+  },
+  "commit_info": {
+    "id": "unknown",
+    "time": null,
+    "author_time": null,
+    "dirty": false,
+    "error": "FileNotFoundError(2, 'The system cannot find the file specified', None, 2, None)",
+    "project": "zarr-benchmarks",
+    "branch": "(unknown)"
+  },
+  "benchmarks": [
+    {
+      "group": "read",
+      "name": "test_read_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.914223705435877
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6375031000061426,
+        "max": 0.6784582999971462,
+        "mean": 0.6592066666683726,
+        "stddev": 0.02058740110794854,
+        "rounds": 3,
+        "median": 0.6616586000018287,
+        "iqr": 0.030716399993252708,
+        "q1": 0.6435419750050642,
+        "q3": 0.6742583749983169,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6375031000061426,
+        "hd15iqr": 0.6784582999971462,
+        "ops": 1.516974949683072,
+        "total": 1.9776200000051176,
+        "data": [0.6784582999971462, 0.6616586000018287, 0.6375031000061426],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9130180553153768
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5681390999961877,
+        "max": 0.6198481000028551,
+        "mean": 0.5962330666661728,
+        "stddev": 0.026143848287417618,
+        "rounds": 3,
+        "median": 0.6007119999994757,
+        "iqr": 0.038781750005000504,
+        "q1": 0.5762823249970097,
+        "q3": 0.6150640750020102,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5681390999961877,
+        "hd15iqr": 0.6198481000028551,
+        "ops": 1.677196478872739,
+        "total": 1.7886991999985185,
+        "data": [0.5681390999961877, 0.6007119999994757, 0.6198481000028551],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9117307135215016
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.555347300003632,
+        "max": 0.6034897999925306,
+        "mean": 0.5803617000007458,
+        "stddev": 0.024126617501793634,
+        "rounds": 3,
+        "median": 0.582248000006075,
+        "iqr": 0.036106874991673976,
+        "q1": 0.5620724750042427,
+        "q3": 0.5981793499959167,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.555347300003632,
+        "hd15iqr": 0.6034897999925306,
+        "ops": 1.723063393050773,
+        "total": 1.7410851000022376,
+        "data": [0.6034897999925306, 0.555347300003632, 0.582248000006075],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9118825188985271
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4924299999984214,
+        "max": 0.5287148999923375,
+        "mean": 0.5051722999972602,
+        "stddev": 0.02041159846505619,
+        "rounds": 3,
+        "median": 0.49437200000102166,
+        "iqr": 0.02721367499543703,
+        "q1": 0.49291549999907147,
+        "q3": 0.5201291749945085,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4924299999984214,
+        "hd15iqr": 0.5287148999923375,
+        "ops": 1.9795226302103728,
+        "total": 1.5155168999917805,
+        "data": [0.4924299999984214, 0.5287148999923375, 0.49437200000102166],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4642341246508654
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4792708000022685,
+        "max": 0.5267086000094423,
+        "mean": 0.5103997000017747,
+        "stddev": 0.026968695133408375,
+        "rounds": 3,
+        "median": 0.5252196999936132,
+        "iqr": 0.035578350005380344,
+        "q1": 0.4907580250001047,
+        "q3": 0.526336375005485,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4792708000022685,
+        "hd15iqr": 0.5267086000094423,
+        "ops": 1.9592488004920907,
+        "total": 1.531199100005324,
+        "data": [0.4792708000022685, 0.5252196999936132, 0.5267086000094423],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5200612538360154
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4830484999984037,
+        "max": 0.5164981999987504,
+        "mean": 0.5042328333317224,
+        "stddev": 0.01842231207867522,
+        "rounds": 3,
+        "median": 0.5131517999980133,
+        "iqr": 0.02508727500025998,
+        "q1": 0.4905743249983061,
+        "q3": 0.5156615999985661,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4830484999984037,
+        "hd15iqr": 0.5164981999987504,
+        "ops": 1.9832107984569194,
+        "total": 1.5126984999951674,
+        "data": [0.5131517999980133, 0.4830484999984037, 0.5164981999987504],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7091702932627046
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5125161999894772,
+        "max": 0.5960602999984985,
+        "mean": 0.5422424333276771,
+        "stddev": 0.04669271098420453,
+        "rounds": 3,
+        "median": 0.5181507999950554,
+        "iqr": 0.06265807500676601,
+        "q1": 0.5139248499908717,
+        "q3": 0.5765829249976377,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5125161999894772,
+        "hd15iqr": 0.5960602999984985,
+        "ops": 1.844193553542314,
+        "total": 1.6267272999830311,
+        "data": [0.5181507999950554, 0.5960602999984985, 0.5125161999894772],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8569408528157383
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5110507999925176,
+        "max": 0.5412450000003446,
+        "mean": 0.5301826333306963,
+        "stddev": 0.016636094726950112,
+        "rounds": 3,
+        "median": 0.5382520999992266,
+        "iqr": 0.022645650005870266,
+        "q1": 0.5178511249941948,
+        "q3": 0.5404967750000651,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5110507999925176,
+        "hd15iqr": 0.5412450000003446,
+        "ops": 1.886142504739984,
+        "total": 1.5905478999920888,
+        "data": [0.5110507999925176, 0.5412450000003446, 0.5382520999992266],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8171484344583597
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5183531999937259,
+        "max": 0.5287141000007978,
+        "mean": 0.52338513333234,
+        "stddev": 0.005186832736691449,
+        "rounds": 3,
+        "median": 0.5230881000024965,
+        "iqr": 0.007770675005303929,
+        "q1": 0.5195369249959185,
+        "q3": 0.5273076000012225,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5183531999937259,
+        "hd15iqr": 0.5287141000007978,
+        "ops": 1.910638908738392,
+        "total": 1.5701553999970201,
+        "data": [0.5287141000007978, 0.5230881000024965, 0.5183531999937259],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5304638435044642
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47836789999564644,
+        "max": 0.5083870999951614,
+        "mean": 0.48883799999506056,
+        "stddev": 0.016944299127201207,
+        "rounds": 3,
+        "median": 0.4797589999943739,
+        "iqr": 0.022514399999636225,
+        "q1": 0.4787156749953283,
+        "q3": 0.5012300749949645,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47836789999564644,
+        "hd15iqr": 0.5083870999951614,
+        "ops": 2.045667480862994,
+        "total": 1.4665139999851817,
+        "data": [0.47836789999564644, 0.4797589999943739, 0.5083870999951614],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5233646583153488
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.455686399989645,
+        "max": 0.5300729999871692,
+        "mean": 0.492296066659037,
+        "stddev": 0.03720703493141277,
+        "rounds": 3,
+        "median": 0.4911288000002969,
+        "iqr": 0.05578994999814313,
+        "q1": 0.464546999992308,
+        "q3": 0.5203369499904511,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.455686399989645,
+        "hd15iqr": 0.5300729999871692,
+        "ops": 2.0312979682866272,
+        "total": 1.476888199977111,
+        "data": [0.5300729999871692, 0.455686399989645, 0.4911288000002969],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7170510106280648
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48988889998872764,
+        "max": 0.5312209000112489,
+        "mean": 0.5100167000006574,
+        "stddev": 0.020687013660344096,
+        "rounds": 3,
+        "median": 0.5089403000019956,
+        "iqr": 0.030999000016890932,
+        "q1": 0.49465174999204464,
+        "q3": 0.5256507500089356,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48988889998872764,
+        "hd15iqr": 0.5312209000112489,
+        "ops": 1.9607201097507416,
+        "total": 1.5300501000019722,
+        "data": [0.5312209000112489, 0.5089403000019956, 0.48988889998872764],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8828479050445648
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47570540000742767,
+        "max": 0.5407785999996122,
+        "mean": 0.5095926666690502,
+        "stddev": 0.03262059534450337,
+        "rounds": 3,
+        "median": 0.5122940000001108,
+        "iqr": 0.048804899994138395,
+        "q1": 0.48485255000559846,
+        "q3": 0.5336574499997369,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47570540000742767,
+        "hd15iqr": 0.5407785999996122,
+        "ops": 1.9623516298546733,
+        "total": 1.5287780000071507,
+        "data": [0.5407785999996122, 0.5122940000001108, 0.47570540000742767],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8683560327932889
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5130015000031563,
+        "max": 0.5330663000058848,
+        "mean": 0.5256115000035303,
+        "stddev": 0.010980943267864562,
+        "rounds": 3,
+        "median": 0.5307667000015499,
+        "iqr": 0.015048600002046442,
+        "q1": 0.5174428000027547,
+        "q3": 0.5324914000048011,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5130015000031563,
+        "hd15iqr": 0.5330663000058848,
+        "ops": 1.9025458917723135,
+        "total": 1.576834500010591,
+        "data": [0.5130015000031563, 0.5330663000058848, 0.5307667000015499],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.589715189799665
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.476167799992254,
+        "max": 0.4980255999980727,
+        "mean": 0.48779586666690494,
+        "stddev": 0.010995788165393823,
+        "rounds": 3,
+        "median": 0.48919420001038816,
+        "iqr": 0.016393350004364038,
+        "q1": 0.47942439999678754,
+        "q3": 0.4958177500011516,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.476167799992254,
+        "hd15iqr": 0.4980255999980727,
+        "ops": 2.050037871031936,
+        "total": 1.4633876000007149,
+        "data": [0.4980255999980727, 0.48919420001038816, 0.476167799992254],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.534008663269028
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.476923700000043,
+        "max": 0.5241956999961985,
+        "mean": 0.5018414333317196,
+        "stddev": 0.023740029842536137,
+        "rounds": 3,
+        "median": 0.5044048999989172,
+        "iqr": 0.035453999997116625,
+        "q1": 0.4837939999997616,
+        "q3": 0.5192479999968782,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.476923700000043,
+        "hd15iqr": 0.5241956999961985,
+        "ops": 1.9926612941482558,
+        "total": 1.5055242999951588,
+        "data": [0.476923700000043, 0.5241956999961985, 0.5044048999989172],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.760191259385244
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5116992999974173,
+        "max": 0.5425876999943284,
+        "mean": 0.5308005666641596,
+        "stddev": 0.016692684728382604,
+        "rounds": 3,
+        "median": 0.5381147000007331,
+        "iqr": 0.02316629999768338,
+        "q1": 0.5183031499982462,
+        "q3": 0.5414694499959296,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5116992999974173,
+        "hd15iqr": 0.5425876999943284,
+        "ops": 1.8839467453558794,
+        "total": 1.5924016999924788,
+        "data": [0.5116992999974173, 0.5381147000007331, 0.5425876999943284],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9025341246671432
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5001386000076309,
+        "max": 0.5298253999935696,
+        "mean": 0.5184933000030773,
+        "stddev": 0.016041016379066103,
+        "rounds": 3,
+        "median": 0.5255159000080312,
+        "iqr": 0.02226509998945403,
+        "q1": 0.506482925007731,
+        "q3": 0.528748024997185,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5001386000076309,
+        "hd15iqr": 0.5298253999935696,
+        "ops": 1.9286652305710894,
+        "total": 1.5554799000092316,
+        "data": [0.5298253999935696, 0.5001386000076309, 0.5255159000080312],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9100523589797551
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48966740000469144,
+        "max": 0.5416070999926887,
+        "mean": 0.5140355333326928,
+        "stddev": 0.02611761086977889,
+        "rounds": 3,
+        "median": 0.5108321000006981,
+        "iqr": 0.038954774990997976,
+        "q1": 0.4949585750036931,
+        "q3": 0.5339133499946911,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48966740000469144,
+        "hd15iqr": 0.5416070999926887,
+        "ops": 1.9453908050219995,
+        "total": 1.5421065999980783,
+        "data": [0.48966740000469144, 0.5108321000006981, 0.5416070999926887],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904689860522647
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47520289999374654,
+        "max": 0.5231169000035152,
+        "mean": 0.5008479333337164,
+        "stddev": 0.02413475126979988,
+        "rounds": 3,
+        "median": 0.5042240000038873,
+        "iqr": 0.03593550000732648,
+        "q1": 0.48245817499628174,
+        "q3": 0.5183936750036082,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47520289999374654,
+        "hd15iqr": 0.5231169000035152,
+        "ops": 1.9966140088546542,
+        "total": 1.502543800001149,
+        "data": [0.5042240000038873, 0.5231169000035152, 0.47520289999374654],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5805269713452537
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.456210899996222,
+        "max": 0.5540507999976398,
+        "mean": 0.5027541999976771,
+        "stddev": 0.04909283963806453,
+        "rounds": 3,
+        "median": 0.49800089999916963,
+        "iqr": 0.07337992500106338,
+        "q1": 0.4666583999969589,
+        "q3": 0.5400383249980223,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.456210899996222,
+        "hd15iqr": 0.5540507999976398,
+        "ops": 1.989043552504624,
+        "total": 1.5082625999930315,
+        "data": [0.5540507999976398, 0.456210899996222, 0.49800089999916963],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.791115683505884
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.471676800007117,
+        "max": 0.5483473000058439,
+        "mean": 0.5171145333345825,
+        "stddev": 0.0402607401917997,
+        "rounds": 3,
+        "median": 0.5313194999907864,
+        "iqr": 0.05750287499904516,
+        "q1": 0.48658747500303434,
+        "q3": 0.5440903500020795,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.471676800007117,
+        "hd15iqr": 0.5483473000058439,
+        "ops": 1.9338075717028476,
+        "total": 1.5513436000037473,
+        "data": [0.5313194999907864, 0.471676800007117, 0.5483473000058439],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.946077143623026
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5148658999969484,
+        "max": 0.6041342999960762,
+        "mean": 0.5477378999979313,
+        "stddev": 0.049063834501809206,
+        "rounds": 3,
+        "median": 0.5242135000007693,
+        "iqr": 0.06695129999934579,
+        "q1": 0.5172027999979036,
+        "q3": 0.5841540999972494,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5148658999969484,
+        "hd15iqr": 0.6041342999960762,
+        "ops": 1.8256907181405135,
+        "total": 1.6432136999937939,
+        "data": [0.6041342999960762, 0.5242135000007693, 0.5148658999969484],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.973789301510622
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47816379999858327,
+        "max": 0.5084759000019403,
+        "mean": 0.49591186666414916,
+        "stddev": 0.015807008028434388,
+        "rounds": 3,
+        "median": 0.5010958999919239,
+        "iqr": 0.022734075002517784,
+        "q1": 0.48389682499691844,
+        "q3": 0.5066308999994362,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47816379999858327,
+        "hd15iqr": 0.5084759000019403,
+        "ops": 2.016487338217375,
+        "total": 1.4877355999924475,
+        "data": [0.5084759000019403, 0.47816379999858327, 0.5010958999919239],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904689860522647
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5229498999979114,
+        "max": 0.5568570000032196,
+        "mean": 0.5358925999995942,
+        "stddev": 0.018321670526547706,
+        "rounds": 3,
+        "median": 0.5278708999976516,
+        "iqr": 0.025430325003981125,
+        "q1": 0.5241801499978465,
+        "q3": 0.5496104750018276,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5229498999979114,
+        "hd15iqr": 0.5568570000032196,
+        "ops": 1.866045547187547,
+        "total": 1.6076777999987826,
+        "data": [0.5278708999976516, 0.5568570000032196, 0.5229498999979114],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5840493587600013
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4889273000007961,
+        "max": 0.542623299988918,
+        "mean": 0.5225924333256747,
+        "stddev": 0.029329763453385227,
+        "rounds": 3,
+        "median": 0.53622669998731,
+        "iqr": 0.040271999991091434,
+        "q1": 0.5007521499974246,
+        "q3": 0.541024149988516,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4889273000007961,
+        "hd15iqr": 0.542623299988918,
+        "ops": 1.9135370821123416,
+        "total": 1.567777299977024,
+        "data": [0.4889273000007961, 0.53622669998731, 0.542623299988918],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.814312852659383
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49806579999858513,
+        "max": 0.5196672000020044,
+        "mean": 0.5056296333350474,
+        "stddev": 0.012169101772632978,
+        "rounds": 3,
+        "median": 0.4991559000045527,
+        "iqr": 0.016201050002564443,
+        "q1": 0.498338325000077,
+        "q3": 0.5145393750026415,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49806579999858513,
+        "hd15iqr": 0.5196672000020044,
+        "ops": 1.977732185916734,
+        "total": 1.5168889000051422,
+        "data": [0.49806579999858513, 0.5196672000020044, 0.4991559000045527],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.964983047182941
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5385257000016281,
+        "max": 0.5861072999978205,
+        "mean": 0.5585837666682588,
+        "stddev": 0.024653641899746042,
+        "rounds": 3,
+        "median": 0.5511183000053279,
+        "iqr": 0.035686199997144286,
+        "q1": 0.5416738500025531,
+        "q3": 0.5773600499996974,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5385257000016281,
+        "hd15iqr": 0.5861072999978205,
+        "ops": 1.7902417858732669,
+        "total": 1.6757513000047766,
+        "data": [0.5385257000016281, 0.5511183000053279, 0.5861072999978205],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.982129826089199
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4858356000040658,
+        "max": 0.5385504000005312,
+        "mean": 0.5091831333362885,
+        "stddev": 0.026868018659892138,
+        "rounds": 3,
+        "median": 0.5031634000042686,
+        "iqr": 0.03953609999734908,
+        "q1": 0.4901675500041165,
+        "q3": 0.5297036500014656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4858356000040658,
+        "hd15iqr": 0.5385504000005312,
+        "ops": 1.9639299390138143,
+        "total": 1.5275494000088656,
+        "data": [0.5385504000005312, 0.4858356000040658, 0.5031634000042686],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5851194327903932
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5161113999929512,
+        "max": 0.5404031000070972,
+        "mean": 0.5257315666676732,
+        "stddev": 0.012909643731732617,
+        "rounds": 3,
+        "median": 0.5206802000029711,
+        "iqr": 0.018218775010609534,
+        "q1": 0.5172535999954562,
+        "q3": 0.5354723750060657,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5161113999929512,
+        "hd15iqr": 0.5404031000070972,
+        "ops": 1.9021113880196634,
+        "total": 1.5771947000030195,
+        "data": [0.5404031000070972, 0.5161113999929512, 0.5206802000029711],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5886823151984495
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4813639000058174,
+        "max": 0.5318016999954125,
+        "mean": 0.5056796333374223,
+        "stddev": 0.025267371193143682,
+        "rounds": 3,
+        "median": 0.5038733000110369,
+        "iqr": 0.03782834999219631,
+        "q1": 0.4869912500071223,
+        "q3": 0.5248195999993186,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4813639000058174,
+        "hd15iqr": 0.5318016999954125,
+        "ops": 1.9775366340149496,
+        "total": 1.5170389000122668,
+        "data": [0.4813639000058174, 0.5318016999954125, 0.5038733000110369],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8340807132202896
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4894540999957826,
+        "max": 0.5083469000092009,
+        "mean": 0.5009388666706703,
+        "stddev": 0.010084606542080788,
+        "rounds": 3,
+        "median": 0.5050156000070274,
+        "iqr": 0.014169600010063732,
+        "q1": 0.4933444749985938,
+        "q3": 0.5075140750086575,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4894540999957826,
+        "hd15iqr": 0.5083469000092009,
+        "ops": 1.996251571865804,
+        "total": 1.502816600012011,
+        "data": [0.5050156000070274, 0.4894540999957826, 0.5083469000092009],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.977681607544043
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5117880000034347,
+        "max": 0.5414739000116242,
+        "mean": 0.5240767666691681,
+        "stddev": 0.015488212369474537,
+        "rounds": 3,
+        "median": 0.5189683999924455,
+        "iqr": 0.02226442500614212,
+        "q1": 0.5135831000006874,
+        "q3": 0.5358475250068295,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5117880000034347,
+        "hd15iqr": 0.5414739000116242,
+        "ops": 1.9081174049283243,
+        "total": 1.5722303000075044,
+        "data": [0.5117880000034347, 0.5414739000116242, 0.5189683999924455],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9897958260752897
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5109807000117144,
+        "max": 0.5168944999895757,
+        "mean": 0.5147060666689262,
+        "stddev": 0.003242665663511318,
+        "rounds": 3,
+        "median": 0.5162430000054883,
+        "iqr": 0.004435349983396009,
+        "q1": 0.5122962750101578,
+        "q3": 0.5167316249935539,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5109807000117144,
+        "hd15iqr": 0.5168944999895757,
+        "ops": 1.9428564471209722,
+        "total": 1.5441182000067784,
+        "data": [0.5109807000117144, 0.5168944999895757, 0.5162430000054883],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.597722981562111
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4863188000017544,
+        "max": 0.5369389999978011,
+        "mean": 0.5163289333334736,
+        "stddev": 0.026587066440724467,
+        "rounds": 3,
+        "median": 0.5257290000008652,
+        "iqr": 0.03796514999703504,
+        "q1": 0.4961713500015321,
+        "q3": 0.5341364999985672,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4863188000017544,
+        "hd15iqr": 0.5369389999978011,
+        "ops": 1.936749880631123,
+        "total": 1.5489868000004208,
+        "data": [0.5369389999978011, 0.5257290000008652, 0.4863188000017544],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5925613095483373
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4844131000136258,
+        "max": 0.5341640999977244,
+        "mean": 0.5026328333381874,
+        "stddev": 0.02741693253539802,
+        "rounds": 3,
+        "median": 0.48932130000321195,
+        "iqr": 0.03731324998807395,
+        "q1": 0.48564015001102234,
+        "q3": 0.5229533999990963,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4844131000136258,
+        "hd15iqr": 0.5341640999977244,
+        "ops": 1.9895238306630243,
+        "total": 1.5078985000145622,
+        "data": [0.5341640999977244, 0.48932130000321195, 0.4844131000136258],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.85018444831235
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.479519699991215,
+        "max": 0.5311861999944085,
+        "mean": 0.5043175666651223,
+        "stddev": 0.025895421632998575,
+        "rounds": 3,
+        "median": 0.5022468000097433,
+        "iqr": 0.03874987500239513,
+        "q1": 0.4852014749958471,
+        "q3": 0.5239513499982422,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.479519699991215,
+        "hd15iqr": 0.5311861999944085,
+        "ops": 1.982877587653062,
+        "total": 1.5129526999953669,
+        "data": [0.5022468000097433, 0.479519699991215, 0.5311861999944085],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9829448470913096
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4983806999953231,
+        "max": 0.6017448999918997,
+        "mean": 0.5671233333268901,
+        "stddev": 0.05953339275634152,
+        "rounds": 3,
+        "median": 0.6012443999934476,
+        "iqr": 0.07752314999743248,
+        "q1": 0.5240966249948542,
+        "q3": 0.6016197749922867,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4983806999953231,
+        "hd15iqr": 0.6017448999918997,
+        "ops": 1.7632848822032148,
+        "total": 1.7013699999806704,
+        "data": [0.6017448999918997, 0.4983806999953231, 0.6012443999934476],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9890804019811035
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4908889999933308,
+        "max": 0.5287013000051957,
+        "mean": 0.5152995999960694,
+        "stddev": 0.021174026951641455,
+        "rounds": 3,
+        "median": 0.5263084999896819,
+        "iqr": 0.028359225008898648,
+        "q1": 0.49974387499241857,
+        "q3": 0.5281031000013172,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4908889999933308,
+        "hd15iqr": 0.5287013000051957,
+        "ops": 1.9406186226568538,
+        "total": 1.5458987999882083,
+        "data": [0.5263084999896819, 0.4908889999933308, 0.5287013000051957],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.60365162491852
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4971966000011889,
+        "max": 0.5829460999957519,
+        "mean": 0.5320337666683675,
+        "stddev": 0.045078292167011286,
+        "rounds": 3,
+        "median": 0.5159586000081617,
+        "iqr": 0.0643121249959222,
+        "q1": 0.5018871000029321,
+        "q3": 0.5661992249988543,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4971966000011889,
+        "hd15iqr": 0.5829460999957519,
+        "ops": 1.8795799489608895,
+        "total": 1.5961013000051025,
+        "data": [0.5159586000081617, 0.4971966000011889, 0.5829460999957519],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5994499206706827
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4979812999954447,
+        "max": 0.5273289999895496,
+        "mean": 0.5132330666626027,
+        "stddev": 0.014707951481044331,
+        "rounds": 3,
+        "median": 0.5143889000028139,
+        "iqr": 0.022010774995578686,
+        "q1": 0.502083199997287,
+        "q3": 0.5240939749928657,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4979812999954447,
+        "hd15iqr": 0.5273289999895496,
+        "ops": 1.9484325250177144,
+        "total": 1.5396991999878082,
+        "data": [0.4979812999954447, 0.5143889000028139, 0.5273289999895496],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8626925155662106
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4918210000032559,
+        "max": 0.6232971999997972,
+        "mean": 0.555929166667435,
+        "stddev": 0.06579869177577452,
+        "rounds": 3,
+        "median": 0.552669299999252,
+        "iqr": 0.09860714999740594,
+        "q1": 0.5070330750022549,
+        "q3": 0.6056402249996609,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4918210000032559,
+        "hd15iqr": 0.6232971999997972,
+        "ops": 1.7987903135116756,
+        "total": 1.667787500002305,
+        "data": [0.6232971999997972, 0.4918210000032559, 0.552669299999252],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9894079274388314
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5078829999984009,
+        "max": 0.5487594000005629,
+        "mean": 0.5344443666690495,
+        "stddev": 0.023026061961918212,
+        "rounds": 3,
+        "median": 0.5466907000081846,
+        "iqr": 0.03065730000162148,
+        "q1": 0.5175849250008469,
+        "q3": 0.5482422250024683,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5078829999984009,
+        "hd15iqr": 0.5487594000005629,
+        "ops": 1.8711021433952961,
+        "total": 1.6033331000071485,
+        "data": [0.5466907000081846, 0.5487594000005629, 0.5078829999984009],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9965854204673645
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48954280000180006,
+        "max": 0.5454105000098934,
+        "mean": 0.5178035000038411,
+        "stddev": 0.02793958605298486,
+        "rounds": 3,
+        "median": 0.5184571999998298,
+        "iqr": 0.041900775006070035,
+        "q1": 0.4967714000013075,
+        "q3": 0.5386721750073775,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48954280000180006,
+        "hd15iqr": 0.5454105000098934,
+        "ops": 1.9312345320040942,
+        "total": 1.5534105000115233,
+        "data": [0.5184571999998298, 0.48954280000180006, 0.5454105000098934],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.6049166821859566
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49159409999265336,
+        "max": 0.5150533999985782,
+        "mean": 0.505121866663103,
+        "stddev": 0.012136076789542928,
+        "rounds": 3,
+        "median": 0.5087180999980774,
+        "iqr": 0.017594475004443666,
+        "q1": 0.49587509999400936,
+        "q3": 0.513469574998453,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49159409999265336,
+        "hd15iqr": 0.5150533999985782,
+        "ops": 1.9797202734582104,
+        "total": 1.515365599989309,
+        "data": [0.5150533999985782, 0.49159409999265336, 0.5087180999980774],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.6047554382269784
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5190271000028588,
+        "max": 0.5460711000050651,
+        "mean": 0.531937300004453,
+        "stddev": 0.013563457588241677,
+        "rounds": 3,
+        "median": 0.5307137000054354,
+        "iqr": 0.020283000001654727,
+        "q1": 0.5219487500035029,
+        "q3": 0.5422317500051577,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5190271000028588,
+        "hd15iqr": 0.5460711000050651,
+        "ops": 1.8799208102000529,
+        "total": 1.5958119000133593,
+        "data": [0.5460711000050651, 0.5307137000054354, 0.5190271000028588],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8749818741222157
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4926031999930274,
+        "max": 0.5449127000028966,
+        "mean": 0.5105385666684015,
+        "stddev": 0.029778276222363828,
+        "rounds": 3,
+        "median": 0.49409980000928044,
+        "iqr": 0.03923212500740192,
+        "q1": 0.49297734999709064,
+        "q3": 0.5322094750044926,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4926031999930274,
+        "hd15iqr": 0.5449127000028966,
+        "ops": 1.9587158841410452,
+        "total": 1.5316157000052044,
+        "data": [0.4926031999930274, 0.49409980000928044, 0.5449127000028966],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9943420292403111
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5713707999966573,
+        "max": 0.6197648999950616,
+        "mean": 0.5915522999954798,
+        "stddev": 0.02517679793143947,
+        "rounds": 3,
+        "median": 0.5835211999947205,
+        "iqr": 0.036295574998803204,
+        "q1": 0.5744083999961731,
+        "q3": 0.6107039749949763,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5713707999966573,
+        "hd15iqr": 0.6197648999950616,
+        "ops": 1.6904676053286265,
+        "total": 1.7746568999864394,
+        "data": [0.5713707999966573, 0.6197648999950616, 0.5835211999947205],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.0392728210068145
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4845810000115307,
+        "max": 0.5370555999979842,
+        "mean": 0.5091303000032591,
+        "stddev": 0.02639969588744826,
+        "rounds": 3,
+        "median": 0.5057543000002624,
+        "iqr": 0.039355949989840155,
+        "q1": 0.48987432500871364,
+        "q3": 0.5292302749985538,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4845810000115307,
+        "hd15iqr": 0.5370555999979842,
+        "ops": 1.9641337394250522,
+        "total": 1.5273909000097774,
+        "data": [0.5370555999979842, 0.5057543000002624, 0.4845810000115307],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070703131374034
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48628179999650456,
+        "max": 0.5103488999884576,
+        "mean": 0.4986850333273954,
+        "stddev": 0.01205057354693154,
+        "rounds": 3,
+        "median": 0.4994243999972241,
+        "iqr": 0.01805032499396475,
+        "q1": 0.48956744999668445,
+        "q3": 0.5076177749906492,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48628179999650456,
+        "hd15iqr": 0.5103488999884576,
+        "ops": 2.005273736265276,
+        "total": 1.4960550999821862,
+        "data": [0.5103488999884576, 0.4994243999972241, 0.48628179999650456],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.906654381972863
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48792230000253767,
+        "max": 0.5483700000040699,
+        "mean": 0.5245530333340866,
+        "stddev": 0.032196670183601284,
+        "rounds": 3,
+        "median": 0.5373667999956524,
+        "iqr": 0.04533577500114916,
+        "q1": 0.5002834250008164,
+        "q3": 0.5456192000019655,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48792230000253767,
+        "hd15iqr": 0.5483700000040699,
+        "ops": 1.9063849343200772,
+        "total": 1.57365910000226,
+        "data": [0.48792230000253767, 0.5373667999956524, 0.5483700000040699],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9074271126416016
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49038020000443794,
+        "max": 0.5388171000086004,
+        "mean": 0.5135291333378215,
+        "stddev": 0.024289193445175872,
+        "rounds": 3,
+        "median": 0.5113901000004262,
+        "iqr": 0.03632767500312184,
+        "q1": 0.495632675003435,
+        "q3": 0.5319603500065568,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49038020000443794,
+        "hd15iqr": 0.5388171000086004,
+        "ops": 1.9473091886729572,
+        "total": 1.5405874000134645,
+        "data": [0.49038020000443794, 0.5113901000004262, 0.5388171000086004],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9077841141616765
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46687789999123197,
+        "max": 0.4682186999998521,
+        "mean": 0.46773416666352813,
+        "stddev": 0.0007436904064082528,
+        "rounds": 3,
+        "median": 0.46810589999950025,
+        "iqr": 0.0010056000064651016,
+        "q1": 0.46718489999329904,
+        "q3": 0.46819049999976414,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46687789999123197,
+        "hd15iqr": 0.4682186999998521,
+        "ops": 2.137966544401204,
+        "total": 1.4032024999905843,
+        "data": [0.4682186999998521, 0.46810589999950025, 0.46687789999123197],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070605390622348
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4546492999943439,
+        "max": 0.46535230000154115,
+        "mean": 0.45961833333421964,
+        "stddev": 0.005392345921312363,
+        "rounds": 3,
+        "median": 0.4588534000067739,
+        "iqr": 0.008027250005397946,
+        "q1": 0.4557003249974514,
+        "q3": 0.46372757500284933,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4546492999943439,
+        "hd15iqr": 0.46535230000154115,
+        "ops": 2.1757182589860538,
+        "total": 1.378855000002659,
+        "data": [0.4546492999943439, 0.4588534000067739, 0.46535230000154115],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9047151292180988
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4054402000037953,
+        "max": 0.46593760000541806,
+        "mean": 0.425711200000175,
+        "stddev": 0.034837441695313914,
+        "rounds": 3,
+        "median": 0.4057557999913115,
+        "iqr": 0.04537305000121705,
+        "q1": 0.40551910000067437,
+        "q3": 0.4508921500018914,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4054402000037953,
+        "hd15iqr": 0.46593760000541806,
+        "ops": 2.3490103149731296,
+        "total": 1.277133600000525,
+        "data": [0.4054402000037953, 0.4057557999913115, 0.46593760000541806],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9046907886634077
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4045678999973461,
+        "max": 0.40640849999908824,
+        "mean": 0.40564983333266963,
+        "stddev": 0.0009619397569608653,
+        "rounds": 3,
+        "median": 0.4059731000015745,
+        "iqr": 0.001380450001306599,
+        "q1": 0.4049191999984032,
+        "q3": 0.4062996499997098,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4045678999973461,
+        "hd15iqr": 0.40640849999908824,
+        "ops": 2.465180354653097,
+        "total": 1.2169494999980088,
+        "data": [0.4059731000015745, 0.4045678999973461, 0.40640849999908824],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9052425260065369
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4041819999984,
+        "max": 0.4511789999960456,
+        "mean": 0.4256099333336654,
+        "stddev": 0.023770596145645584,
+        "rounds": 3,
+        "median": 0.42146880000655074,
+        "iqr": 0.03524774999823421,
+        "q1": 0.4085037000004377,
+        "q3": 0.4437514499986719,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4041819999984,
+        "hd15iqr": 0.4511789999960456,
+        "ops": 2.349569222145081,
+        "total": 1.2768298000009963,
+        "data": [0.4511789999960456, 0.42146880000655074, 0.4041819999984],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9057196298070953
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3854210999998031,
+        "max": 0.4193832000019029,
+        "mean": 0.40705306666980806,
+        "stddev": 0.01879492316352607,
+        "rounds": 3,
+        "median": 0.41635490000771824,
+        "iqr": 0.02547157500157482,
+        "q1": 0.3931545500017819,
+        "q3": 0.4186261250033567,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3854210999998031,
+        "hd15iqr": 0.4193832000019029,
+        "ops": 2.4566821426533476,
+        "total": 1.2211592000094242,
+        "data": [0.4193832000019029, 0.41635490000771824, 0.3854210999998031],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.904637485078483
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37355240000761114,
+        "max": 0.41195959999458864,
+        "mean": 0.38801900000059203,
+        "stddev": 0.02088290592145538,
+        "rounds": 3,
+        "median": 0.37854499999957625,
+        "iqr": 0.028805399990233127,
+        "q1": 0.3748005500056024,
+        "q3": 0.40360594999583554,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37355240000761114,
+        "hd15iqr": 0.41195959999458864,
+        "ops": 2.5771933848560877,
+        "total": 1.164057000001776,
+        "data": [0.37355240000761114, 0.37854499999957625, 0.41195959999458864],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9050632120201225
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3714102000085404,
+        "max": 0.4377957999968203,
+        "mean": 0.4021750000053241,
+        "stddev": 0.03345814584540605,
+        "rounds": 3,
+        "median": 0.3973190000106115,
+        "iqr": 0.0497891999912099,
+        "q1": 0.3778874000090582,
+        "q3": 0.4276766000002681,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3714102000085404,
+        "hd15iqr": 0.4377957999968203,
+        "ops": 2.4864797662379856,
+        "total": 1.2065250000159722,
+        "data": [0.4377957999968203, 0.3973190000106115, 0.3714102000085404],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9055016256957897
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37037550000241026,
+        "max": 0.38990979999653064,
+        "mean": 0.37950186666663893,
+        "stddev": 0.009830006556659913,
+        "rounds": 3,
+        "median": 0.37822030000097584,
+        "iqr": 0.01465072499559028,
+        "q1": 0.37233670000205166,
+        "q3": 0.38698742499764194,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37037550000241026,
+        "hd15iqr": 0.38990979999653064,
+        "ops": 2.6350331522306254,
+        "total": 1.1385055999999167,
+        "data": [0.37037550000241026, 0.38990979999653064, 0.37822030000097584],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.905330550633594
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39041659999929834,
+        "max": 0.44353409999166615,
+        "mean": 0.4242210333274367,
+        "stddev": 0.029374597566616742,
+        "rounds": 3,
+        "median": 0.4387123999913456,
+        "iqr": 0.03983812499427586,
+        "q1": 0.40249054999731015,
+        "q3": 0.442328674991586,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39041659999929834,
+        "hd15iqr": 0.44353409999166615,
+        "ops": 2.3572617136787417,
+        "total": 1.27266309998231,
+        "data": [0.4387123999913456, 0.44353409999166615, 0.39041659999929834],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9036037719390047
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.38659090000146534,
+        "max": 0.4629166999948211,
+        "mean": 0.4261619999985366,
+        "stddev": 0.038240763824481334,
+        "rounds": 3,
+        "median": 0.4289783999993233,
+        "iqr": 0.05724434999501682,
+        "q1": 0.39718777500092983,
+        "q3": 0.45443212499594665,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.38659090000146534,
+        "hd15iqr": 0.4629166999948211,
+        "ops": 2.346525499700663,
+        "total": 1.2784859999956097,
+        "data": [0.4629166999948211, 0.38659090000146534, 0.4289783999993233],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9025675194688567
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3275545999931637,
+        "max": 0.35196739999810234,
+        "mean": 0.3359243333300886,
+        "stddev": 0.013898065848447475,
+        "rounds": 3,
+        "median": 0.32825099999899976,
+        "iqr": 0.018309600003703963,
+        "q1": 0.32772869999462273,
+        "q3": 0.3460382999983267,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3275545999931637,
+        "hd15iqr": 0.35196739999810234,
+        "ops": 2.9768608605598454,
+        "total": 1.0077729999902658,
+        "data": [0.32825099999899976, 0.35196739999810234, 0.3275545999931637],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9023341492982444
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3417347999929916,
+        "max": 0.3622437000012724,
+        "mean": 0.3548904999964482,
+        "stddev": 0.011419522737969935,
+        "rounds": 3,
+        "median": 0.36069299999508075,
+        "iqr": 0.015381675006210571,
+        "q1": 0.3464743499935139,
+        "q3": 0.36185602499972447,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3417347999929916,
+        "hd15iqr": 0.3622437000012724,
+        "ops": 2.8177705517899407,
+        "total": 1.0646714999893447,
+        "data": [0.3622437000012724, 0.3417347999929916, 0.36069299999508075],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.902201563027947
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37117749999742955,
+        "max": 0.3984375,
+        "mean": 0.3865243666659808,
+        "stddev": 0.013950619824744078,
+        "rounds": 3,
+        "median": 0.3899581000005128,
+        "iqr": 0.020445000001927838,
+        "q1": 0.37587264999820036,
+        "q3": 0.3963176500001282,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37117749999742955,
+        "hd15iqr": 0.3984375,
+        "ops": 2.5871590156802737,
+        "total": 1.1595730999979423,
+        "data": [0.3984375, 0.3899581000005128, 0.37117749999742955],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9022808243372407
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3495404999994207,
+        "max": 0.3804736000020057,
+        "mean": 0.36857743333287846,
+        "stddev": 0.016657042965613416,
+        "rounds": 3,
+        "median": 0.375718199997209,
+        "iqr": 0.023199825001938734,
+        "q1": 0.3560849249988678,
+        "q3": 0.3792847500008065,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3495404999994207,
+        "hd15iqr": 0.3804736000020057,
+        "ops": 2.713134092224404,
+        "total": 1.1057322999986354,
+        "data": [0.3804736000020057, 0.3495404999994207, 0.375718199997209],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.90185249472559
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3489839999965625,
+        "max": 0.4083102000004146,
+        "mean": 0.3826805666612927,
+        "stddev": 0.030474679025120563,
+        "rounds": 3,
+        "median": 0.39074749998690095,
+        "iqr": 0.0444946500028891,
+        "q1": 0.3594248749941471,
+        "q3": 0.4039195249970362,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3489839999965625,
+        "hd15iqr": 0.4083102000004146,
+        "ops": 2.6131454981488296,
+        "total": 1.148041699983878,
+        "data": [0.3489839999965625, 0.39074749998690095, 0.4083102000004146],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9020110338377907
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3980018000002019,
+        "max": 0.4666039000003366,
+        "mean": 0.42173776666944224,
+        "stddev": 0.03887704963688827,
+        "rounds": 3,
+        "median": 0.4006076000077883,
+        "iqr": 0.051451575000101,
+        "q1": 0.3986532500020985,
+        "q3": 0.4501048250021995,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3980018000002019,
+        "hd15iqr": 0.4666039000003366,
+        "ops": 2.371141688109235,
+        "total": 1.2652133000083268,
+        "data": [0.3980018000002019, 0.4006076000077883, 0.4666039000003366],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9008682631535003
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3784020999883069,
+        "max": 0.431461499989382,
+        "mean": 0.40483289999732125,
+        "stddev": 0.026530253028259877,
+        "rounds": 3,
+        "median": 0.40463510001427494,
+        "iqr": 0.03979455000080634,
+        "q1": 0.3849603499947989,
+        "q3": 0.42475489999560523,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3784020999883069,
+        "hd15iqr": 0.431461499989382,
+        "ops": 2.470154970128705,
+        "total": 1.2144986999919638,
+        "data": [0.40463510001427494, 0.3784020999883069, 0.431461499989382],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9015651985996405
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3705692999938037,
+        "max": 0.45023610000498593,
+        "mean": 0.4157842333321848,
+        "stddev": 0.04090944217465221,
+        "rounds": 3,
+        "median": 0.42654729999776464,
+        "iqr": 0.05975010000838665,
+        "q1": 0.38456379999479395,
+        "q3": 0.4443139000031806,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3705692999938037,
+        "hd15iqr": 0.45023610000498593,
+        "ops": 2.405093603443747,
+        "total": 1.2473526999965543,
+        "data": [0.42654729999776464, 0.3705692999938037, 0.45023610000498593],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9014091543388028
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36375540000153705,
+        "max": 0.3861771000083536,
+        "mean": 0.3766410666673134,
+        "stddev": 0.011580077303565644,
+        "rounds": 3,
+        "median": 0.3799906999920495,
+        "iqr": 0.016816275005112402,
+        "q1": 0.36781422499916516,
+        "q3": 0.38463050000427756,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36375540000153705,
+        "hd15iqr": 0.3861771000083536,
+        "ops": 2.6550477058926205,
+        "total": 1.1299232000019401,
+        "data": [0.3799906999920495, 0.36375540000153705, 0.3861771000083536],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.900355742243844
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.39541490000556223,
+        "max": 0.4299291000061203,
+        "mean": 0.4097214000018236,
+        "stddev": 0.017997933813934237,
+        "rounds": 3,
+        "median": 0.40382019999378826,
+        "iqr": 0.025885650000418536,
+        "q1": 0.39751622500261874,
+        "q3": 0.4234018750030373,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.39541490000556223,
+        "hd15iqr": 0.4299291000061203,
+        "ops": 2.4406828640035623,
+        "total": 1.2291642000054708,
+        "data": [0.4299291000061203, 0.39541490000556223, 0.40382019999378826],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8997573034369746
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3781770000059623,
+        "max": 0.4321305999910692,
+        "mean": 0.39866259999689646,
+        "stddev": 0.029225926336410576,
+        "rounds": 3,
+        "median": 0.3856801999936579,
+        "iqr": 0.040465199988830136,
+        "q1": 0.3800528000028862,
+        "q3": 0.42051799999171635,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3781770000059623,
+        "hd15iqr": 0.4321305999910692,
+        "ops": 2.5083867912560267,
+        "total": 1.1959877999906894,
+        "data": [0.3781770000059623, 0.4321305999910692, 0.3856801999936579],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.899888711547925
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.32799610000802204,
+        "max": 0.34353540001029614,
+        "mean": 0.3382610000068477,
+        "stddev": 0.00889079742166382,
+        "rounds": 3,
+        "median": 0.34325150000222493,
+        "iqr": 0.011654475001705578,
+        "q1": 0.33180995000657276,
+        "q3": 0.34346442500827834,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.32799610000802204,
+        "hd15iqr": 0.34353540001029614,
+        "ops": 2.956297060493986,
+        "total": 1.0147830000205431,
+        "data": [0.32799610000802204, 0.34353540001029614, 0.34325150000222493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8987521237522347
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3389932999998564,
+        "max": 0.364205400008359,
+        "mean": 0.3487477000016952,
+        "stddev": 0.013539136601661932,
+        "rounds": 3,
+        "median": 0.3430443999968702,
+        "iqr": 0.018909075006376952,
+        "q1": 0.34000607499910984,
+        "q3": 0.3589151500054868,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3389932999998564,
+        "hd15iqr": 0.364205400008359,
+        "ops": 2.867402422998458,
+        "total": 1.0462431000050856,
+        "data": [0.3389932999998564, 0.3430443999968702, 0.364205400008359],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8972289103399627
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.350035299998126,
+        "max": 0.39115330000640824,
+        "mean": 0.3719160666660173,
+        "stddev": 0.020686074603715382,
+        "rounds": 3,
+        "median": 0.3745595999935176,
+        "iqr": 0.03083850000621169,
+        "q1": 0.3561663749969739,
+        "q3": 0.3870048750031856,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.350035299998126,
+        "hd15iqr": 0.39115330000640824,
+        "ops": 2.6887787047339518,
+        "total": 1.1157481999980519,
+        "data": [0.350035299998126, 0.3745595999935176, 0.39115330000640824],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964312943440584
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33281380000698846,
+        "max": 0.3838151000090875,
+        "mean": 0.3542603000047772,
+        "stddev": 0.026449792952362487,
+        "rounds": 3,
+        "median": 0.34615199999825563,
+        "iqr": 0.03825097500157426,
+        "q1": 0.33614835000480525,
+        "q3": 0.3743993250063795,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33281380000698846,
+        "hd15iqr": 0.3838151000090875,
+        "ops": 2.822783134284353,
+        "total": 1.0627809000143316,
+        "data": [0.33281380000698846, 0.34615199999825563, 0.3838151000090875],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8954554528704495
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.35447049999493174,
+        "max": 0.3683561999932863,
+        "mean": 0.35988593332876917,
+        "stddev": 0.007429816358413542,
+        "rounds": 3,
+        "median": 0.3568310999980895,
+        "iqr": 0.010414274998765904,
+        "q1": 0.3550606499957212,
+        "q3": 0.3654749249944871,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.35447049999493174,
+        "hd15iqr": 0.3683561999932863,
+        "ops": 2.778658200809596,
+        "total": 1.0796577999863075,
+        "data": [0.3683561999932863, 0.35447049999493174, 0.3568310999980895],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962512162955514
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3281857999972999,
+        "max": 0.3815848999947775,
+        "mean": 0.3509276666639683,
+        "stddev": 0.027565480989926453,
+        "rounds": 3,
+        "median": 0.3430122999998275,
+        "iqr": 0.040049324998108204,
+        "q1": 0.3318924249979318,
+        "q3": 0.37194174999604,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3281857999972999,
+        "hd15iqr": 0.3815848999947775,
+        "ops": 2.849590086487973,
+        "total": 1.052782999991905,
+        "data": [0.3815848999947775, 0.3430122999998275, 0.3281857999972999],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8958796544126229
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3482600999996066,
+        "max": 0.3754579999949783,
+        "mean": 0.3645878666623806,
+        "stddev": 0.014396901132346093,
+        "rounds": 3,
+        "median": 0.37004549999255687,
+        "iqr": 0.020398424996528774,
+        "q1": 0.3537064499978442,
+        "q3": 0.37410487499437295,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3482600999996066,
+        "hd15iqr": 0.3754579999949783,
+        "ops": 2.7428230378440714,
+        "total": 1.0937635999871418,
+        "data": [0.37004549999255687, 0.3482600999996066, 0.3754579999949783],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.896494583798872
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33588959999906365,
+        "max": 0.3831280999875162,
+        "mean": 0.35790539999531273,
+        "stddev": 0.0237819706075379,
+        "rounds": 3,
+        "median": 0.3546984999993583,
+        "iqr": 0.0354288749913394,
+        "q1": 0.3405918249991373,
+        "q3": 0.3760206999904767,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33588959999906365,
+        "hd15iqr": 0.3831280999875162,
+        "ops": 2.794034401305754,
+        "total": 1.0737161999859381,
+        "data": [0.3546984999993583, 0.3831280999875162, 0.33588959999906365],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962696471113236
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3408832999994047,
+        "max": 0.43066679999174085,
+        "mean": 0.3789385999989463,
+        "stddev": 0.04642715114442818,
+        "rounds": 3,
+        "median": 0.36526570000569336,
+        "iqr": 0.06733762499425211,
+        "q1": 0.34697890000097686,
+        "q3": 0.414316524995229,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3408832999994047,
+        "hd15iqr": 0.43066679999174085,
+        "ops": 2.6389499512659325,
+        "total": 1.136815799996839,
+        "data": [0.43066679999174085, 0.36526570000569336, 0.3408832999994047],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8960868432486397
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34743979999620933,
+        "max": 0.38363450000179,
+        "mean": 0.3702952333308834,
+        "stddev": 0.01988547580780869,
+        "rounds": 3,
+        "median": 0.37981139999465086,
+        "iqr": 0.027146025004185503,
+        "q1": 0.3555326999958197,
+        "q3": 0.3826787250000052,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34743979999620933,
+        "hd15iqr": 0.38363450000179,
+        "ops": 2.7005478601622546,
+        "total": 1.1108856999926502,
+        "data": [0.37981139999465086, 0.38363450000179, 0.34743979999620933],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8958082403058558
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37609380000503734,
+        "max": 0.37801900001068134,
+        "mean": 0.3769395333365537,
+        "stddev": 0.0009836524904757167,
+        "rounds": 3,
+        "median": 0.3767057999939425,
+        "iqr": 0.0014439000042330008,
+        "q1": 0.3762468000022636,
+        "q3": 0.3776907000064966,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37609380000503734,
+        "hd15iqr": 0.37801900001068134,
+        "ops": 2.652945397232031,
+        "total": 1.1308186000096612,
+        "data": [0.3767057999939425, 0.37609380000503734, 0.37801900001068134],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8967707259192612
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34193260000029113,
+        "max": 0.39477220000117086,
+        "mean": 0.36802663333461777,
+        "stddev": 0.026425824562830463,
+        "rounds": 3,
+        "median": 0.36737510000239126,
+        "iqr": 0.039629700000659795,
+        "q1": 0.34829322500081616,
+        "q3": 0.38792292500147596,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34193260000029113,
+        "hd15iqr": 0.39477220000117086,
+        "ops": 2.7171946522978363,
+        "total": 1.1040799000038533,
+        "data": [0.39477220000117086, 0.36737510000239126, 0.34193260000029113],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964481214942304
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3288375999982236,
+        "max": 0.38657200000307057,
+        "mean": 0.36406300000089686,
+        "stddev": 0.03089652662856211,
+        "rounds": 3,
+        "median": 0.3767794000013964,
+        "iqr": 0.04330080000363523,
+        "q1": 0.3408230499990168,
+        "q3": 0.38412385000265203,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3288375999982236,
+        "hd15iqr": 0.38657200000307057,
+        "ops": 2.7467773434749936,
+        "total": 1.0921890000026906,
+        "data": [0.38657200000307057, 0.3288375999982236, 0.3767794000013964],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8950663017511895
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3533714999939548,
+        "max": 0.3767407999985153,
+        "mean": 0.363402266666526,
+        "stddev": 0.012030670633038561,
+        "rounds": 3,
+        "median": 0.36009450000710785,
+        "iqr": 0.017526975003420375,
+        "q1": 0.35505224999724305,
+        "q3": 0.3725792250006634,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3533714999939548,
+        "hd15iqr": 0.3767407999985153,
+        "ops": 2.751771498766254,
+        "total": 1.090206799999578,
+        "data": [0.3533714999939548, 0.36009450000710785, 0.3767407999985153],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8935404766911959
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33267350000096485,
+        "max": 0.3818396999995457,
+        "mean": 0.3609280666666261,
+        "stddev": 0.025392278511821825,
+        "rounds": 3,
+        "median": 0.36827099999936763,
+        "iqr": 0.03687464999893564,
+        "q1": 0.34157287500056555,
+        "q3": 0.3784475249995012,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33267350000096485,
+        "hd15iqr": 0.3818396999995457,
+        "ops": 2.7706351828927107,
+        "total": 1.0827841999998782,
+        "data": [0.33267350000096485, 0.3818396999995457, 0.36827099999936763],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8939789512158685
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.31433530000504106,
+        "max": 0.35915649999515153,
+        "mean": 0.33495699999912176,
+        "stddev": 0.022623781332457,
+        "rounds": 3,
+        "median": 0.3313791999971727,
+        "iqr": 0.033615899992582854,
+        "q1": 0.31859627500307397,
+        "q3": 0.3522121749956568,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.31433530000504106,
+        "hd15iqr": 0.35915649999515153,
+        "ops": 2.9854578348940968,
+        "total": 1.0048709999973653,
+        "data": [0.3313791999971727, 0.31433530000504106, 0.35915649999515153],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8930363830145307
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3346878000011202,
+        "max": 0.3718778999900678,
+        "mean": 0.35403186666371766,
+        "stddev": 0.01864025113039955,
+        "rounds": 3,
+        "median": 0.355529899999965,
+        "iqr": 0.027892574991710717,
+        "q1": 0.3398983250008314,
+        "q3": 0.3677908999925421,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3346878000011202,
+        "hd15iqr": 0.3718778999900678,
+        "ops": 2.824604489487565,
+        "total": 1.062095599991153,
+        "data": [0.355529899999965, 0.3346878000011202, 0.3718778999900678],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892781757311813
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.318926800013287,
+        "max": 0.3558530000009341,
+        "mean": 0.3378859666700009,
+        "stddev": 0.01848308166361933,
+        "rounds": 3,
+        "median": 0.33887809999578167,
+        "iqr": 0.027694649990735343,
+        "q1": 0.32391462500891066,
+        "q3": 0.351609274999646,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.318926800013287,
+        "hd15iqr": 0.3558530000009341,
+        "ops": 2.9595783744894564,
+        "total": 1.0136579000100028,
+        "data": [0.33887809999578167, 0.318926800013287, 0.3558530000009341],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8915070750472742
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3128065999917453,
+        "max": 0.3908231999957934,
+        "mean": 0.3477951333334204,
+        "stddev": 0.03962477811999543,
+        "rounds": 3,
+        "median": 0.3397556000127224,
+        "iqr": 0.058512450003036065,
+        "q1": 0.3195438499969896,
+        "q3": 0.37805630000002566,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3128065999917453,
+        "hd15iqr": 0.3908231999957934,
+        "ops": 2.875255873811584,
+        "total": 1.0433854000002611,
+        "data": [0.3908231999957934, 0.3128065999917453, 0.3397556000127224],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8918055818729316
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.32508429999870714,
+        "max": 0.35895380000874866,
+        "mean": 0.3456397666692889,
+        "stddev": 0.01805864129023455,
+        "rounds": 3,
+        "median": 0.3528812000004109,
+        "iqr": 0.02540212500753114,
+        "q1": 0.3320335249991331,
+        "q3": 0.3574356500066642,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.32508429999870714,
+        "hd15iqr": 0.35895380000874866,
+        "ops": 2.893185612397455,
+        "total": 1.0369193000078667,
+        "data": [0.32508429999870714, 0.35895380000874866, 0.3528812000004109],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8913835939463415
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33848370000487193,
+        "max": 0.3576805000047898,
+        "mean": 0.3486970333372786,
+        "stddev": 0.009657313889963265,
+        "rounds": 3,
+        "median": 0.3499269000021741,
+        "iqr": 0.014397599999938393,
+        "q1": 0.34134450000419747,
+        "q3": 0.35574210000413586,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33848370000487193,
+        "hd15iqr": 0.3576805000047898,
+        "ops": 2.86781906467425,
+        "total": 1.0460911000118358,
+        "data": [0.3499269000021741, 0.3576805000047898, 0.33848370000487193],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8908067565653373
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34170830000948627,
+        "max": 0.3663821999944048,
+        "mean": 0.35476633333504043,
+        "stddev": 0.012400008815974388,
+        "rounds": 3,
+        "median": 0.3562085000012303,
+        "iqr": 0.0185054249886889,
+        "q1": 0.34533335000742227,
+        "q3": 0.36383877499611117,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34170830000948627,
+        "hd15iqr": 0.3663821999944048,
+        "ops": 2.8187567591302485,
+        "total": 1.0642990000051213,
+        "data": [0.3562085000012303, 0.3663821999944048, 0.34170830000948627],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8912807343209397
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33568999999260996,
+        "max": 0.37777699998696335,
+        "mean": 0.35290386666019913,
+        "stddev": 0.022064160225316494,
+        "rounds": 3,
+        "median": 0.3452446000010241,
+        "iqr": 0.03156524999576504,
+        "q1": 0.3380786499947135,
+        "q3": 0.36964389999047853,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33568999999260996,
+        "hd15iqr": 0.37777699998696335,
+        "ops": 2.8336328798654704,
+        "total": 1.0587115999805974,
+        "data": [0.37777699998696335, 0.3452446000010241, 0.33568999999260996],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.89116891893076
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.316091000000597,
+        "max": 0.3543599999975413,
+        "mean": 0.33272343333131477,
+        "stddev": 0.019619125949470673,
+        "rounds": 3,
+        "median": 0.32771929999580607,
+        "iqr": 0.028701749997708248,
+        "q1": 0.31899807499939925,
+        "q3": 0.3476998249971075,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.316091000000597,
+        "hd15iqr": 0.3543599999975413,
+        "ops": 3.005499161834609,
+        "total": 0.9981702999939444,
+        "data": [0.316091000000597, 0.3543599999975413, 0.32771929999580607],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8915375817885884
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3172054000024218,
+        "max": 0.3746556999976747,
+        "mean": 0.3420386333358086,
+        "stddev": 0.02950551284675961,
+        "rounds": 3,
+        "median": 0.3342548000073293,
+        "iqr": 0.04308772499643965,
+        "q1": 0.3214677500036487,
+        "q3": 0.36455547500008834,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3172054000024218,
+        "hd15iqr": 0.3746556999976747,
+        "ops": 2.9236463444122536,
+        "total": 1.0261159000074258,
+        "data": [0.3172054000024218, 0.3746556999976747, 0.3342548000073293],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891626504624187
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3393588000035379,
+        "max": 0.35880279999400955,
+        "mean": 0.34669456666354864,
+        "stddev": 0.010564071776440337,
+        "rounds": 3,
+        "median": 0.3419220999930985,
+        "iqr": 0.014582999992853729,
+        "q1": 0.33999962500092806,
+        "q3": 0.3545826249937818,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3393588000035379,
+        "hd15iqr": 0.35880279999400955,
+        "ops": 2.8843832472588318,
+        "total": 1.040083699990646,
+        "data": [0.35880279999400955, 0.3393588000035379, 0.3419220999930985],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891574372948497
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.309230300001218,
+        "max": 0.33918769999581855,
+        "mean": 0.3264807666661606,
+        "stddev": 0.015486904951789287,
+        "rounds": 3,
+        "median": 0.3310243000014452,
+        "iqr": 0.022468049995950423,
+        "q1": 0.3146788000012748,
+        "q3": 0.3371468499972252,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.309230300001218,
+        "hd15iqr": 0.33918769999581855,
+        "ops": 3.0629675683852438,
+        "total": 0.9794422999984818,
+        "data": [0.33918769999581855, 0.3310243000014452, 0.309230300001218],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8917726479681403
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.30858849998912774,
+        "max": 0.31627429999934975,
+        "mean": 0.3128427333285799,
+        "stddev": 0.003908384037566276,
+        "rounds": 3,
+        "median": 0.3136653999972623,
+        "iqr": 0.005764350007666508,
+        "q1": 0.3098577249911614,
+        "q3": 0.3156220749988279,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.30858849998912774,
+        "hd15iqr": 0.31627429999934975,
+        "ops": 3.1964942556287417,
+        "total": 0.9385281999857398,
+        "data": [0.3136653999972623, 0.30858849998912774, 0.31627429999934975],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892158864359982
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33100249999552034,
+        "max": 0.34936150000430644,
+        "mean": 0.3380576333341499,
+        "stddev": 0.009889490458182009,
+        "rounds": 3,
+        "median": 0.333808900002623,
+        "iqr": 0.013769250006589573,
+        "q1": 0.331704099997296,
+        "q3": 0.34547335000388557,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33100249999552034,
+        "hd15iqr": 0.34936150000430644,
+        "ops": 2.9580754918542524,
+        "total": 1.0141729000024498,
+        "data": [0.34936150000430644, 0.33100249999552034, 0.333808900002623],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892461681876854
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3121133000095142,
+        "max": 0.3371350000088569,
+        "mean": 0.32173586667340714,
+        "stddev": 0.013473971559918101,
+        "rounds": 3,
+        "median": 0.31595930000185035,
+        "iqr": 0.018766274999507004,
+        "q1": 0.31307480000759824,
+        "q3": 0.33184107500710525,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3121133000095142,
+        "hd15iqr": 0.3371350000088569,
+        "ops": 3.1081396374594945,
+        "total": 0.9652076000202214,
+        "data": [0.3121133000095142, 0.3371350000088569, 0.31595930000185035],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8924984640684357
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34796949999872595,
+        "max": 0.3662772999959998,
+        "mean": 0.35712163333179586,
+        "stddev": 0.009153900510075834,
+        "rounds": 3,
+        "median": 0.3571181000006618,
+        "iqr": 0.013730849997955374,
+        "q1": 0.3502566499992099,
+        "q3": 0.3639874999971653,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34796949999872595,
+        "hd15iqr": 0.3662772999959998,
+        "ops": 2.80016640456759,
+        "total": 1.0713648999953875,
+        "data": [0.3571181000006618, 0.3662772999959998, 0.34796949999872595],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892453606832916
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.30910109999240376,
+        "max": 0.3530553000018699,
+        "mean": 0.3238488666635628,
+        "stddev": 0.025293926266236614,
+        "rounds": 3,
+        "median": 0.3093901999964146,
+        "iqr": 0.03296565000709961,
+        "q1": 0.30917337499340647,
+        "q3": 0.3421390250005061,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.30910109999240376,
+        "hd15iqr": 0.3530553000018699,
+        "ops": 3.0878601191427704,
+        "total": 0.9715465999906883,
+        "data": [0.3093901999964146, 0.3530553000018699, 0.30910109999240376],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892664338627653
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33448020000651013,
+        "max": 0.34385829999519046,
+        "mean": 0.33911076666845474,
+        "stddev": 0.0046901440009796905,
+        "rounds": 3,
+        "median": 0.33899380000366364,
+        "iqr": 0.00703357499151025,
+        "q1": 0.3356086000057985,
+        "q3": 0.34264217499730876,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33448020000651013,
+        "hd15iqr": 0.34385829999519046,
+        "ops": 2.948888971660667,
+        "total": 1.0173323000053642,
+        "data": [0.34385829999519046, 0.33899380000366364, 0.33448020000651013],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892235421425225
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.31283200001053046,
+        "max": 0.3192336000065552,
+        "mean": 0.3152013000071747,
+        "stddev": 0.003509885665388762,
+        "rounds": 3,
+        "median": 0.3135383000044385,
+        "iqr": 0.004801199997018557,
+        "q1": 0.3130085750090075,
+        "q3": 0.31780977500602603,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.31283200001053046,
+        "hd15iqr": 0.3192336000065552,
+        "ops": 3.172575747553191,
+        "total": 0.9456039000215242,
+        "data": [0.31283200001053046, 0.3192336000065552, 0.3135383000044385],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8905702490638328
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.323047800004133,
+        "max": 0.3790995000017574,
+        "mean": 0.35021630000361864,
+        "stddev": 0.028065163730503287,
+        "rounds": 3,
+        "median": 0.34850160000496544,
+        "iqr": 0.04203877499821829,
+        "q1": 0.3294112500043411,
+        "q3": 0.3714500250025594,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.323047800004133,
+        "hd15iqr": 0.3790995000017574,
+        "ops": 2.855378233365116,
+        "total": 1.0506489000108559,
+        "data": [0.3790995000017574, 0.34850160000496544, 0.323047800004133],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.887884254741475
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3119200000073761,
+        "max": 0.3425844000012148,
+        "mean": 0.32653203333999653,
+        "stddev": 0.015382856588379049,
+        "rounds": 3,
+        "median": 0.32509170001139864,
+        "iqr": 0.022998299995379057,
+        "q1": 0.3152129250083817,
+        "q3": 0.3382112250037608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3119200000073761,
+        "hd15iqr": 0.3425844000012148,
+        "ops": 3.062486671740304,
+        "total": 0.9795961000199895,
+        "data": [0.3425844000012148, 0.3119200000073761, 0.32509170001139864],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8882476966484343
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3060140000015963,
+        "max": 0.3221088999998756,
+        "mean": 0.316077933331447,
+        "stddev": 0.008772688673249488,
+        "rounds": 3,
+        "median": 0.32011089999286924,
+        "iqr": 0.012071174998709466,
+        "q1": 0.3095382249994145,
+        "q3": 0.321609399998124,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3060140000015963,
+        "hd15iqr": 0.3221088999998756,
+        "ops": 3.163776697284893,
+        "total": 0.9482337999943411,
+        "data": [0.32011089999286924, 0.3221088999998756, 0.3060140000015963],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8867096588238204
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3041030000022147,
+        "max": 0.33417849999386817,
+        "mean": 0.32265009999779676,
+        "stddev": 0.016219757618390448,
+        "rounds": 3,
+        "median": 0.32966879999730736,
+        "iqr": 0.022556624993740115,
+        "q1": 0.31049445000098785,
+        "q3": 0.33305107499472797,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3041030000022147,
+        "hd15iqr": 0.33417849999386817,
+        "ops": 3.0993326827012564,
+        "total": 0.9679502999933902,
+        "data": [0.33417849999386817, 0.32966879999730736, 0.3041030000022147],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4146555710762847
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.28517840000858996,
+        "max": 0.32843639999919105,
+        "mean": 0.31244240000281326,
+        "stddev": 0.023729165930565066,
+        "rounds": 3,
+        "median": 0.3237124000006588,
+        "iqr": 0.03244349999295082,
+        "q1": 0.2948119000066072,
+        "q3": 0.327255399999558,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.28517840000858996,
+        "hd15iqr": 0.32843639999919105,
+        "ops": 3.2005899327075835,
+        "total": 0.9373272000084398,
+        "data": [0.32843639999919105, 0.28517840000858996, 0.3237124000006588],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5072488684820662
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.28997610000078566,
+        "max": 0.318737500012503,
+        "mean": 0.3049848333369785,
+        "stddev": 0.01442178249213791,
+        "rounds": 3,
+        "median": 0.3062408999976469,
+        "iqr": 0.021571050008788006,
+        "q1": 0.294042300000001,
+        "q3": 0.315613350008789,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.28997610000078566,
+        "hd15iqr": 0.318737500012503,
+        "ops": 3.278851571268455,
+        "total": 0.9149545000109356,
+        "data": [0.318737500012503, 0.3062408999976469, 0.28997610000078566],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.6967365340626168
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.27397530000598636,
+        "max": 0.29263569999602623,
+        "mean": 0.2803975333372364,
+        "stddev": 0.010602897825588126,
+        "rounds": 3,
+        "median": 0.27458160000969656,
+        "iqr": 0.013995299992529908,
+        "q1": 0.2741268750069139,
+        "q3": 0.2881221749994438,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.27397530000598636,
+        "hd15iqr": 0.29263569999602623,
+        "ops": 3.566365181955049,
+        "total": 0.8411926000117091,
+        "data": [0.27397530000598636, 0.27458160000969656, 0.29263569999602623],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.824926408291705
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3405962999968324,
+        "max": 0.36170530000526924,
+        "mean": 0.35012516666999244,
+        "stddev": 0.010702954803622248,
+        "rounds": 3,
+        "median": 0.34807390000787564,
+        "iqr": 0.01583175000632764,
+        "q1": 0.3424656999995932,
+        "q3": 0.35829745000592084,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3405962999968324,
+        "hd15iqr": 0.36170530000526924,
+        "ops": 2.856121453681568,
+        "total": 1.0503755000099773,
+        "data": [0.3405962999968324, 0.36170530000526924, 0.34807390000787564],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.785365986198655
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.32875450000574347,
+        "max": 0.34192730000359006,
+        "mean": 0.33412220000172965,
+        "stddev": 0.006916383016960062,
+        "rounds": 3,
+        "median": 0.33168479999585543,
+        "iqr": 0.009879599998384947,
+        "q1": 0.32948707500327146,
+        "q3": 0.3393666750016564,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.32875450000574347,
+        "hd15iqr": 0.34192730000359006,
+        "ops": 2.992916962700543,
+        "total": 1.002366600005189,
+        "data": [0.34192730000359006, 0.33168479999585543, 0.32875450000574347],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5157875516198314
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3138749000063399,
+        "max": 0.3370206999970833,
+        "mean": 0.3250058333360357,
+        "stddev": 0.011598190285711827,
+        "rounds": 3,
+        "median": 0.324121900004684,
+        "iqr": 0.01735934999305755,
+        "q1": 0.3164366500059259,
+        "q3": 0.33379599999898346,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3138749000063399,
+        "hd15iqr": 0.3370206999970833,
+        "ops": 3.0768678510642684,
+        "total": 0.9750175000081072,
+        "data": [0.3138749000063399, 0.324121900004684, 0.3370206999970833],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5120095522417953
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.30960999999661,
+        "max": 0.35044040001230314,
+        "mean": 0.32909403333906084,
+        "stddev": 0.020478808691830965,
+        "rounds": 3,
+        "median": 0.3272317000082694,
+        "iqr": 0.03062280001176987,
+        "q1": 0.31401542499952484,
+        "q3": 0.3446382250112947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.30960999999661,
+        "hd15iqr": 0.35044040001230314,
+        "ops": 3.0386451855531345,
+        "total": 0.9872821000171825,
+        "data": [0.30960999999661, 0.3272317000082694, 0.35044040001230314],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7064359240363838
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3021371999930125,
+        "max": 0.31425820000004023,
+        "mean": 0.3074039666632113,
+        "stddev": 0.0062144748857677545,
+        "rounds": 3,
+        "median": 0.3058164999965811,
+        "iqr": 0.00909075000527082,
+        "q1": 0.30305702499390463,
+        "q3": 0.31214777499917545,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3021371999930125,
+        "hd15iqr": 0.31425820000004023,
+        "ops": 3.253048458856063,
+        "total": 0.9222118999896338,
+        "data": [0.31425820000004023, 0.3021371999930125, 0.3058164999965811],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8534004244336844
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.32587169999897014,
+        "max": 0.35138540000480134,
+        "mean": 0.33648116666881833,
+        "stddev": 0.013288001638105514,
+        "rounds": 3,
+        "median": 0.3321864000026835,
+        "iqr": 0.019135275004373398,
+        "q1": 0.3274503749998985,
+        "q3": 0.3465856500042719,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.32587169999897014,
+        "hd15iqr": 0.35138540000480134,
+        "ops": 2.971934536188322,
+        "total": 1.009443500006455,
+        "data": [0.32587169999897014, 0.35138540000480134, 0.3321864000026835],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8363354211884506
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3075559999997495,
+        "max": 0.34967260000121314,
+        "mean": 0.3227095666661626,
+        "stddev": 0.023410459759882266,
+        "rounds": 3,
+        "median": 0.3109000999975251,
+        "iqr": 0.03158745000109775,
+        "q1": 0.3083920249991934,
+        "q3": 0.33997947500029113,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3075559999997495,
+        "hd15iqr": 0.34967260000121314,
+        "ops": 3.098761559289262,
+        "total": 0.9681286999984877,
+        "data": [0.34967260000121314, 0.3075559999997495, 0.3109000999975251],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.789400833459141
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3046574000036344,
+        "max": 0.310857099990244,
+        "mean": 0.3082768999981151,
+        "stddev": 0.003227875207029861,
+        "rounds": 3,
+        "median": 0.3093162000004668,
+        "iqr": 0.004649774989957223,
+        "q1": 0.3058221000028425,
+        "q3": 0.3104718749927997,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3046574000036344,
+        "hd15iqr": 0.310857099990244,
+        "ops": 3.2438369530967597,
+        "total": 0.9248306999943452,
+        "data": [0.3093162000004668, 0.3046574000036344, 0.310857099990244],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.5385809862179636
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34399199999461416,
+        "max": 0.35283449999406,
+        "mean": 0.34915736666395486,
+        "stddev": 0.004605277452451595,
+        "rounds": 3,
+        "median": 0.35064560000319034,
+        "iqr": 0.006631874999584397,
+        "q1": 0.3456553999967582,
+        "q3": 0.3522872749963426,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34399199999461416,
+        "hd15iqr": 0.35283449999406,
+        "ops": 2.86403809707514,
+        "total": 1.0474720999918645,
+        "data": [0.35064560000319034, 0.34399199999461416, 0.35283449999406],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5472970571305236
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3020535999967251,
+        "max": 0.31307879999803845,
+        "mean": 0.30656336666531087,
+        "stddev": 0.00577977359789961,
+        "rounds": 3,
+        "median": 0.304557700001169,
+        "iqr": 0.008268900000985013,
+        "q1": 0.30267962499783607,
+        "q3": 0.3109485249988211,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3020535999967251,
+        "hd15iqr": 0.31307879999803845,
+        "ops": 3.261968352180009,
+        "total": 0.9196900999959325,
+        "data": [0.304557700001169, 0.31307879999803845, 0.3020535999967251],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5232791000415031
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.29517959999793675,
+        "max": 0.31632600000011735,
+        "mean": 0.3041126999984651,
+        "stddev": 0.010948166161443944,
+        "rounds": 3,
+        "median": 0.3008324999973411,
+        "iqr": 0.01585980000163545,
+        "q1": 0.29659282499778783,
+        "q3": 0.3124526249994233,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.29517959999793675,
+        "hd15iqr": 0.31632600000011735,
+        "ops": 3.2882546503485295,
+        "total": 0.9123380999953952,
+        "data": [0.29517959999793675, 0.3008324999973411, 0.31632600000011735],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.751653132821788
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.26980519999051467,
+        "max": 0.2759952000051271,
+        "mean": 0.27280603333201725,
+        "stddev": 0.0030992946178237495,
+        "rounds": 3,
+        "median": 0.27261770000040997,
+        "iqr": 0.004642500010959338,
+        "q1": 0.2705083249929885,
+        "q3": 0.27515082500394783,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.26980519999051467,
+        "hd15iqr": 0.2759952000051271,
+        "ops": 3.6656080797998882,
+        "total": 0.8184180999960518,
+        "data": [0.2759952000051271, 0.26980519999051467, 0.27261770000040997],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8733849844872352
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3405186000018148,
+        "max": 0.35706070000014734,
+        "mean": 0.34755146666915,
+        "stddev": 0.008544563299454293,
+        "rounds": 3,
+        "median": 0.3450751000054879,
+        "iqr": 0.01240657499874942,
+        "q1": 0.34165772500273306,
+        "q3": 0.3540643000014825,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3405186000018148,
+        "hd15iqr": 0.35706070000014734,
+        "ops": 2.877271701897162,
+        "total": 1.04265440000745,
+        "data": [0.3450751000054879, 0.35706070000014734, 0.3405186000018148],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8847109439209706
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2997919999907026,
+        "max": 0.3254584999958752,
+        "mean": 0.3125752333289711,
+        "stddev": 0.012833542403756231,
+        "rounds": 3,
+        "median": 0.31247520000033546,
+        "iqr": 0.019249875003879424,
+        "q1": 0.3029627999931108,
+        "q3": 0.32221267499699024,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2997919999907026,
+        "hd15iqr": 0.3254584999958752,
+        "ops": 3.1992297961353384,
+        "total": 0.9377256999869132,
+        "data": [0.31247520000033546, 0.2997919999907026, 0.3254584999958752],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5473588410519943
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.31036309999763034,
+        "max": 0.3262323000089964,
+        "mean": 0.3208393666718621,
+        "stddev": 0.009074033591089445,
+        "rounds": 3,
+        "median": 0.3259227000089595,
+        "iqr": 0.011901900008524535,
+        "q1": 0.31425300000046263,
+        "q3": 0.32615490000898717,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.31036309999763034,
+        "hd15iqr": 0.3262323000089964,
+        "ops": 3.116824504340667,
+        "total": 0.9625181000155862,
+        "data": [0.31036309999763034, 0.3259227000089595, 0.3262323000089964],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5693781702865028
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2835263000015402,
+        "max": 0.299594000010984,
+        "mean": 0.2903931000037119,
+        "stddev": 0.008284247885217318,
+        "rounds": 3,
+        "median": 0.2880589999986114,
+        "iqr": 0.012050775007082848,
+        "q1": 0.284659475000808,
+        "q3": 0.29671025000789086,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2835263000015402,
+        "hd15iqr": 0.299594000010984,
+        "ops": 3.4436079920191554,
+        "total": 0.8711793000111356,
+        "data": [0.2835263000015402, 0.299594000010984, 0.2880589999986114],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.78449177571698
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2862289999902714,
+        "max": 0.29584299999987707,
+        "mean": 0.2910139333301534,
+        "stddev": 0.0048071519488442,
+        "rounds": 3,
+        "median": 0.2909698000003118,
+        "iqr": 0.007210500007204246,
+        "q1": 0.2874141999927815,
+        "q3": 0.29462469999998575,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2862289999902714,
+        "hd15iqr": 0.29584299999987707,
+        "ops": 3.4362615856798393,
+        "total": 0.8730417999904603,
+        "data": [0.29584299999987707, 0.2862289999902714, 0.2909698000003118],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.914559995860679
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.32495889998972416,
+        "max": 0.3603966000082437,
+        "mean": 0.3373282666677066,
+        "stddev": 0.0199952134618635,
+        "rounds": 3,
+        "median": 0.3266293000051519,
+        "iqr": 0.026578275013889652,
+        "q1": 0.3253764999935811,
+        "q3": 0.35195477500747074,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.32495889998972416,
+        "hd15iqr": 0.3603966000082437,
+        "ops": 2.964471403118655,
+        "total": 1.0119848000031197,
+        "data": [0.32495889998972416, 0.3603966000082437, 0.3266293000051519],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9503900960364533
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3047760999907041,
+        "max": 0.3163440999924205,
+        "mean": 0.3124845999943015,
+        "stddev": 0.00667575889255724,
+        "rounds": 3,
+        "median": 0.31633359999977984,
+        "iqr": 0.00867600000128732,
+        "q1": 0.30766547499297303,
+        "q3": 0.31634147499426035,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3047760999907041,
+        "hd15iqr": 0.3163440999924205,
+        "ops": 3.2001577038300004,
+        "total": 0.9374537999829045,
+        "data": [0.3047760999907041, 0.3163440999924205, 0.31633359999977984],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5473588410519943
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3122659000073327,
+        "max": 0.3307616000092821,
+        "mean": 0.32223586667290266,
+        "stddev": 0.00933204624251224,
+        "rounds": 3,
+        "median": 0.32368010000209324,
+        "iqr": 0.013871775001462083,
+        "q1": 0.3151194500060228,
+        "q3": 0.3289912250074849,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3122659000073327,
+        "hd15iqr": 0.3307616000092821,
+        "ops": 3.1033168663843576,
+        "total": 0.966707600018708,
+        "data": [0.3307616000092821, 0.3122659000073327, 0.32368010000209324],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5700271037216975
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.28604220000852365,
+        "max": 0.32707810000283644,
+        "mean": 0.3107879666737669,
+        "stddev": 0.021785535876417378,
+        "rounds": 3,
+        "median": 0.31924360000994056,
+        "iqr": 0.03077692499573459,
+        "q1": 0.2943425500088779,
+        "q3": 0.32511947500461247,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.28604220000852365,
+        "hd15iqr": 0.32707810000283644,
+        "ops": 3.2176277952540446,
+        "total": 0.9323639000213007,
+        "data": [0.32707810000283644, 0.31924360000994056, 0.28604220000852365],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8059417814176282
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2757409000041662,
+        "max": 0.28378329999395646,
+        "mean": 0.27931246666897397,
+        "stddev": 0.0040959198958867545,
+        "rounds": 3,
+        "median": 0.2784132000087993,
+        "iqr": 0.006031799992342712,
+        "q1": 0.27640897500532446,
+        "q3": 0.2824407749976672,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2757409000041662,
+        "hd15iqr": 0.28378329999395646,
+        "ops": 3.580219715667564,
+        "total": 0.837937400006922,
+        "data": [0.2757409000041662, 0.2784132000087993, 0.28378329999395646],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9342465180929453
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3258268999925349,
+        "max": 0.36663960000441875,
+        "mean": 0.3481336666639739,
+        "stddev": 0.020670120248138454,
+        "rounds": 3,
+        "median": 0.35193449999496806,
+        "iqr": 0.030609525008912897,
+        "q1": 0.3323537999931432,
+        "q3": 0.3629633250020561,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3258268999925349,
+        "hd15iqr": 0.36663960000441875,
+        "ops": 2.8724599076630573,
+        "total": 1.0444009999919217,
+        "data": [0.36663960000441875, 0.3258268999925349, 0.35193449999496806],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9576818451879254
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3106143000040902,
+        "max": 0.3138219999964349,
+        "mean": 0.3125829000006585,
+        "stddev": 0.0017237930556156227,
+        "rounds": 3,
+        "median": 0.31331240000145044,
+        "iqr": 0.002405774994258536,
+        "q1": 0.31128882500343025,
+        "q3": 0.3136945999976888,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3106143000040902,
+        "hd15iqr": 0.3138219999964349,
+        "ops": 3.1991513291286675,
+        "total": 0.9377487000019755,
+        "data": [0.31331240000145044, 0.3138219999964349, 0.3106143000040902],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5474496038152028
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3273594000056619,
+        "max": 0.3464918000099715,
+        "mean": 0.33547633333849564,
+        "stddev": 0.009890060875325344,
+        "rounds": 3,
+        "median": 0.3325777999998536,
+        "iqr": 0.014349300003232202,
+        "q1": 0.3286640000042098,
+        "q3": 0.343013300007442,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3273594000056619,
+        "hd15iqr": 0.3464918000099715,
+        "ops": 2.9808362039983307,
+        "total": 1.006429000015487,
+        "data": [0.3325777999998536, 0.3273594000056619, 0.3464918000099715],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5780160598237727
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.29276759999629576,
+        "max": 0.33635090000461787,
+        "mean": 0.31089573333156295,
+        "stddev": 0.022696697404107985,
+        "rounds": 3,
+        "median": 0.3035686999937752,
+        "iqr": 0.032687475006241584,
+        "q1": 0.2954678749956656,
+        "q3": 0.3281553500019072,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.29276759999629576,
+        "hd15iqr": 0.33635090000461787,
+        "ops": 3.216512459929849,
+        "total": 0.9326871999946889,
+        "data": [0.3035686999937752, 0.33635090000461787, 0.29276759999629576],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.824079733686706
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.28956239999388345,
+        "max": 0.30475850000220817,
+        "mean": 0.29714166666478076,
+        "stddev": 0.007598119655979187,
+        "rounds": 3,
+        "median": 0.2971040999982506,
+        "iqr": 0.01139707500624354,
+        "q1": 0.29144782499497524,
+        "q3": 0.3028449000012188,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.28956239999388345,
+        "hd15iqr": 0.30475850000220817,
+        "ops": 3.365398098571434,
+        "total": 0.8914249999943422,
+        "data": [0.2971040999982506, 0.28956239999388345, 0.30475850000220817],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.949569476804978
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3318662000092445,
+        "max": 0.36248490000434685,
+        "mean": 0.3462677000061376,
+        "stddev": 0.01538989188456517,
+        "rounds": 3,
+        "median": 0.34445200000482146,
+        "iqr": 0.02296402499632677,
+        "q1": 0.33501265000813873,
+        "q3": 0.3579766750044655,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3318662000092445,
+        "hd15iqr": 0.36248490000434685,
+        "ops": 2.8879390136078964,
+        "total": 1.0388031000184128,
+        "data": [0.36248490000434685, 0.34445200000482146, 0.3318662000092445],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9665460171921185
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2916473999939626,
+        "max": 0.3065896999905817,
+        "mean": 0.2973730999947293,
+        "stddev": 0.008059644494579667,
+        "rounds": 3,
+        "median": 0.2938821999996435,
+        "iqr": 0.011206724997464335,
+        "q1": 0.29220609999538283,
+        "q3": 0.30341282499284716,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2916473999939626,
+        "hd15iqr": 0.3065896999905817,
+        "ops": 3.362778946776707,
+        "total": 0.8921192999841878,
+        "data": [0.3065896999905817, 0.2938821999996435, 0.2916473999939626],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5503210875437177
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.31808189999719616,
+        "max": 0.3388252000004286,
+        "mean": 0.3263539333323327,
+        "stddev": 0.010990736744845776,
+        "rounds": 3,
+        "median": 0.3221546999993734,
+        "iqr": 0.015557475002424326,
+        "q1": 0.31910009999774047,
+        "q3": 0.3346575750001648,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.31808189999719616,
+        "hd15iqr": 0.3388252000004286,
+        "ops": 3.064157952040615,
+        "total": 0.9790617999969982,
+        "data": [0.31808189999719616, 0.3388252000004286, 0.3221546999993734],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5830837307098642
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3041150000062771,
+        "max": 0.33452519999991637,
+        "mean": 0.3184155333340944,
+        "stddev": 0.01528560723325358,
+        "rounds": 3,
+        "median": 0.31660639999608975,
+        "iqr": 0.02280764999522944,
+        "q1": 0.3072378500037303,
+        "q3": 0.3300454999989597,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3041150000062771,
+        "hd15iqr": 0.33452519999991637,
+        "ops": 3.1405503039663576,
+        "total": 0.9552466000022832,
+        "data": [0.31660639999608975, 0.33452519999991637, 0.3041150000062771],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8389544520809327
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.26932229999511037,
+        "max": 0.2807316999969771,
+        "mean": 0.27312583333211177,
+        "stddev": 0.006586873776898121,
+        "rounds": 3,
+        "median": 0.26932350000424776,
+        "iqr": 0.008557050001400057,
+        "q1": 0.2693225999973947,
+        "q3": 0.2778796499987948,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.26932229999511037,
+        "hd15iqr": 0.2807316999969771,
+        "ops": 3.661316060074163,
+        "total": 0.8193774999963352,
+        "data": [0.2807316999969771, 0.26932350000424776, 0.26932229999511037],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9548133122157656
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3360945000022184,
+        "max": 0.3613403999916045,
+        "mean": 0.34474173332758556,
+        "stddev": 0.014379076315006746,
+        "rounds": 3,
+        "median": 0.33679029998893384,
+        "iqr": 0.018934424992039567,
+        "q1": 0.33626844999889727,
+        "q3": 0.35520287499093683,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3360945000022184,
+        "hd15iqr": 0.3613403999916045,
+        "ops": 2.900722202524187,
+        "total": 1.0342251999827567,
+        "data": [0.3613403999916045, 0.3360945000022184, 0.33679029998893384],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.965435006686164
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2948266000021249,
+        "max": 0.33526430001074914,
+        "mean": 0.3179325666715158,
+        "stddev": 0.02082806336196909,
+        "rounds": 3,
+        "median": 0.3237068000016734,
+        "iqr": 0.030328275006468175,
+        "q1": 0.30204665000201203,
+        "q3": 0.3323749250084802,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2948266000021249,
+        "hd15iqr": 0.33526430001074914,
+        "ops": 3.1453210675117416,
+        "total": 0.9537977000145474,
+        "data": [0.3237068000016734, 0.33526430001074914, 0.2948266000021249],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5515114379461599
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.30687669999315403,
+        "max": 0.33690130000468343,
+        "mean": 0.3250196333344017,
+        "stddev": 0.015961570934804447,
+        "rounds": 3,
+        "median": 0.3312809000053676,
+        "iqr": 0.02251845000864705,
+        "q1": 0.3129777499962074,
+        "q3": 0.3354962000048545,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.30687669999315403,
+        "hd15iqr": 0.33690130000468343,
+        "ops": 3.076737210429174,
+        "total": 0.975058900003205,
+        "data": [0.30687669999315403, 0.33690130000468343, 0.3312809000053676],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5896409275733376
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2833629000087967,
+        "max": 0.32070240000030026,
+        "mean": 0.30535566667094827,
+        "stddev": 0.019536808444558837,
+        "rounds": 3,
+        "median": 0.31200170000374783,
+        "iqr": 0.028004624993627658,
+        "q1": 0.2905226000075345,
+        "q3": 0.31852722500116215,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2833629000087967,
+        "hd15iqr": 0.32070240000030026,
+        "ops": 3.2748696328521114,
+        "total": 0.9160670000128448,
+        "data": [0.31200170000374783, 0.2833629000087967, 0.32070240000030026],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8508621854410627
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2813927000097465,
+        "max": 0.31995679999818094,
+        "mean": 0.29536793333439465,
+        "stddev": 0.021360813689387873,
+        "rounds": 3,
+        "median": 0.2847542999952566,
+        "iqr": 0.028923074991325848,
+        "q1": 0.282233100006124,
+        "q3": 0.31115617499744985,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2813927000097465,
+        "hd15iqr": 0.31995679999818094,
+        "ops": 3.385607871210145,
+        "total": 0.886103800003184,
+        "data": [0.2847542999952566, 0.31995679999818094, 0.2813927000097465],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9608458940436502
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34727299999212846,
+        "max": 0.3731100000004517,
+        "mean": 0.3596532999993845,
+        "stddev": 0.012952089409339756,
+        "rounds": 3,
+        "median": 0.3585769000055734,
+        "iqr": 0.019377750006242422,
+        "q1": 0.3500989749954897,
+        "q3": 0.3694767250017321,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34727299999212846,
+        "hd15iqr": 0.3731100000004517,
+        "ops": 2.7804555109092877,
+        "total": 1.0789598999981536,
+        "data": [0.34727299999212846, 0.3731100000004517, 0.3585769000055734],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.974728852460541
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.296008500008611,
+        "max": 0.32455220000701956,
+        "mean": 0.31011646667320747,
+        "stddev": 0.014274672523104468,
+        "rounds": 3,
+        "median": 0.30978870000399183,
+        "iqr": 0.021407774998806417,
+        "q1": 0.2994535500074562,
+        "q3": 0.32086132500626263,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.296008500008611,
+        "hd15iqr": 0.32455220000701956,
+        "ops": 3.224594974680185,
+        "total": 0.9303494000196224,
+        "data": [0.32455220000701956, 0.30978870000399183, 0.296008500008611],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5588332775958256
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3036125000071479,
+        "max": 0.3916758999985177,
+        "mean": 0.34393766666956554,
+        "stddev": 0.04449725578686692,
+        "rounds": 3,
+        "median": 0.3365246000030311,
+        "iqr": 0.06604754999352735,
+        "q1": 0.3118405250061187,
+        "q3": 0.37788807499964605,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3036125000071479,
+        "hd15iqr": 0.3916758999985177,
+        "ops": 2.9075035883195057,
+        "total": 1.0318130000086967,
+        "data": [0.3365246000030311, 0.3916758999985177, 0.3036125000071479],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5947108093502524
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3093312999990303,
+        "max": 0.32008189999032766,
+        "mean": 0.31338606666152674,
+        "stddev": 0.00584168425157668,
+        "rounds": 3,
+        "median": 0.3107449999952223,
+        "iqr": 0.008062949993473012,
+        "q1": 0.3096847249980783,
+        "q3": 0.3177476749915513,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3093312999990303,
+        "hd15iqr": 0.32008189999032766,
+        "ops": 3.19095233126638,
+        "total": 0.9401581999845803,
+        "data": [0.3107449999952223, 0.32008189999032766, 0.3093312999990303],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8626855575580636
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.27076620000298135,
+        "max": 0.30288390000350773,
+        "mean": 0.2871524000026208,
+        "stddev": 0.01606885613219647,
+        "rounds": 3,
+        "median": 0.28780710000137333,
+        "iqr": 0.024088275000394788,
+        "q1": 0.27502642500257934,
+        "q3": 0.29911470000297413,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.27076620000298135,
+        "hd15iqr": 0.30288390000350773,
+        "ops": 3.4824713287817657,
+        "total": 0.8614572000078624,
+        "data": [0.27076620000298135, 0.30288390000350773, 0.28780710000137333],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9660083270566964
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3298734999989392,
+        "max": 0.34356550000666175,
+        "mean": 0.3348108333351168,
+        "stddev": 0.007602416812951556,
+        "rounds": 3,
+        "median": 0.3309934999997495,
+        "iqr": 0.010269000005791895,
+        "q1": 0.3301534999991418,
+        "q3": 0.3404225000049337,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3298734999989392,
+        "hd15iqr": 0.34356550000666175,
+        "ops": 2.9867611810490198,
+        "total": 1.0044325000053504,
+        "data": [0.3298734999989392, 0.34356550000666175, 0.3309934999997495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.0223507592307657
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3078036999941105,
+        "max": 0.3107145000103628,
+        "mean": 0.30973779999961454,
+        "stddev": 0.0016750075361389916,
+        "rounds": 3,
+        "median": 0.31069519999437034,
+        "iqr": 0.002183100012189243,
+        "q1": 0.30852657499417546,
+        "q3": 0.3107096750063647,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3078036999941105,
+        "hd15iqr": 0.3107145000103628,
+        "ops": 3.2285371691838853,
+        "total": 0.9292133999988437,
+        "data": [0.31069519999437034, 0.3107145000103628, 0.3078036999941105],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.883058109676938
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.308763099994394,
+        "max": 0.3205154999886872,
+        "mean": 0.3141921999922488,
+        "stddev": 0.005927007814619963,
+        "rounds": 3,
+        "median": 0.31329799999366514,
+        "iqr": 0.00881429999571992,
+        "q1": 0.3098968249942118,
+        "q3": 0.3187111249899317,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.308763099994394,
+        "hd15iqr": 0.3205154999886872,
+        "ops": 3.18276519921459,
+        "total": 0.9425765999767464,
+        "data": [0.31329799999366514, 0.3205154999886872, 0.308763099994394],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8822810224125162
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.31102520000422373,
+        "max": 0.35131149999506306,
+        "mean": 0.32954993333260063,
+        "stddev": 0.020337264055483487,
+        "rounds": 3,
+        "median": 0.3263130999985151,
+        "iqr": 0.030214724993129494,
+        "q1": 0.3148471750027966,
+        "q3": 0.34506189999592607,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.31102520000422373,
+        "hd15iqr": 0.35131149999506306,
+        "ops": 3.0344415181257003,
+        "total": 0.9886497999978019,
+        "data": [0.31102520000422373, 0.35131149999506306, 0.3263130999985151],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.5522092047796592
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8098891000117874,
+        "max": 0.8430467999860412,
+        "mean": 0.8222850333307482,
+        "stddev": 0.018092778737776087,
+        "rounds": 3,
+        "median": 0.813919199994416,
+        "iqr": 0.02486827498069033,
+        "q1": 0.8108966250074445,
+        "q3": 0.8357648999881349,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8098891000117874,
+        "hd15iqr": 0.8430467999860412,
+        "ops": 1.2161233142592898,
+        "total": 2.4668550999922445,
+        "data": [0.8098891000117874, 0.8430467999860412, 0.813919199994416],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.5630618096719429
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7855966999923112,
+        "max": 0.7993721999955596,
+        "mean": 0.7918206666654442,
+        "stddev": 0.0069830455394779825,
+        "rounds": 3,
+        "median": 0.7904931000084616,
+        "iqr": 0.01033162500243634,
+        "q1": 0.7868207999963488,
+        "q3": 0.7971524249987851,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7855966999923112,
+        "hd15iqr": 0.7993721999955596,
+        "ops": 1.2629122250764828,
+        "total": 2.3754619999963325,
+        "data": [0.7904931000084616, 0.7855966999923112, 0.7993721999955596],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.5765173557011671
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7930011999997078,
+        "max": 0.8330818999966141,
+        "mean": 0.8180423666684268,
+        "stddev": 0.021832089459539312,
+        "rounds": 3,
+        "median": 0.8280440000089584,
+        "iqr": 0.03006052499767975,
+        "q1": 0.8017619000020204,
+        "q3": 0.8318224249997002,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7930011999997078,
+        "hd15iqr": 0.8330818999966141,
+        "ops": 1.222430574192162,
+        "total": 2.4541271000052802,
+        "data": [0.8280440000089584, 0.8330818999966141, 0.7930011999997078],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.5741927787346468
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7853813999972772,
+        "max": 0.8188549000042258,
+        "mean": 0.8037606666669793,
+        "stddev": 0.016976819009322835,
+        "rounds": 3,
+        "median": 0.8070456999994349,
+        "iqr": 0.02510512500521145,
+        "q1": 0.7907974749978166,
+        "q3": 0.8159026000030281,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7853813999972772,
+        "hd15iqr": 0.8188549000042258,
+        "ops": 1.2441514513851275,
+        "total": 2.411282000000938,
+        "data": [0.8070456999994349, 0.8188549000042258, 0.7853813999972772],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.583661725145473
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7895636000030208,
+        "max": 0.8048099000006914,
+        "mean": 0.7974338666681433,
+        "stddev": 0.007635156569777278,
+        "rounds": 3,
+        "median": 0.7979281000007177,
+        "iqr": 0.011434724998252932,
+        "q1": 0.791654725002445,
+        "q3": 0.803089450000698,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7895636000030208,
+        "hd15iqr": 0.8048099000006914,
+        "ops": 1.2540224861256812,
+        "total": 2.39230160000443,
+        "data": [0.7895636000030208, 0.8048099000006914, 0.7979281000007177],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.5888087160683988
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7890096000046469,
+        "max": 0.8269367999891983,
+        "mean": 0.8071677666642548,
+        "stddev": 0.01901484402321398,
+        "rounds": 3,
+        "median": 0.8055568999989191,
+        "iqr": 0.028445399988413556,
+        "q1": 0.793146425003215,
+        "q3": 0.8215918249916285,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7890096000046469,
+        "hd15iqr": 0.8269367999891983,
+        "ops": 1.2388998189715308,
+        "total": 2.4215032999927644,
+        "data": [0.8055568999989191, 0.8269367999891983, 0.7890096000046469],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.5900567419229639
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.778158799992525,
+        "max": 0.810938000009628,
+        "mean": 0.7936005000034735,
+        "stddev": 0.016471628081543076,
+        "rounds": 3,
+        "median": 0.7917047000082675,
+        "iqr": 0.024584400012827246,
+        "q1": 0.7815452749964606,
+        "q3": 0.8061296750092879,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.778158799992525,
+        "hd15iqr": 0.810938000009628,
+        "ops": 1.2600798512546592,
+        "total": 2.3808015000104206,
+        "data": [0.810938000009628, 0.778158799992525, 0.7917047000082675],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.5909385822648898
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7956108000071254,
+        "max": 0.8166193000070052,
+        "mean": 0.8040076666705621,
+        "stddev": 0.011120362478001886,
+        "rounds": 3,
+        "median": 0.7997928999975557,
+        "iqr": 0.015756374999909895,
+        "q1": 0.7966563250047329,
+        "q3": 0.8124127000046428,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7956108000071254,
+        "hd15iqr": 0.8166193000070052,
+        "ops": 1.2437692343669464,
+        "total": 2.4120230000116862,
+        "data": [0.8166193000070052, 0.7997928999975557, 0.7956108000071254],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.5911952391819908
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7753883000114001,
+        "max": 0.8166038999916054,
+        "mean": 0.7976178000050519,
+        "stddev": 0.02079834496147731,
+        "rounds": 3,
+        "median": 0.8008612000121502,
+        "iqr": 0.030911699985153973,
+        "q1": 0.7817565250115877,
+        "q3": 0.8126682249967416,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7753883000114001,
+        "hd15iqr": 0.8166038999916054,
+        "ops": 1.2537333043390784,
+        "total": 2.392853400015156,
+        "data": [0.7753883000114001, 0.8166038999916054, 0.8008612000121502],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.5145256633145638
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5996689000021433,
+        "max": 0.6251803000050131,
+        "mean": 0.612804166667047,
+        "stddev": 0.012772630703291172,
+        "rounds": 3,
+        "median": 0.6135632999939844,
+        "iqr": 0.019133550002152333,
+        "q1": 0.6031425000001036,
+        "q3": 0.6222760500022559,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5996689000021433,
+        "hd15iqr": 0.6251803000050131,
+        "ops": 1.6318426903636363,
+        "total": 1.8384125000011409,
+        "data": [0.6135632999939844, 0.6251803000050131, 0.5996689000021433],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.5261154545978521
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6010187000065343,
+        "max": 0.6061173000052804,
+        "mean": 0.6029541333409725,
+        "stddev": 0.0027621418018918312,
+        "rounds": 3,
+        "median": 0.6017264000111027,
+        "iqr": 0.0038239499990595505,
+        "q1": 0.6011956250076764,
+        "q3": 0.605019575006736,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6010187000065343,
+        "hd15iqr": 0.6061173000052804,
+        "ops": 1.6585009451033927,
+        "total": 1.8088624000229174,
+        "data": [0.6010187000065343, 0.6061173000052804, 0.6017264000111027],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.5386010705594535
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5902502999961143,
+        "max": 0.6158387000032235,
+        "mean": 0.6068521666650971,
+        "stddev": 0.014393975477122171,
+        "rounds": 3,
+        "median": 0.6144674999959534,
+        "iqr": 0.01919130000533187,
+        "q1": 0.5963045999960741,
+        "q3": 0.615495900001406,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5902502999961143,
+        "hd15iqr": 0.6158387000032235,
+        "ops": 1.647847787205593,
+        "total": 1.8205564999952912,
+        "data": [0.6158387000032235, 0.5902502999961143, 0.6144674999959534],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.53970521271019
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5853147000016179,
+        "max": 0.6007742000074359,
+        "mean": 0.5920168333347343,
+        "stddev": 0.007932025161809431,
+        "rounds": 3,
+        "median": 0.5899615999951493,
+        "iqr": 0.011594625004363479,
+        "q1": 0.5864764250000007,
+        "q3": 0.5980710500043642,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5853147000016179,
+        "hd15iqr": 0.6007742000074359,
+        "ops": 1.689141158988948,
+        "total": 1.776050500004203,
+        "data": [0.6007742000074359, 0.5899615999951493, 0.5853147000016179],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.5493503572526899
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5934033000085037,
+        "max": 0.6188717000040924,
+        "mean": 0.6051165000050484,
+        "stddev": 0.012856405897119191,
+        "rounds": 3,
+        "median": 0.603074500002549,
+        "iqr": 0.019101299996691523,
+        "q1": 0.595821100007015,
+        "q3": 0.6149224000037066,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5934033000085037,
+        "hd15iqr": 0.6188717000040924,
+        "ops": 1.6525743389771343,
+        "total": 1.8153495000151452,
+        "data": [0.603074500002549, 0.6188717000040924, 0.5934033000085037],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.5537069771807088
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5851240000047255,
+        "max": 0.6034704000048805,
+        "mean": 0.592195266673419,
+        "stddev": 0.00986924360983003,
+        "rounds": 3,
+        "median": 0.587991400010651,
+        "iqr": 0.013759800000116229,
+        "q1": 0.5858408500062069,
+        "q3": 0.5996006500063231,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5851240000047255,
+        "hd15iqr": 0.6034704000048805,
+        "ops": 1.6886322067674937,
+        "total": 1.776585800020257,
+        "data": [0.587991400010651, 0.5851240000047255, 0.6034704000048805],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.5548775911094823
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5806587999977637,
+        "max": 0.6019904000131646,
+        "mean": 0.5902853000055378,
+        "stddev": 0.01081664103471147,
+        "rounds": 3,
+        "median": 0.588206700005685,
+        "iqr": 0.01599870001155068,
+        "q1": 0.582545774999744,
+        "q3": 0.5985444750112947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5806587999977637,
+        "hd15iqr": 0.6019904000131646,
+        "ops": 1.694096058279985,
+        "total": 1.7708559000166133,
+        "data": [0.6019904000131646, 0.5806587999977637, 0.588206700005685],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.5555508596017438
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5867748000018764,
+        "max": 0.5940320999943651,
+        "mean": 0.5894923000014387,
+        "stddev": 0.003956979118545525,
+        "rounds": 3,
+        "median": 0.5876700000080746,
+        "iqr": 0.005442974994366523,
+        "q1": 0.586998600003426,
+        "q3": 0.5924415749977925,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5867748000018764,
+        "hd15iqr": 0.5940320999943651,
+        "ops": 1.6963749992961052,
+        "total": 1.7684769000043161,
+        "data": [0.5867748000018764, 0.5876700000080746, 0.5940320999943651],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.5558622154445352
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5863747999974294,
+        "max": 0.6077000999939628,
+        "mean": 0.5981841666653054,
+        "stddev": 0.010846058378351868,
+        "rounds": 3,
+        "median": 0.600477600004524,
+        "iqr": 0.015993974997400073,
+        "q1": 0.589900499999203,
+        "q3": 0.6058944749966031,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5863747999974294,
+        "hd15iqr": 0.6077000999939628,
+        "ops": 1.6717259595396774,
+        "total": 1.7945524999959162,
+        "data": [0.6077000999939628, 0.5863747999974294, 0.600477600004524],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.5497945705982994
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.45690509999985807,
+        "max": 0.48311280000780243,
+        "mean": 0.46985750000264187,
+        "stddev": 0.013106475355151045,
+        "rounds": 3,
+        "median": 0.46955460000026505,
+        "iqr": 0.019655775005958276,
+        "q1": 0.4600674749999598,
+        "q3": 0.4797232500059181,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.45690509999985807,
+        "hd15iqr": 0.48311280000780243,
+        "ops": 2.1283048583759485,
+        "total": 1.4095725000079256,
+        "data": [0.46955460000026505, 0.45690509999985807, 0.48311280000780243],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.5527473365202165
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4536281000036979,
+        "max": 0.5191043000086211,
+        "mean": 0.47632163333764765,
+        "stddev": 0.037073752850847345,
+        "rounds": 3,
+        "median": 0.456232500000624,
+        "iqr": 0.04910715000369237,
+        "q1": 0.45427920000292943,
+        "q3": 0.5033863500066218,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4536281000036979,
+        "hd15iqr": 0.5191043000086211,
+        "ops": 2.099421756246656,
+        "total": 1.428964900012943,
+        "data": [0.5191043000086211, 0.4536281000036979, 0.456232500000624],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.5984026031244365
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.476322499991511,
+        "max": 0.56132210000942,
+        "mean": 0.524379466670022,
+        "stddev": 0.04357613228569991,
+        "rounds": 3,
+        "median": 0.5354938000091352,
+        "iqr": 0.06374970001343172,
+        "q1": 0.49111532499591704,
+        "q3": 0.5548650250093488,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.476322499991511,
+        "hd15iqr": 0.56132210000942,
+        "ops": 1.9070159370471178,
+        "total": 1.573138400010066,
+        "data": [0.5354938000091352, 0.56132210000942, 0.476322499991511],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.6253039070331066
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4979680000105873,
+        "max": 0.5382801999949152,
+        "mean": 0.5129576666658977,
+        "stddev": 0.022053218975164723,
+        "rounds": 3,
+        "median": 0.5026247999921907,
+        "iqr": 0.030234149988245917,
+        "q1": 0.4991322000059881,
+        "q3": 0.529366349994234,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4979680000105873,
+        "hd15iqr": 0.5382801999949152,
+        "ops": 1.9494786119481577,
+        "total": 1.5388729999976931,
+        "data": [0.4979680000105873, 0.5026247999921907, 0.5382801999949152],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.6536231064204858
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5028751999925589,
+        "max": 0.5325072999985423,
+        "mean": 0.5129536999981307,
+        "stddev": 0.016936601714196083,
+        "rounds": 3,
+        "median": 0.5034786000032909,
+        "iqr": 0.02222407500448753,
+        "q1": 0.5030260499952419,
+        "q3": 0.5252501249997295,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5028751999925589,
+        "hd15iqr": 0.5325072999985423,
+        "ops": 1.9494936872541209,
+        "total": 1.5388610999943921,
+        "data": [0.5034786000032909, 0.5028751999925589, 0.5325072999985423],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.657530342229662
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48439589999907184,
+        "max": 0.5108932999864919,
+        "mean": 0.49503216665956035,
+        "stddev": 0.014000088402753493,
+        "rounds": 3,
+        "median": 0.48980729999311734,
+        "iqr": 0.01987304999056505,
+        "q1": 0.4857487499975832,
+        "q3": 0.5056217999881483,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48439589999907184,
+        "hd15iqr": 0.5108932999864919,
+        "ops": 2.0200707496402193,
+        "total": 1.485096499978681,
+        "data": [0.48980729999311734, 0.48439589999907184, 0.5108932999864919],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.6605454258867216
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.45851959999708924,
+        "max": 0.5102764000039315,
+        "mean": 0.48955040000146255,
+        "stddev": 0.027373952291302447,
+        "rounds": 3,
+        "median": 0.4998552000033669,
+        "iqr": 0.03881760000513168,
+        "q1": 0.46885349999865866,
+        "q3": 0.5076711000037903,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.45851959999708924,
+        "hd15iqr": 0.5102764000039315,
+        "ops": 2.0426905993683437,
+        "total": 1.4686512000043876,
+        "data": [0.45851959999708924, 0.4998552000033669, 0.5102764000039315],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.6612631122270756
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4938770000007935,
+        "max": 0.512329300006968,
+        "mean": 0.5043663000008868,
+        "stddev": 0.00948200862814813,
+        "rounds": 3,
+        "median": 0.5068925999948988,
+        "iqr": 0.013839225004630862,
+        "q1": 0.4971308999993198,
+        "q3": 0.5109701250039507,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4938770000007935,
+        "hd15iqr": 0.512329300006968,
+        "ops": 1.9826859962654957,
+        "total": 1.5130989000026602,
+        "data": [0.512329300006968, 0.4938770000007935, 0.5068925999948988],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.6612631122270756
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48093869999866,
+        "max": 0.519131599998218,
+        "mean": 0.501392966665056,
+        "stddev": 0.019240722462903703,
+        "rounds": 3,
+        "median": 0.5041085999982897,
+        "iqr": 0.028644674999668496,
+        "q1": 0.48673117499856744,
+        "q3": 0.5153758499982359,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48093869999866,
+        "hd15iqr": 0.519131599998218,
+        "ops": 1.9944436130633383,
+        "total": 1.5041788999951677,
+        "data": [0.519131599998218, 0.5041085999982897, 0.48093869999866],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {
+        "compression_ratio": 1.6632745632720636
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47397609999461565,
+        "max": 0.5019174999906681,
+        "mean": 0.491170466664092,
+        "stddev": 0.015045150011239669,
+        "rounds": 3,
+        "median": 0.4976178000069922,
+        "iqr": 0.020956049997039372,
+        "q1": 0.4798865249977098,
+        "q3": 0.5008425749947492,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47397609999461565,
+        "hd15iqr": 0.5019174999906681,
+        "ops": 2.035953030302803,
+        "total": 1.473511399992276,
+        "data": [0.47397609999461565, 0.5019174999906681, 0.4976178000069922],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {
+        "compression_ratio": 1.6647573717208248
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.46022870000160765,
+        "max": 0.4917841000133194,
+        "mean": 0.48067786666797474,
+        "stddev": 0.017731430279466682,
+        "rounds": 3,
+        "median": 0.49002079998899717,
+        "iqr": 0.023666550008783815,
+        "q1": 0.46767672499845503,
+        "q3": 0.49134327500723884,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.46022870000160765,
+        "hd15iqr": 0.4917841000133194,
+        "ops": 2.080395352779461,
+        "total": 1.4420336000039242,
+        "data": [0.4917841000133194, 0.49002079998899717, 0.46022870000160765],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {
+        "compression_ratio": 1.6647573717208248
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.462164099997608,
+        "max": 0.5379945000022417,
+        "mean": 0.4915257666677159,
+        "stddev": 0.04070689362517504,
+        "rounds": 3,
+        "median": 0.474418700003298,
+        "iqr": 0.05687280000347528,
+        "q1": 0.4652277499990305,
+        "q3": 0.5221005500025058,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.462164099997608,
+        "hd15iqr": 0.5379945000022417,
+        "ops": 2.034481339156378,
+        "total": 1.4745773000031477,
+        "data": [0.474418700003298, 0.5379945000022417, 0.462164099997608],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {
+        "compression_ratio": 1.6711665859867475
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4900995000061812,
+        "max": 0.5238379999937024,
+        "mean": 0.5063838333347425,
+        "stddev": 0.016899644311868696,
+        "rounds": 3,
+        "median": 0.5052140000043437,
+        "iqr": 0.025303874990640907,
+        "q1": 0.4938781250057218,
+        "q3": 0.5191819999963627,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4900995000061812,
+        "hd15iqr": 0.5238379999937024,
+        "ops": 1.9747865831628064,
+        "total": 1.5191515000042273,
+        "data": [0.5238379999937024, 0.5052140000043437, 0.4900995000061812],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {
+        "compression_ratio": 1.6733412427074634
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4784607000037795,
+        "max": 0.5057957999961218,
+        "mean": 0.49246353333486087,
+        "stddev": 0.013679881857744368,
+        "rounds": 3,
+        "median": 0.4931341000046814,
+        "iqr": 0.02050132499425672,
+        "q1": 0.48212905000400497,
+        "q3": 0.5026303749982617,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4784607000037795,
+        "hd15iqr": 0.5057957999961218,
+        "ops": 2.0306072070518755,
+        "total": 1.4773906000045827,
+        "data": [0.4784607000037795, 0.5057957999961218, 0.4931341000046814],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {
+        "compression_ratio": 1.6743626876534652
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4824623000022257,
+        "max": 0.4945481999893673,
+        "mean": 0.49025556666310877,
+        "stddev": 0.006760774358933372,
+        "rounds": 3,
+        "median": 0.49375619999773335,
+        "iqr": 0.009064424990356201,
+        "q1": 0.4852857750011026,
+        "q3": 0.4943501999914588,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4824623000022257,
+        "hd15iqr": 0.4945481999893673,
+        "ops": 2.039752463814806,
+        "total": 1.4707666999893263,
+        "data": [0.49375619999773335, 0.4824623000022257, 0.4945481999893673],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {
+        "compression_ratio": 1.6641106625556246
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48535469999478664,
+        "max": 0.5264740999991773,
+        "mean": 0.5080139999966681,
+        "stddev": 0.020878846343998878,
+        "rounds": 3,
+        "median": 0.5122131999960402,
+        "iqr": 0.03083955000329297,
+        "q1": 0.49206932499510003,
+        "q3": 0.522908874998393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48535469999478664,
+        "hd15iqr": 0.5264740999991773,
+        "ops": 1.968449688407325,
+        "total": 1.5240419999900041,
+        "data": [0.5264740999991773, 0.48535469999478664, 0.5122131999960402],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {
+        "compression_ratio": 1.688169361341407
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5116073999961372,
+        "max": 0.5684136999916518,
+        "mean": 0.5331589333315302,
+        "stddev": 0.03078267178883379,
+        "rounds": 3,
+        "median": 0.5194557000068016,
+        "iqr": 0.04260472499663592,
+        "q1": 0.5135694749988033,
+        "q3": 0.5561741999954393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5116073999961372,
+        "hd15iqr": 0.5684136999916518,
+        "ops": 1.8756133255638006,
+        "total": 1.5994767999945907,
+        "data": [0.5116073999961372, 0.5684136999916518, 0.5194557000068016],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {
+        "compression_ratio": 1.7225805303456598
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49231370000052266,
+        "max": 0.5281197000003885,
+        "mean": 0.5082344333301686,
+        "stddev": 0.01822924991473842,
+        "rounds": 3,
+        "median": 0.5042698999895947,
+        "iqr": 0.026854499999899417,
+        "q1": 0.49530274999779067,
+        "q3": 0.5221572499976901,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49231370000052266,
+        "hd15iqr": 0.5281197000003885,
+        "ops": 1.967595925068622,
+        "total": 1.524703299990506,
+        "data": [0.5042698999895947, 0.5281197000003885, 0.49231370000052266],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {
+        "compression_ratio": 1.7310446043680345
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5077391999948304,
+        "max": 0.5281485000014072,
+        "mean": 0.5194435999971271,
+        "stddev": 0.010530082234635694,
+        "rounds": 3,
+        "median": 0.5224430999951437,
+        "iqr": 0.01530697500493261,
+        "q1": 0.5114151749949087,
+        "q3": 0.5267221499998413,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5077391999948304,
+        "hd15iqr": 0.5281485000014072,
+        "ops": 1.9251368194844074,
+        "total": 1.5583307999913814,
+        "data": [0.5077391999948304, 0.5224430999951437, 0.5281485000014072],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.502399493480299
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.347689200003515,
+        "max": 0.38170939999690745,
+        "mean": 0.36288700000053115,
+        "stddev": 0.01729730602620321,
+        "rounds": 3,
+        "median": 0.35926240000117105,
+        "iqr": 0.02551514999504434,
+        "q1": 0.350582500002929,
+        "q3": 0.37609764999797335,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.347689200003515,
+        "hd15iqr": 0.38170939999690745,
+        "ops": 2.755678765010971,
+        "total": 1.0886610000015935,
+        "data": [0.347689200003515, 0.38170939999690745, 0.35926240000117105],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.507665134033379
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3428352999908384,
+        "max": 0.3880141999979969,
+        "mean": 0.36583703332871664,
+        "stddev": 0.02260073414974454,
+        "rounds": 3,
+        "median": 0.3666615999973146,
+        "iqr": 0.03388417500536889,
+        "q1": 0.34879187499245745,
+        "q3": 0.38267604999782634,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3428352999908384,
+        "hd15iqr": 0.3880141999979969,
+        "ops": 2.733457547753147,
+        "total": 1.09751109998615,
+        "data": [0.3666615999973146, 0.3428352999908384, 0.3880141999979969],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.5481615004067724
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3545561000064481,
+        "max": 0.3766260999982478,
+        "mean": 0.36495756666893914,
+        "stddev": 0.011089423716457495,
+        "rounds": 3,
+        "median": 0.36369050000212155,
+        "iqr": 0.01655249999384978,
+        "q1": 0.35683970000536647,
+        "q3": 0.37339219999921625,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3545561000064481,
+        "hd15iqr": 0.3766260999982478,
+        "ops": 2.7400445732013594,
+        "total": 1.0948727000068175,
+        "data": [0.3766260999982478, 0.36369050000212155, 0.3545561000064481],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.5981362795640592
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36571479999111034,
+        "max": 0.3689464000053704,
+        "mean": 0.3671121333366803,
+        "stddev": 0.0016595158057942491,
+        "rounds": 3,
+        "median": 0.36667520001356024,
+        "iqr": 0.002423700010695029,
+        "q1": 0.3659548999967228,
+        "q3": 0.36837860000741784,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36571479999111034,
+        "hd15iqr": 0.3689464000053704,
+        "ops": 2.723963359399225,
+        "total": 1.101336400010041,
+        "data": [0.36667520001356024, 0.36571479999111034, 0.3689464000053704],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.6372603632222458
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3478545999969356,
+        "max": 0.35991440000361763,
+        "mean": 0.35499146666552406,
+        "stddev": 0.006327386478175593,
+        "rounds": 3,
+        "median": 0.35720539999601897,
+        "iqr": 0.00904485000501154,
+        "q1": 0.3501922999967064,
+        "q3": 0.35923715000171796,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3478545999969356,
+        "hd15iqr": 0.35991440000361763,
+        "ops": 2.8169691215203447,
+        "total": 1.0649743999965722,
+        "data": [0.35991440000361763, 0.35720539999601897, 0.3478545999969356],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.6428123788896745
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3332574999949429,
+        "max": 0.3689333000074839,
+        "mean": 0.3462173666678912,
+        "stddev": 0.01973768740852667,
+        "rounds": 3,
+        "median": 0.33646130000124685,
+        "iqr": 0.026756850009405753,
+        "q1": 0.3340584499965189,
+        "q3": 0.36081530000592466,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3332574999949429,
+        "hd15iqr": 0.3689333000074839,
+        "ops": 2.888358864329441,
+        "total": 1.0386521000036737,
+        "data": [0.33646130000124685, 0.3332574999949429, 0.3689333000074839],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.6658632383935235
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3558705000032205,
+        "max": 0.37732580000010785,
+        "mean": 0.36384533333572716,
+        "stddev": 0.011739526109596185,
+        "rounds": 3,
+        "median": 0.35833970000385307,
+        "iqr": 0.0160914749976655,
+        "q1": 0.35648780000337865,
+        "q3": 0.37257927500104415,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3558705000032205,
+        "hd15iqr": 0.37732580000010785,
+        "ops": 2.748420574291881,
+        "total": 1.0915360000071814,
+        "data": [0.3558705000032205, 0.37732580000010785, 0.35833970000385307],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.667354377626296
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.35700059999362566,
+        "max": 0.36882290001085494,
+        "mean": 0.3623882000004717,
+        "stddev": 0.005980301684480509,
+        "rounds": 3,
+        "median": 0.36134109999693464,
+        "iqr": 0.008866725012921961,
+        "q1": 0.3580857249944529,
+        "q3": 0.36695245000737486,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.35700059999362566,
+        "hd15iqr": 0.36882290001085494,
+        "ops": 2.759471748800591,
+        "total": 1.0871646000014152,
+        "data": [0.36134109999693464, 0.35700059999362566, 0.36882290001085494],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.6778700012648744
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3461005999997724,
+        "max": 0.3767809999990277,
+        "mean": 0.36407716666387085,
+        "stddev": 0.01600540607411055,
+        "rounds": 3,
+        "median": 0.3693498999928124,
+        "iqr": 0.023010299999441486,
+        "q1": 0.3519129249980324,
+        "q3": 0.3749232249974739,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3461005999997724,
+        "hd15iqr": 0.3767809999990277,
+        "ops": 2.7466704631967103,
+        "total": 1.0922314999916125,
+        "data": [0.3767809999990277, 0.3461005999997724, 0.3693498999928124],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {
+        "compression_ratio": 1.6855269793764998
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.35087080000084825,
+        "max": 0.3575120000023162,
+        "mean": 0.35462350000064663,
+        "stddev": 0.003403897118370193,
+        "rounds": 3,
+        "median": 0.3554876999987755,
+        "iqr": 0.004980900001100963,
+        "q1": 0.35202502500033006,
+        "q3": 0.357005925001431,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.35087080000084825,
+        "hd15iqr": 0.3575120000023162,
+        "ops": 2.8198920827248517,
+        "total": 1.06387050000194,
+        "data": [0.3575120000023162, 0.3554876999987755, 0.35087080000084825],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {
+        "compression_ratio": 1.6884528082324888
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3478487000102177,
+        "max": 0.3585263999993913,
+        "mean": 0.3545715333360325,
+        "stddev": 0.005852311410720555,
+        "rounds": 3,
+        "median": 0.35733949999848846,
+        "iqr": 0.008008274991880171,
+        "q1": 0.3502214000072854,
+        "q3": 0.3582296749991656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3478487000102177,
+        "hd15iqr": 0.3585263999993913,
+        "ops": 2.8203053713629225,
+        "total": 1.0637146000080975,
+        "data": [0.35733949999848846, 0.3478487000102177, 0.3585263999993913],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {
+        "compression_ratio": 1.6887609620514146
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3485551000048872,
+        "max": 0.36171129999274854,
+        "mean": 0.354358033335302,
+        "stddev": 0.00671372099500936,
+        "rounds": 3,
+        "median": 0.35280770000827033,
+        "iqr": 0.009867149990895996,
+        "q1": 0.349618250005733,
+        "q3": 0.359485399996629,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3485551000048872,
+        "hd15iqr": 0.36171129999274854,
+        "ops": 2.8220045996636856,
+        "total": 1.063074100005906,
+        "data": [0.3485551000048872, 0.35280770000827033, 0.36171129999274854],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {
+        "compression_ratio": 1.6918239198586216
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36430589998781215,
+        "max": 0.37469539999437984,
+        "mean": 0.36845349999687943,
+        "stddev": 0.005502271978717578,
+        "rounds": 3,
+        "median": 0.36635920000844635,
+        "iqr": 0.007792125004925765,
+        "q1": 0.3648192249929707,
+        "q3": 0.37261134999789647,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36430589998781215,
+        "hd15iqr": 0.37469539999437984,
+        "ops": 2.714046684340003,
+        "total": 1.1053604999906383,
+        "data": [0.36635920000844635, 0.36430589998781215, 0.37469539999437984],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {
+        "compression_ratio": 1.6965485824902609
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3589270999946166,
+        "max": 0.36553389999608044,
+        "mean": 0.3611394999995052,
+        "stddev": 0.0038056923861008885,
+        "rounds": 3,
+        "median": 0.35895750000781845,
+        "iqr": 0.00495510000109789,
+        "q1": 0.35893469999791705,
+        "q3": 0.36388979999901494,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3589270999946166,
+        "hd15iqr": 0.36553389999608044,
+        "ops": 2.769013082206101,
+        "total": 1.0834184999985155,
+        "data": [0.36553389999608044, 0.35895750000781845, 0.3589270999946166],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {
+        "compression_ratio": 1.6996526266096026
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33092919999035075,
+        "max": 0.3492375999921933,
+        "mean": 0.33799083332996815,
+        "stddev": 0.009845602234138249,
+        "rounds": 3,
+        "median": 0.33380570000736043,
+        "iqr": 0.013731300001381896,
+        "q1": 0.33164832499460317,
+        "q3": 0.34537962499598507,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33092919999035075,
+        "hd15iqr": 0.3492375999921933,
+        "ops": 2.9586601214824557,
+        "total": 1.0139724999899045,
+        "data": [0.33380570000736043, 0.3492375999921933, 0.33092919999035075],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {
+        "compression_ratio": 1.7101925693386566
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33918149999226443,
+        "max": 0.38087939999240916,
+        "mean": 0.35943806666182354,
+        "stddev": 0.020874181903402282,
+        "rounds": 3,
+        "median": 0.358253300000797,
+        "iqr": 0.031273425000108546,
+        "q1": 0.3439494499943976,
+        "q3": 0.37522287499450613,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33918149999226443,
+        "hd15iqr": 0.38087939999240916,
+        "ops": 2.7821204617730366,
+        "total": 1.0783141999854706,
+        "data": [0.38087939999240916, 0.358253300000797, 0.33918149999226443],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {
+        "compression_ratio": 1.723309221269611
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3115399000089383,
+        "max": 0.3612192000000505,
+        "mean": 0.342604200001612,
+        "stddev": 0.027078534204450198,
+        "rounds": 3,
+        "median": 0.35505349999584723,
+        "iqr": 0.03725947499333415,
+        "q1": 0.3224183000056655,
+        "q3": 0.35967777499899967,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3115399000089383,
+        "hd15iqr": 0.3612192000000505,
+        "ops": 2.918820026127219,
+        "total": 1.027812600004836,
+        "data": [0.35505349999584723, 0.3115399000089383, 0.3612192000000505],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {
+        "compression_ratio": 1.7376284825461996
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.33122249999723863,
+        "max": 0.3411020999919856,
+        "mean": 0.3372398333303863,
+        "stddev": 0.005280611544429786,
+        "rounds": 3,
+        "median": 0.33939490000193473,
+        "iqr": 0.007409699996060226,
+        "q1": 0.33326559999841265,
+        "q3": 0.3406752999944729,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.33122249999723863,
+        "hd15iqr": 0.3411020999919856,
+        "ops": 2.9652487671001855,
+        "total": 1.011719499991159,
+        "data": [0.3411020999919856, 0.33939490000193473, 0.33122249999723863],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_read_zarr_python_benchmark.py::test_read_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {
+        "compression_ratio": 1.7409524307219595
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3403358999930788,
+        "max": 0.392326300003333,
+        "mean": 0.36269636666596244,
+        "stddev": 0.026746668624262823,
+        "rounds": 3,
+        "median": 0.3554269000014756,
+        "iqr": 0.038992800007690676,
+        "q1": 0.344108649995178,
+        "q3": 0.38310145000286866,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3403358999930788,
+        "hd15iqr": 0.392326300003333,
+        "ops": 2.7571271507138753,
+        "total": 1.0880890999978874,
+        "data": [0.392326300003333, 0.3403358999930788, 0.3554269000014756],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1357966999930795,
+        "max": 1.259191799996188,
+        "mean": 1.2175807333308815,
+        "stddev": 0.07083070036817625,
+        "rounds": 3,
+        "median": 1.2577537000033772,
+        "iqr": 0.09254632500233129,
+        "q1": 1.166285949995654,
+        "q3": 1.2588322749979852,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1357966999930795,
+        "hd15iqr": 1.259191799996188,
+        "ops": 0.8213007750741459,
+        "total": 3.6527421999926446,
+        "data": [1.1357966999930795, 1.259191799996188, 1.2577537000033772],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2058931000065058,
+        "max": 1.352457200002391,
+        "mean": 1.267505700001493,
+        "stddev": 0.0760183335914131,
+        "rounds": 3,
+        "median": 1.2441667999955826,
+        "iqr": 0.10992307499691378,
+        "q1": 1.215461525003775,
+        "q3": 1.3253846000006888,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2058931000065058,
+        "hd15iqr": 1.352457200002391,
+        "ops": 0.7889510871618345,
+        "total": 3.8025171000044793,
+        "data": [1.2441667999955826, 1.352457200002391, 1.2058931000065058],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1677304999902844,
+        "max": 1.1864441000070656,
+        "mean": 1.1791984666682158,
+        "stddev": 0.010045933531372717,
+        "rounds": 3,
+        "median": 1.1834208000072977,
+        "iqr": 0.014035200012585847,
+        "q1": 1.1716530749945377,
+        "q3": 1.1856882750071236,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1677304999902844,
+        "hd15iqr": 1.1864441000070656,
+        "ops": 0.8480336671616145,
+        "total": 3.5375954000046477,
+        "data": [1.1864441000070656, 1.1834208000072977, 1.1677304999902844],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.973297000004095,
+        "max": 1.0394579999992857,
+        "mean": 1.011228833333007,
+        "stddev": 0.03413100914660359,
+        "rounds": 3,
+        "median": 1.0209314999956405,
+        "iqr": 0.04962074999639299,
+        "q1": 0.9852056250019814,
+        "q3": 1.0348263749983744,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.973297000004095,
+        "hd15iqr": 1.0394579999992857,
+        "ops": 0.9888958532798191,
+        "total": 3.033686499999021,
+        "data": [1.0394579999992857, 0.973297000004095, 1.0209314999956405],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6296906000061426,
+        "max": 0.7125505000003614,
+        "mean": 0.6674105333319554,
+        "stddev": 0.04192533157730391,
+        "rounds": 3,
+        "median": 0.6599904999893624,
+        "iqr": 0.06214492499566404,
+        "q1": 0.6372655750019476,
+        "q3": 0.6994104999976116,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6296906000061426,
+        "hd15iqr": 0.7125505000003614,
+        "ops": 1.4983281654361031,
+        "total": 2.0022315999958664,
+        "data": [0.7125505000003614, 0.6599904999893624, 0.6296906000061426],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6119849999959115,
+        "max": 0.661065399996005,
+        "mean": 0.6316778666659957,
+        "stddev": 0.025936679380321463,
+        "rounds": 3,
+        "median": 0.6219832000060705,
+        "iqr": 0.03681030000007013,
+        "q1": 0.6144845499984513,
+        "q3": 0.6512948499985214,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6119849999959115,
+        "hd15iqr": 0.661065399996005,
+        "ops": 1.5830853869837382,
+        "total": 1.895033599997987,
+        "data": [0.6219832000060705, 0.6119849999959115, 0.661065399996005],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9525443000020459,
+        "max": 0.9927273000066634,
+        "mean": 0.969212566667314,
+        "stddev": 0.020948125256983082,
+        "rounds": 3,
+        "median": 0.9623660999932326,
+        "iqr": 0.030137250003463123,
+        "q1": 0.9549997499998426,
+        "q3": 0.9851370000033057,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9525443000020459,
+        "hd15iqr": 0.9927273000066634,
+        "ops": 1.0317654087364447,
+        "total": 2.907637700001942,
+        "data": [0.9623660999932326, 0.9927273000066634, 0.9525443000020459],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.026465000002645,
+        "max": 1.0748934000002919,
+        "mean": 1.0444354666688014,
+        "stddev": 0.026519428715026917,
+        "rounds": 3,
+        "median": 1.0319480000034673,
+        "iqr": 0.03632129999823519,
+        "q1": 1.0278357500028505,
+        "q3": 1.0641570500010857,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.026465000002645,
+        "hd15iqr": 1.0748934000002919,
+        "ops": 0.9574550385477362,
+        "total": 3.133306400006404,
+        "data": [1.0748934000002919, 1.0319480000034673, 1.026465000002645],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6330445999919903,
+        "max": 0.7068399999989197,
+        "mean": 0.6815067999996245,
+        "stddev": 0.0419839641599622,
+        "rounds": 3,
+        "median": 0.7046358000079636,
+        "iqr": 0.05534655000519706,
+        "q1": 0.6509423999959836,
+        "q3": 0.7062889500011806,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6330445999919903,
+        "hd15iqr": 0.7068399999989197,
+        "ops": 1.4673367895970384,
+        "total": 2.0445203999988735,
+        "data": [0.7068399999989197, 0.6330445999919903, 0.7046358000079636],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6473413000057917,
+        "max": 0.6761200000037206,
+        "mean": 0.6610253333395425,
+        "stddev": 0.014441115198882084,
+        "rounds": 3,
+        "median": 0.659614700009115,
+        "iqr": 0.021584024998446694,
+        "q1": 0.6504096500066225,
+        "q3": 0.6719936750050692,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6473413000057917,
+        "hd15iqr": 0.6761200000037206,
+        "ops": 1.5128013247963368,
+        "total": 1.9830760000186274,
+        "data": [0.6761200000037206, 0.659614700009115, 0.6473413000057917],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6458312000031583,
+        "max": 0.6824874999874737,
+        "mean": 0.6618287333306702,
+        "stddev": 0.018767429345747003,
+        "rounds": 3,
+        "median": 0.6571675000013784,
+        "iqr": 0.027492224988236558,
+        "q1": 0.6486652750027133,
+        "q3": 0.6761574999909499,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6458312000031583,
+        "hd15iqr": 0.6824874999874737,
+        "ops": 1.5109649213437353,
+        "total": 1.9854861999920104,
+        "data": [0.6824874999874737, 0.6571675000013784, 0.6458312000031583],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9809924000001047,
+        "max": 1.0374241999961669,
+        "mean": 1.0121715333322452,
+        "stddev": 0.028678899352590593,
+        "rounds": 3,
+        "median": 1.0180980000004638,
+        "iqr": 0.042323849997046636,
+        "q1": 0.9902688000001945,
+        "q3": 1.032592649997241,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9809924000001047,
+        "hd15iqr": 1.0374241999961669,
+        "ops": 0.987974831408097,
+        "total": 3.0365145999967353,
+        "data": [1.0374241999961669, 0.9809924000001047, 1.0180980000004638],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1047458999964874,
+        "max": 1.2114732000045478,
+        "mean": 1.1486964333356202,
+        "stddev": 0.055798740467805696,
+        "rounds": 3,
+        "median": 1.1298702000058256,
+        "iqr": 0.08004547500604531,
+        "q1": 1.111026974998822,
+        "q3": 1.1910724500048673,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1047458999964874,
+        "hd15iqr": 1.2114732000045478,
+        "ops": 0.8705520196455813,
+        "total": 3.446089300006861,
+        "data": [1.1047458999964874, 1.2114732000045478, 1.1298702000058256],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7565066000097431,
+        "max": 0.8148717000003671,
+        "mean": 0.7828208000040225,
+        "stddev": 0.029602424215157717,
+        "rounds": 3,
+        "median": 0.7770841000019573,
+        "iqr": 0.043773824992968,
+        "q1": 0.7616509750077967,
+        "q3": 0.8054248000007647,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7565066000097431,
+        "hd15iqr": 0.8148717000003671,
+        "ops": 1.2774315654296124,
+        "total": 2.3484624000120675,
+        "data": [0.7565066000097431, 0.8148717000003671, 0.7770841000019573],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6249557999981334,
+        "max": 0.6862297999905422,
+        "mean": 0.6550836999958847,
+        "stddev": 0.030649687065167616,
+        "rounds": 3,
+        "median": 0.6540654999989783,
+        "iqr": 0.04595549999430659,
+        "q1": 0.6322332249983447,
+        "q3": 0.6781887249926513,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6249557999981334,
+        "hd15iqr": 0.6862297999905422,
+        "ops": 1.5265224886625666,
+        "total": 1.965251099987654,
+        "data": [0.6249557999981334, 0.6540654999989783, 0.6862297999905422],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5830178000032902,
+        "max": 0.7053689999884227,
+        "mean": 0.6565711333338792,
+        "stddev": 0.06482344392434017,
+        "rounds": 3,
+        "median": 0.6813266000099247,
+        "iqr": 0.09176339998884941,
+        "q1": 0.6075950000049488,
+        "q3": 0.6993583999937982,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5830178000032902,
+        "hd15iqr": 0.7053689999884227,
+        "ops": 1.5230642183768999,
+        "total": 1.9697134000016376,
+        "data": [0.7053689999884227, 0.5830178000032902, 0.6813266000099247],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1145102000009501,
+        "max": 1.1568045999883907,
+        "mean": 1.1361418999974073,
+        "stddev": 0.021163843893120145,
+        "rounds": 3,
+        "median": 1.137110900002881,
+        "iqr": 0.03172079999058042,
+        "q1": 1.1201603750014328,
+        "q3": 1.1518811749920133,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1145102000009501,
+        "hd15iqr": 1.1568045999883907,
+        "ops": 0.8801717461544919,
+        "total": 3.408425699992222,
+        "data": [1.137110900002881, 1.1145102000009501, 1.1568045999883907],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3553544999886071,
+        "max": 1.4057026999944355,
+        "mean": 1.3750074666604633,
+        "stddev": 0.02692924155513271,
+        "rounds": 3,
+        "median": 1.363965199998347,
+        "iqr": 0.0377611500043713,
+        "q1": 1.3575071749910421,
+        "q3": 1.3952683249954134,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3553544999886071,
+        "hd15iqr": 1.4057026999944355,
+        "ops": 0.7272687779861594,
+        "total": 4.12502239998139,
+        "data": [1.363965199998347, 1.3553544999886071, 1.4057026999944355],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9408402999979444,
+        "max": 1.0030507000046782,
+        "mean": 0.971209466670795,
+        "stddev": 0.031131313856635572,
+        "rounds": 3,
+        "median": 0.9697374000097625,
+        "iqr": 0.046657800005050376,
+        "q1": 0.9480645750008989,
+        "q3": 0.9947223750059493,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9408402999979444,
+        "hd15iqr": 1.0030507000046782,
+        "ops": 1.0296439998962283,
+        "total": 2.913628400012385,
+        "data": [0.9408402999979444, 0.9697374000097625, 1.0030507000046782],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6537939999980154,
+        "max": 0.7409959000069648,
+        "mean": 0.6859162666708775,
+        "stddev": 0.04791996822176566,
+        "rounds": 3,
+        "median": 0.6629589000076521,
+        "iqr": 0.06540142500671209,
+        "q1": 0.6560852250004245,
+        "q3": 0.7214866500071366,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6537939999980154,
+        "hd15iqr": 0.7409959000069648,
+        "ops": 1.4579038996312783,
+        "total": 2.0577488000126323,
+        "data": [0.6629589000076521, 0.7409959000069648, 0.6537939999980154],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5857538999989629,
+        "max": 0.6437889999942854,
+        "mean": 0.622590200000559,
+        "stddev": 0.03202212926616318,
+        "rounds": 3,
+        "median": 0.6382277000084287,
+        "iqr": 0.043526324996491894,
+        "q1": 0.5988723500013293,
+        "q3": 0.6423986749978212,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5857538999989629,
+        "hd15iqr": 0.6437889999942854,
+        "ops": 1.606192966094073,
+        "total": 1.867770600001677,
+        "data": [0.6437889999942854, 0.5857538999989629, 0.6382277000084287],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.237296299994341,
+        "max": 1.275374400007422,
+        "mean": 1.2580202333338093,
+        "stddev": 0.019261410142777248,
+        "rounds": 3,
+        "median": 1.2613899999996647,
+        "iqr": 0.02855857500981074,
+        "q1": 1.243319724995672,
+        "q3": 1.2718783000054827,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.237296299994341,
+        "hd15iqr": 1.275374400007422,
+        "ops": 0.7948997746641608,
+        "total": 3.774060700001428,
+        "data": [1.2613899999996647, 1.237296299994341, 1.275374400007422],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.277602600006503,
+        "max": 1.3601219000120182,
+        "mean": 1.3129944000053608,
+        "stddev": 0.04249298423686967,
+        "rounds": 3,
+        "median": 1.301258699997561,
+        "iqr": 0.06188947500413633,
+        "q1": 1.2835166250042676,
+        "q3": 1.3454061000084039,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.277602600006503,
+        "hd15iqr": 1.3601219000120182,
+        "ops": 0.7616178713297765,
+        "total": 3.9389832000160823,
+        "data": [1.277602600006503, 1.3601219000120182, 1.301258699997561],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1876734000106808,
+        "max": 1.2240656000067247,
+        "mean": 1.2068715666731198,
+        "stddev": 0.01827868890095302,
+        "rounds": 3,
+        "median": 1.208875700001954,
+        "iqr": 0.027294149997032946,
+        "q1": 1.192973975008499,
+        "q3": 1.220268125005532,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1876734000106808,
+        "hd15iqr": 1.2240656000067247,
+        "ops": 0.828588581928908,
+        "total": 3.6206147000193596,
+        "data": [1.2240656000067247, 1.1876734000106808, 1.208875700001954],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6100838999991538,
+        "max": 0.6983690999913961,
+        "mean": 0.6611801999970339,
+        "stddev": 0.045756212316590876,
+        "rounds": 3,
+        "median": 0.6750876000005519,
+        "iqr": 0.0662138999941817,
+        "q1": 0.6263348249995033,
+        "q3": 0.692548724993685,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6100838999991538,
+        "hd15iqr": 0.6983690999913961,
+        "ops": 1.5124469849588449,
+        "total": 1.9835405999911018,
+        "data": [0.6100838999991538, 0.6983690999913961, 0.6750876000005519],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5841537999949651,
+        "max": 0.6148818999936339,
+        "mean": 0.5992341333330842,
+        "stddev": 0.015371906772212755,
+        "rounds": 3,
+        "median": 0.5986667000106536,
+        "iqr": 0.023046074999001576,
+        "q1": 0.5877820249988872,
+        "q3": 0.6108280999978888,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5841537999949651,
+        "hd15iqr": 0.6148818999936339,
+        "ops": 1.6687967930627714,
+        "total": 1.7977023999992525,
+        "data": [0.5841537999949651, 0.5986667000106536, 0.6148818999936339],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4723827999987407,
+        "max": 1.5028184999973746,
+        "mean": 1.4859277666643418,
+        "stddev": 0.01549124186585391,
+        "rounds": 3,
+        "median": 1.4825819999969099,
+        "iqr": 0.022826774998975452,
+        "q1": 1.474932599998283,
+        "q3": 1.4977593749972584,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4723827999987407,
+        "hd15iqr": 1.5028184999973746,
+        "ops": 0.6729802231536679,
+        "total": 4.457783299993025,
+        "data": [1.5028184999973746, 1.4825819999969099, 1.4723827999987407],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6415542000031564,
+        "max": 1.6615636000060476,
+        "mean": 1.6516751666689136,
+        "stddev": 0.01000672653421767,
+        "rounds": 3,
+        "median": 1.6519076999975368,
+        "iqr": 0.015007050002168398,
+        "q1": 1.6441425750017515,
+        "q3": 1.65914962500392,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6415542000031564,
+        "hd15iqr": 1.6615636000060476,
+        "ops": 0.605445925554958,
+        "total": 4.955025500006741,
+        "data": [1.6615636000060476, 1.6415542000031564, 1.6519076999975368],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.495870400001877,
+        "max": 1.539628200000152,
+        "mean": 1.5143666000027831,
+        "stddev": 0.022649817725676383,
+        "rounds": 3,
+        "median": 1.5076012000063201,
+        "iqr": 0.03281834999870625,
+        "q1": 1.4988031000029878,
+        "q3": 1.531621450001694,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.495870400001877,
+        "hd15iqr": 1.539628200000152,
+        "ops": 0.6603420862545187,
+        "total": 4.543099800008349,
+        "data": [1.495870400001877, 1.539628200000152, 1.5076012000063201],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6624301999981981,
+        "max": 0.7314502999943215,
+        "mean": 0.6916382666677237,
+        "stddev": 0.03571101556266562,
+        "rounds": 3,
+        "median": 0.6810343000106514,
+        "iqr": 0.0517650749970926,
+        "q1": 0.6670812250013114,
+        "q3": 0.718846299998404,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6624301999981981,
+        "hd15iqr": 0.7314502999943215,
+        "ops": 1.4458424991693226,
+        "total": 2.074914800003171,
+        "data": [0.6624301999981981, 0.6810343000106514, 0.7314502999943215],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6098673999949824,
+        "max": 0.6918947999947704,
+        "mean": 0.6443613333346244,
+        "stddev": 0.0425399301785241,
+        "rounds": 3,
+        "median": 0.6313218000141205,
+        "iqr": 0.06152054999984102,
+        "q1": 0.6152309999997669,
+        "q3": 0.676751549999608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6098673999949824,
+        "hd15iqr": 0.6918947999947704,
+        "ops": 1.5519242826457562,
+        "total": 1.9330840000038734,
+        "data": [0.6313218000141205, 0.6918947999947704, 0.6098673999949824],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7797927000065101,
+        "max": 1.806757899990771,
+        "mean": 1.7960912666652196,
+        "stddev": 0.014337695329084407,
+        "rounds": 3,
+        "median": 1.8017231999983778,
+        "iqr": 0.020223899988195626,
+        "q1": 1.785275325004477,
+        "q3": 1.8054992249926727,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7797927000065101,
+        "hd15iqr": 1.806757899990771,
+        "ops": 0.5567645801522589,
+        "total": 5.388273799995659,
+        "data": [1.806757899990771, 1.8017231999983778, 1.7797927000065101],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4208170999918366,
+        "max": 2.4601137999998173,
+        "mean": 2.43971409999358,
+        "stddev": 0.019691400111646117,
+        "rounds": 3,
+        "median": 2.438211399989086,
+        "iqr": 0.029472525005985517,
+        "q1": 2.425165674991149,
+        "q3": 2.4546381999971345,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4208170999918366,
+        "hd15iqr": 2.4601137999998173,
+        "ops": 0.4098840925674986,
+        "total": 7.31914229998074,
+        "data": [2.4208170999918366, 2.438211399989086, 2.4601137999998173],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8791180999978678,
+        "max": 1.9150393000018084,
+        "mean": 1.8960238666671405,
+        "stddev": 0.018053287027854102,
+        "rounds": 3,
+        "median": 1.8939142000017455,
+        "iqr": 0.02694090000295546,
+        "q1": 1.8828171249988372,
+        "q3": 1.9097580250017927,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8791180999978678,
+        "hd15iqr": 1.9150393000018084,
+        "ops": 0.52741952123093,
+        "total": 5.688071600001422,
+        "data": [1.8791180999978678, 1.9150393000018084, 1.8939142000017455],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6955130999995163,
+        "max": 0.7360470999992685,
+        "mean": 0.7110674999955032,
+        "stddev": 0.0218489607392422,
+        "rounds": 3,
+        "median": 0.701642299987725,
+        "iqr": 0.0304004999998142,
+        "q1": 0.6970453999965684,
+        "q3": 0.7274458999963826,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6955130999995163,
+        "hd15iqr": 0.7360470999992685,
+        "ops": 1.4063362479741008,
+        "total": 2.13320249998651,
+        "data": [0.701642299987725, 0.7360470999992685, 0.6955130999995163],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.670063300000038,
+        "max": 0.7019710000022314,
+        "mean": 0.6810809000016889,
+        "stddev": 0.018100414968408373,
+        "rounds": 3,
+        "median": 0.6712084000027971,
+        "iqr": 0.023930775001645088,
+        "q1": 0.6703495750007278,
+        "q3": 0.6942803500023729,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.670063300000038,
+        "hd15iqr": 0.7019710000022314,
+        "ops": 1.4682543586195418,
+        "total": 2.0432427000050666,
+        "data": [0.6712084000027971, 0.670063300000038, 0.7019710000022314],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.350931799999671,
+        "max": 2.369000999999116,
+        "mean": 2.3585459000023548,
+        "stddev": 0.009363624185097834,
+        "rounds": 3,
+        "median": 2.355704900008277,
+        "iqr": 0.013551899999583839,
+        "q1": 2.3521250750018226,
+        "q3": 2.3656769750014064,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.350931799999671,
+        "hd15iqr": 2.369000999999116,
+        "ops": 0.4239900525145606,
+        "total": 7.075637700007064,
+        "data": [2.350931799999671, 2.369000999999116, 2.355704900008277],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.383402899999055,
+        "max": 3.4210730000049807,
+        "mean": 3.4005568666713466,
+        "stddev": 0.019058783594660254,
+        "rounds": 3,
+        "median": 3.3971947000100045,
+        "iqr": 0.028252575004444225,
+        "q1": 3.3868508500017924,
+        "q3": 3.4151034250062366,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.383402899999055,
+        "hd15iqr": 3.4210730000049807,
+        "ops": 0.29406948308994324,
+        "total": 10.20167060001404,
+        "data": [3.4210730000049807, 3.383402899999055, 3.3971947000100045],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.6446605999954045,
+        "max": 2.663693200011039,
+        "mean": 2.654830600004061,
+        "stddev": 0.009583419896470996,
+        "rounds": 3,
+        "median": 2.6561380000057397,
+        "iqr": 0.014274450011726003,
+        "q1": 2.6475299499979883,
+        "q3": 2.6618044000097143,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.6446605999954045,
+        "hd15iqr": 2.663693200011039,
+        "ops": 0.3766718675001223,
+        "total": 7.964491800012183,
+        "data": [2.6561380000057397, 2.663693200011039, 2.6446605999954045],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6350639000011142,
+        "max": 0.7216370999958599,
+        "mean": 0.6860625999979675,
+        "stddev": 0.04530076377433956,
+        "rounds": 3,
+        "median": 0.7014867999969283,
+        "iqr": 0.06492989999605925,
+        "q1": 0.6516696250000678,
+        "q3": 0.716599524996127,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6350639000011142,
+        "hd15iqr": 0.7216370999958599,
+        "ops": 1.4575929368587686,
+        "total": 2.0581877999939024,
+        "data": [0.6350639000011142, 0.7216370999958599, 0.7014867999969283],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6388129999977536,
+        "max": 0.680803700000979,
+        "mean": 0.6560404666670365,
+        "stddev": 0.021986258347166842,
+        "rounds": 3,
+        "median": 0.6485047000023769,
+        "iqr": 0.03149302500241902,
+        "q1": 0.6412359249989095,
+        "q3": 0.6727289500013285,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6388129999977536,
+        "hd15iqr": 0.680803700000979,
+        "ops": 1.524296214653379,
+        "total": 1.9681214000011096,
+        "data": [0.6485047000023769, 0.6388129999977536, 0.680803700000979],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.350466800009599,
+        "max": 3.4084521000040695,
+        "mean": 3.38149286666885,
+        "stddev": 0.029205788875260312,
+        "rounds": 3,
+        "median": 3.385559699992882,
+        "iqr": 0.043488974995852914,
+        "q1": 3.3592400250054197,
+        "q3": 3.4027290000012727,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.350466800009599,
+        "hd15iqr": 3.4084521000040695,
+        "ops": 0.2957273723262685,
+        "total": 10.14447860000655,
+        "data": [3.385559699992882, 3.4084521000040695, 3.350466800009599],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.848243600004935,
+        "max": 9.913929299989832,
+        "mean": 9.871885333331496,
+        "stddev": 0.03650526591225273,
+        "rounds": 3,
+        "median": 9.853483099999721,
+        "iqr": 0.049264274988672696,
+        "q1": 9.849553475003631,
+        "q3": 9.898817749992304,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.848243600004935,
+        "hd15iqr": 9.913929299989832,
+        "ops": 0.10129777304276355,
+        "total": 29.615655999994488,
+        "data": [9.913929299989832, 9.848243600004935, 9.853483099999721],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.8247142000036547,
+        "max": 3.8529915000108304,
+        "mean": 3.8373105333400113,
+        "stddev": 0.01438880280044211,
+        "rounds": 3,
+        "median": 3.834225900005549,
+        "iqr": 0.02120797500538174,
+        "q1": 3.8270921250041283,
+        "q3": 3.84830010000951,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.8247142000036547,
+        "hd15iqr": 3.8529915000108304,
+        "ops": 0.26059918563056605,
+        "total": 11.511931600020034,
+        "data": [3.8529915000108304, 3.8247142000036547, 3.834225900005549],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.653128599995398,
+        "max": 0.7133553000021493,
+        "mean": 0.6864173000018733,
+        "stddev": 0.03061147483138245,
+        "rounds": 3,
+        "median": 0.6927680000080727,
+        "iqr": 0.04517002500506351,
+        "q1": 0.6630384499985666,
+        "q3": 0.7082084750036302,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.653128599995398,
+        "hd15iqr": 0.7133553000021493,
+        "ops": 1.45683973873804,
+        "total": 2.05925190000562,
+        "data": [0.6927680000080727, 0.653128599995398, 0.7133553000021493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6412918999994872,
+        "max": 0.6632906000013463,
+        "mean": 0.6506302000004022,
+        "stddev": 0.011369387043750163,
+        "rounds": 3,
+        "median": 0.6473081000003731,
+        "iqr": 0.01649902500139433,
+        "q1": 0.6427959499997087,
+        "q3": 0.659294975001103,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6412918999994872,
+        "hd15iqr": 0.6632906000013463,
+        "ops": 1.5369713855879759,
+        "total": 1.9518906000012066,
+        "data": [0.6473081000003731, 0.6632906000013463, 0.6412918999994872],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.637622599999304,
+        "max": 6.746763900009682,
+        "mean": 6.702331400001033,
+        "stddev": 0.05732627755267137,
+        "rounds": 3,
+        "median": 6.722607699994114,
+        "iqr": 0.08185597500778385,
+        "q1": 6.6588688749980065,
+        "q3": 6.74072485000579,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.637622599999304,
+        "hd15iqr": 6.746763900009682,
+        "ops": 0.1492018135659251,
+        "total": 20.1069942000031,
+        "data": [6.637622599999304, 6.746763900009682, 6.722607699994114],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 19.73890389999724,
+        "max": 19.795375899993815,
+        "mean": 19.77241769999576,
+        "stddev": 0.029678901840039275,
+        "rounds": 3,
+        "median": 19.78297329999623,
+        "iqr": 0.04235399999743095,
+        "q1": 19.749921249996987,
+        "q3": 19.792275249994418,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 19.73890389999724,
+        "hd15iqr": 19.795375899993815,
+        "ops": 0.050575504481690896,
+        "total": 59.31725309998728,
+        "data": [19.78297329999623, 19.73890389999724, 19.795375899993815],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 13.225254099990707,
+        "max": 13.318391799999517,
+        "mean": 13.283189200000683,
+        "stddev": 0.05055920003619678,
+        "rounds": 3,
+        "median": 13.305921700011822,
+        "iqr": 0.06985327500660787,
+        "q1": 13.245420999995986,
+        "q3": 13.315274275002594,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 13.225254099990707,
+        "hd15iqr": 13.318391799999517,
+        "ops": 0.07528312553132561,
+        "total": 39.84956760000205,
+        "data": [13.305921700011822, 13.225254099990707, 13.318391799999517],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.030017900004168,
+        "max": 1.0642508000019006,
+        "mean": 1.0495083333322934,
+        "stddev": 0.017603415893129644,
+        "rounds": 3,
+        "median": 1.0542562999908114,
+        "iqr": 0.02567467499829945,
+        "q1": 1.0360775000008289,
+        "q3": 1.0617521749991283,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.030017900004168,
+        "hd15iqr": 1.0642508000019006,
+        "ops": 0.952827117460707,
+        "total": 3.14852499999688,
+        "data": [1.0642508000019006, 1.0542562999908114, 1.030017900004168],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0198691000114195,
+        "max": 1.0460182999959216,
+        "mean": 1.035165866667133,
+        "stddev": 0.013629352112187288,
+        "rounds": 3,
+        "median": 1.0396101999940583,
+        "iqr": 0.019611899988376535,
+        "q1": 1.0248043750070792,
+        "q3": 1.0444162749954558,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0198691000114195,
+        "hd15iqr": 1.0460182999959216,
+        "ops": 0.9660287613806715,
+        "total": 3.1054976000013994,
+        "data": [1.0396101999940583, 1.0460182999959216, 1.0198691000114195],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9966694999893662,
+        "max": 1.0291563000064343,
+        "mean": 1.0167229333358894,
+        "stddev": 0.017532743822545643,
+        "rounds": 3,
+        "median": 1.0243430000118678,
+        "iqr": 0.024365100012801122,
+        "q1": 1.0035878749949916,
+        "q3": 1.0279529750077927,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9966694999893662,
+        "hd15iqr": 1.0291563000064343,
+        "ops": 0.9835521234078776,
+        "total": 3.0501688000076683,
+        "data": [0.9966694999893662, 1.0291563000064343, 1.0243430000118678],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9984218999888981,
+        "max": 1.041218200000003,
+        "mean": 1.0208248999939922,
+        "stddev": 0.021468814457833028,
+        "rounds": 3,
+        "median": 1.0228345999930752,
+        "iqr": 0.03209722500832868,
+        "q1": 1.0045250749899424,
+        "q3": 1.036622299998271,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9984218999888981,
+        "hd15iqr": 1.041218200000003,
+        "ops": 0.9795999294353863,
+        "total": 3.0624746999819763,
+        "data": [1.041218200000003, 0.9984218999888981, 1.0228345999930752],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9968787999969209,
+        "max": 1.0294095999997808,
+        "mean": 1.0088283666652085,
+        "stddev": 0.017900907498920465,
+        "rounds": 3,
+        "median": 1.0001966999989236,
+        "iqr": 0.02439810000214493,
+        "q1": 0.9977082749974215,
+        "q3": 1.0221063749995665,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9968787999969209,
+        "hd15iqr": 1.0294095999997808,
+        "ops": 0.9912488913308499,
+        "total": 3.026485099995625,
+        "data": [0.9968787999969209, 1.0294095999997808, 1.0001966999989236],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8222435000061523,
+        "max": 0.8656755999982124,
+        "mean": 0.8459168333356502,
+        "stddev": 0.021979074174598188,
+        "rounds": 3,
+        "median": 0.8498314000025857,
+        "iqr": 0.03257407499404508,
+        "q1": 0.8291404750052607,
+        "q3": 0.8617145499993057,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8222435000061523,
+        "hd15iqr": 0.8656755999982124,
+        "ops": 1.1821493090009374,
+        "total": 2.5377505000069505,
+        "data": [0.8656755999982124, 0.8498314000025857, 0.8222435000061523],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8314093000080902,
+        "max": 0.8759111000108533,
+        "mean": 0.8571096666758725,
+        "stddev": 0.023039075756620748,
+        "rounds": 3,
+        "median": 0.864008600008674,
+        "iqr": 0.033376350002072286,
+        "q1": 0.8395591250082362,
+        "q3": 0.8729354750103084,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8314093000080902,
+        "hd15iqr": 0.8759111000108533,
+        "ops": 1.1667118443294415,
+        "total": 2.5713290000276174,
+        "data": [0.864008600008674, 0.8759111000108533, 0.8314093000080902],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8561250000057044,
+        "max": 0.9071663999930024,
+        "mean": 0.8880157333333045,
+        "stddev": 0.027803562760782722,
+        "rounds": 3,
+        "median": 0.9007558000012068,
+        "iqr": 0.03828104999047355,
+        "q1": 0.86728270000458,
+        "q3": 0.9055637499950535,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8561250000057044,
+        "hd15iqr": 0.9071663999930024,
+        "ops": 1.12610617409485,
+        "total": 2.6640471999999136,
+        "data": [0.9071663999930024, 0.8561250000057044, 0.9007558000012068],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8680102000071201,
+        "max": 0.9014408999937586,
+        "mean": 0.884502833330771,
+        "stddev": 0.016719800643069955,
+        "rounds": 3,
+        "median": 0.8840573999914341,
+        "iqr": 0.025073024989978876,
+        "q1": 0.8720220000031986,
+        "q3": 0.8970950249931775,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8680102000071201,
+        "hd15iqr": 0.9014408999937586,
+        "ops": 1.1305786282609198,
+        "total": 2.653508499992313,
+        "data": [0.9014408999937586, 0.8840573999914341, 0.8680102000071201],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8402302000031341,
+        "max": 0.8548530999978539,
+        "mean": 0.8454404333363831,
+        "stddev": 0.008167168142784027,
+        "rounds": 3,
+        "median": 0.8412380000081612,
+        "iqr": 0.01096717499603983,
+        "q1": 0.8404821500043909,
+        "q3": 0.8514493250004307,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8402302000031341,
+        "hd15iqr": 0.8548530999978539,
+        "ops": 1.1828154421875408,
+        "total": 2.536321300009149,
+        "data": [0.8412380000081612, 0.8548530999978539, 0.8402302000031341],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8037697999970987,
+        "max": 0.8523603999929037,
+        "mean": 0.8281042666640133,
+        "stddev": 0.024295394709120587,
+        "rounds": 3,
+        "median": 0.8281826000020374,
+        "iqr": 0.03644294999685371,
+        "q1": 0.8098729999983334,
+        "q3": 0.8463159499951871,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8037697999970987,
+        "hd15iqr": 0.8523603999929037,
+        "ops": 1.2075774033002658,
+        "total": 2.48431279999204,
+        "data": [0.8281826000020374, 0.8037697999970987, 0.8523603999929037],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8479576000099769,
+        "max": 0.868816499991226,
+        "mean": 0.8561082999998083,
+        "stddev": 0.011151301798681774,
+        "rounds": 3,
+        "median": 0.8515507999982219,
+        "iqr": 0.015644174985936843,
+        "q1": 0.8488559000070381,
+        "q3": 0.864500074992975,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8479576000099769,
+        "hd15iqr": 0.868816499991226,
+        "ops": 1.1680765155532589,
+        "total": 2.568324899999425,
+        "data": [0.868816499991226, 0.8515507999982219, 0.8479576000099769],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8492853000061586,
+        "max": 0.9142111999972258,
+        "mean": 0.8878853000011683,
+        "stddev": 0.03415894129654374,
+        "rounds": 3,
+        "median": 0.9001594000001205,
+        "iqr": 0.048694424993300345,
+        "q1": 0.8620038250046491,
+        "q3": 0.9106982499979495,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8492853000061586,
+        "hd15iqr": 0.9142111999972258,
+        "ops": 1.1262716028733488,
+        "total": 2.663655900003505,
+        "data": [0.9001594000001205, 0.9142111999972258, 0.8492853000061586],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8579730999917956,
+        "max": 0.8799395999958506,
+        "mean": 0.8718942333265053,
+        "stddev": 0.012104761709194924,
+        "rounds": 3,
+        "median": 0.8777699999918696,
+        "iqr": 0.016474875003041234,
+        "q1": 0.8629223249918141,
+        "q3": 0.8793971999948553,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8579730999917956,
+        "hd15iqr": 0.8799395999958506,
+        "ops": 1.1469281040943895,
+        "total": 2.6156826999795157,
+        "data": [0.8579730999917956, 0.8799395999958506, 0.8777699999918696],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7467249000037555,
+        "max": 0.7796080999978585,
+        "mean": 0.759574033334502,
+        "stddev": 0.01757963767284701,
+        "rounds": 3,
+        "median": 0.7523891000018921,
+        "iqr": 0.02466239999557729,
+        "q1": 0.7481409500032896,
+        "q3": 0.7728033499988669,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7467249000037555,
+        "hd15iqr": 0.7796080999978585,
+        "ops": 1.3165273641728337,
+        "total": 2.278722100003506,
+        "data": [0.7796080999978585, 0.7467249000037555, 0.7523891000018921],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7584417000034591,
+        "max": 0.8032388999999966,
+        "mean": 0.7843538000015542,
+        "stddev": 0.023210586563652026,
+        "rounds": 3,
+        "median": 0.7913808000012068,
+        "iqr": 0.03359789999740315,
+        "q1": 0.766676475002896,
+        "q3": 0.8002743750002992,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7584417000034591,
+        "hd15iqr": 0.8032388999999966,
+        "ops": 1.274934857200945,
+        "total": 2.3530614000046626,
+        "data": [0.8032388999999966, 0.7913808000012068, 0.7584417000034591],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.780346700004884,
+        "max": 0.8182233999978052,
+        "mean": 0.8023211999970954,
+        "stddev": 0.019654915949414056,
+        "rounds": 3,
+        "median": 0.8083934999885969,
+        "iqr": 0.028407524994690903,
+        "q1": 0.7873584000008123,
+        "q3": 0.8157659249955032,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.780346700004884,
+        "hd15iqr": 0.8182233999978052,
+        "ops": 1.2463836179370809,
+        "total": 2.406963599991286,
+        "data": [0.8182233999978052, 0.780346700004884, 0.8083934999885969],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.776016100004199,
+        "max": 0.7821528000058606,
+        "mean": 0.779412666670396,
+        "stddev": 0.0031205689009972033,
+        "rounds": 3,
+        "median": 0.7800691000011284,
+        "iqr": 0.004602525001246249,
+        "q1": 0.7770293500034313,
+        "q3": 0.7816318750046776,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.776016100004199,
+        "hd15iqr": 0.7821528000058606,
+        "ops": 1.2830173831687133,
+        "total": 2.338238000011188,
+        "data": [0.776016100004199, 0.7821528000058606, 0.7800691000011284],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7764946999959648,
+        "max": 0.8050331000122242,
+        "mean": 0.7951294000037402,
+        "stddev": 0.016148772077552234,
+        "rounds": 3,
+        "median": 0.8038604000030318,
+        "iqr": 0.02140380001219455,
+        "q1": 0.7833361249977315,
+        "q3": 0.8047399250099261,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7764946999959648,
+        "hd15iqr": 0.8050331000122242,
+        "ops": 1.2576569297969564,
+        "total": 2.3853882000112208,
+        "data": [0.8050331000122242, 0.7764946999959648, 0.8038604000030318],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8076112999988254,
+        "max": 0.8346219000086421,
+        "mean": 0.8254266000052061,
+        "stddev": 0.01543118363122707,
+        "rounds": 3,
+        "median": 0.8340466000081506,
+        "iqr": 0.020257950007362524,
+        "q1": 0.8142201250011567,
+        "q3": 0.8344780750085192,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8076112999988254,
+        "hd15iqr": 0.8346219000086421,
+        "ops": 1.2114947591871803,
+        "total": 2.476279800015618,
+        "data": [0.8340466000081506, 0.8076112999988254, 0.8346219000086421],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7927287000056822,
+        "max": 0.8210790000011912,
+        "mean": 0.8033825000020443,
+        "stddev": 0.015431610251550492,
+        "rounds": 3,
+        "median": 0.7963397999992594,
+        "iqr": 0.021262724996631732,
+        "q1": 0.7936314750040765,
+        "q3": 0.8148942000007082,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7927287000056822,
+        "hd15iqr": 0.8210790000011912,
+        "ops": 1.244737095962951,
+        "total": 2.4101475000061328,
+        "data": [0.7963397999992594, 0.7927287000056822, 0.8210790000011912],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.807962699997006,
+        "max": 0.8135627000010572,
+        "mean": 0.8109744666677822,
+        "stddev": 0.0028239219849926236,
+        "rounds": 3,
+        "median": 0.8113980000052834,
+        "iqr": 0.00420000000303844,
+        "q1": 0.8088215249990753,
+        "q3": 0.8130215250021138,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.807962699997006,
+        "hd15iqr": 0.8135627000010572,
+        "ops": 1.2330844448271052,
+        "total": 2.4329234000033466,
+        "data": [0.8135627000010572, 0.8113980000052834, 0.807962699997006],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8320539999986067,
+        "max": 0.8563695000048028,
+        "mean": 0.8477064999994278,
+        "stddev": 0.013581263482371098,
+        "rounds": 3,
+        "median": 0.854695999994874,
+        "iqr": 0.018236625004647067,
+        "q1": 0.8377144999976736,
+        "q3": 0.8559511250023206,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8320539999986067,
+        "hd15iqr": 0.8563695000048028,
+        "ops": 1.1796535711365608,
+        "total": 2.5431194999982836,
+        "data": [0.854695999994874, 0.8320539999986067, 0.8563695000048028],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.83411189999606,
+        "max": 0.863760899999761,
+        "mean": 0.8529950999994375,
+        "stddev": 0.016406856414683795,
+        "rounds": 3,
+        "median": 0.8611125000024913,
+        "iqr": 0.022236750002775807,
+        "q1": 0.8408620499976678,
+        "q3": 0.8630988000004436,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.83411189999606,
+        "hd15iqr": 0.863760899999761,
+        "ops": 1.1723396769813326,
+        "total": 2.5589852999983123,
+        "data": [0.8611125000024913, 0.863760899999761, 0.83411189999606],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8697905000008177,
+        "max": 0.8973228999966523,
+        "mean": 0.8856115333328489,
+        "stddev": 0.014218835482402038,
+        "rounds": 3,
+        "median": 0.8897212000010768,
+        "iqr": 0.020649299996875925,
+        "q1": 0.8747731750008825,
+        "q3": 0.8954224749977584,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8697905000008177,
+        "hd15iqr": 0.8973228999966523,
+        "ops": 1.1291632531440388,
+        "total": 2.6568345999985468,
+        "data": [0.8697905000008177, 0.8897212000010768, 0.8973228999966523],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6951009999902453,
+        "max": 0.7366911999997683,
+        "mean": 0.7214723999980682,
+        "stddev": 0.02292861856677061,
+        "rounds": 3,
+        "median": 0.732625000004191,
+        "iqr": 0.03119265000714222,
+        "q1": 0.7044819999937317,
+        "q3": 0.735674650000874,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6951009999902453,
+        "hd15iqr": 0.7366911999997683,
+        "ops": 1.3860544076290064,
+        "total": 2.1644171999942046,
+        "data": [0.732625000004191, 0.6951009999902453, 0.7366911999997683],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7011234000092372,
+        "max": 0.7348624000005657,
+        "mean": 0.7210003666696139,
+        "stddev": 0.01765544101181799,
+        "rounds": 3,
+        "median": 0.7270152999990387,
+        "iqr": 0.02530424999349634,
+        "q1": 0.7075963750066876,
+        "q3": 0.7329006250001839,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7011234000092372,
+        "hd15iqr": 0.7348624000005657,
+        "ops": 1.3869618466619074,
+        "total": 2.1630011000088416,
+        "data": [0.7348624000005657, 0.7011234000092372, 0.7270152999990387],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7161071000009542,
+        "max": 0.7464334999967832,
+        "mean": 0.7354093999989951,
+        "stddev": 0.016772569290657114,
+        "rounds": 3,
+        "median": 0.743687599999248,
+        "iqr": 0.022744799996871734,
+        "q1": 0.7230022250005277,
+        "q3": 0.7457470249973994,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7161071000009542,
+        "hd15iqr": 0.7464334999967832,
+        "ops": 1.3597868071870802,
+        "total": 2.2062281999969855,
+        "data": [0.7161071000009542, 0.7464334999967832, 0.743687599999248],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7347317999956431,
+        "max": 0.7638740999973379,
+        "mean": 0.7486958999991961,
+        "stddev": 0.014609036294185909,
+        "rounds": 3,
+        "median": 0.7474818000046071,
+        "iqr": 0.021856725001271116,
+        "q1": 0.7379192999978841,
+        "q3": 0.7597760249991552,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7347317999956431,
+        "hd15iqr": 0.7638740999973379,
+        "ops": 1.3356557715904065,
+        "total": 2.246087699997588,
+        "data": [0.7638740999973379, 0.7474818000046071, 0.7347317999956431],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7564304999978049,
+        "max": 0.7821140000014566,
+        "mean": 0.7699428333289688,
+        "stddev": 0.012894168802763247,
+        "rounds": 3,
+        "median": 0.7712839999876451,
+        "iqr": 0.019262625002738787,
+        "q1": 0.7601438749952649,
+        "q3": 0.7794064999980037,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7564304999978049,
+        "hd15iqr": 0.7821140000014566,
+        "ops": 1.2987977246003353,
+        "total": 2.3098284999869065,
+        "data": [0.7821140000014566, 0.7712839999876451, 0.7564304999978049],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7628100000001723,
+        "max": 0.7834075999999186,
+        "mean": 0.7702497999998741,
+        "stddev": 0.011427463604856802,
+        "rounds": 3,
+        "median": 0.7645317999995314,
+        "iqr": 0.01544819999980973,
+        "q1": 0.7632404500000121,
+        "q3": 0.7786886499998218,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7628100000001723,
+        "hd15iqr": 0.7834075999999186,
+        "ops": 1.2982801163988142,
+        "total": 2.3107493999996223,
+        "data": [0.7645317999995314, 0.7834075999999186, 0.7628100000001723],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7743375999998534,
+        "max": 0.8173890999896685,
+        "mean": 0.7901394333312055,
+        "stddev": 0.02369910502017416,
+        "rounds": 3,
+        "median": 0.7786916000040947,
+        "iqr": 0.03228862499236129,
+        "q1": 0.7754261000009137,
+        "q3": 0.807714724993275,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7743375999998534,
+        "hd15iqr": 0.8173890999896685,
+        "ops": 1.2655994091878546,
+        "total": 2.3704182999936165,
+        "data": [0.7786916000040947, 0.7743375999998534, 0.8173890999896685],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7813486000086414,
+        "max": 0.8126292000088142,
+        "mean": 0.7985988000048868,
+        "stddev": 0.01588692286396587,
+        "rounds": 3,
+        "median": 0.8018185999972047,
+        "iqr": 0.02346045000012964,
+        "q1": 0.7864661000057822,
+        "q3": 0.8099265500059118,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7813486000086414,
+        "hd15iqr": 0.8126292000088142,
+        "ops": 1.2521932164108946,
+        "total": 2.3957964000146603,
+        "data": [0.7813486000086414, 0.8126292000088142, 0.8018185999972047],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8176033999916399,
+        "max": 0.8302669999975478,
+        "mean": 0.8224398999930903,
+        "stddev": 0.006841012904599566,
+        "rounds": 3,
+        "median": 0.8194492999900831,
+        "iqr": 0.009497700004430953,
+        "q1": 0.8180648749912507,
+        "q3": 0.8275625749956816,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8176033999916399,
+        "hd15iqr": 0.8302669999975478,
+        "ops": 1.2158943164216638,
+        "total": 2.467319699979271,
+        "data": [0.8194492999900831, 0.8302669999975478, 0.8176033999916399],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8219283999933396,
+        "max": 0.8635209000058239,
+        "mean": 0.8405811666646817,
+        "stddev": 0.021125046195052705,
+        "rounds": 3,
+        "median": 0.8362941999948816,
+        "iqr": 0.031194375009363284,
+        "q1": 0.8255198499937251,
+        "q3": 0.8567142250030884,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8219283999933396,
+        "hd15iqr": 0.8635209000058239,
+        "ops": 1.1896531110349187,
+        "total": 2.521743499994045,
+        "data": [0.8635209000058239, 0.8219283999933396, 0.8362941999948816],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8273060000065016,
+        "max": 0.8537077000073623,
+        "mean": 0.8388364333368372,
+        "stddev": 0.013514189442547165,
+        "rounds": 3,
+        "median": 0.8354955999966478,
+        "iqr": 0.019801275000645546,
+        "q1": 0.8293534000040381,
+        "q3": 0.8491546750046837,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8273060000065016,
+        "hd15iqr": 0.8537077000073623,
+        "ops": 1.1921275236246767,
+        "total": 2.5165093000105117,
+        "data": [0.8354955999966478, 0.8273060000065016, 0.8537077000073623],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7805711999972118,
+        "max": 0.8108606000023428,
+        "mean": 0.7930317666662935,
+        "stddev": 0.015842211127979122,
+        "rounds": 3,
+        "median": 0.7876634999993257,
+        "iqr": 0.02271705000384827,
+        "q1": 0.7823442749977403,
+        "q3": 0.8050613250015886,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7805711999972118,
+        "hd15iqr": 0.8108606000023428,
+        "ops": 1.2609835343718312,
+        "total": 2.3790952999988804,
+        "data": [0.8108606000023428, 0.7876634999993257, 0.7805711999972118],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7991557999921497,
+        "max": 0.8206317000003764,
+        "mean": 0.8081343666660056,
+        "stddev": 0.011161982771855625,
+        "rounds": 3,
+        "median": 0.8046156000054907,
+        "iqr": 0.01610692500617006,
+        "q1": 0.800520749995485,
+        "q3": 0.816627675001655,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7991557999921497,
+        "hd15iqr": 0.8206317000003764,
+        "ops": 1.2374179854837069,
+        "total": 2.424403099998017,
+        "data": [0.8206317000003764, 0.8046156000054907, 0.7991557999921497],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8143618000030983,
+        "max": 0.8342849000036949,
+        "mean": 0.8261784333347654,
+        "stddev": 0.010466923182454775,
+        "rounds": 3,
+        "median": 0.8298885999975028,
+        "iqr": 0.014942325000447454,
+        "q1": 0.8182435000016994,
+        "q3": 0.8331858250021469,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8143618000030983,
+        "hd15iqr": 0.8342849000036949,
+        "ops": 1.2103922828917548,
+        "total": 2.478535300004296,
+        "data": [0.8298885999975028, 0.8342849000036949, 0.8143618000030983],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8126702000008663,
+        "max": 0.8400208999955794,
+        "mean": 0.829445933336198,
+        "stddev": 0.014691913696907612,
+        "rounds": 3,
+        "median": 0.8356467000121484,
+        "iqr": 0.0205130249960348,
+        "q1": 0.8184143250036868,
+        "q3": 0.8389273499997216,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8126702000008663,
+        "hd15iqr": 0.8400208999955794,
+        "ops": 1.205624091708786,
+        "total": 2.488337800008594,
+        "data": [0.8400208999955794, 0.8356467000121484, 0.8126702000008663],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.668570699999691,
+        "max": 0.7120505000057165,
+        "mean": 0.6922057666718805,
+        "stddev": 0.021986318979148566,
+        "rounds": 3,
+        "median": 0.6959961000102339,
+        "iqr": 0.0326098500045191,
+        "q1": 0.6754270500023267,
+        "q3": 0.7080369000068458,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.668570699999691,
+        "hd15iqr": 0.7120505000057165,
+        "ops": 1.444657135417972,
+        "total": 2.0766173000156414,
+        "data": [0.668570699999691, 0.7120505000057165, 0.6959961000102339],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7102426000055857,
+        "max": 0.7309698999888496,
+        "mean": 0.7199066999989251,
+        "stddev": 0.010434239394866629,
+        "rounds": 3,
+        "median": 0.71850760000234,
+        "iqr": 0.01554547498744796,
+        "q1": 0.7123088500047743,
+        "q3": 0.7278543249922222,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7102426000055857,
+        "hd15iqr": 0.7309698999888496,
+        "ops": 1.3890688890678375,
+        "total": 2.1597200999967754,
+        "data": [0.7102426000055857, 0.71850760000234, 0.7309698999888496],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.719490899995435,
+        "max": 0.7320968999993056,
+        "mean": 0.7257539666655551,
+        "stddev": 0.00630337949336432,
+        "rounds": 3,
+        "median": 0.7256741000019247,
+        "iqr": 0.009454500002902932,
+        "q1": 0.7210366999970574,
+        "q3": 0.7304911999999604,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.719490899995435,
+        "hd15iqr": 0.7320968999993056,
+        "ops": 1.3778774156680897,
+        "total": 2.1772618999966653,
+        "data": [0.719490899995435, 0.7320968999993056, 0.7256741000019247],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7231812999962131,
+        "max": 0.7440482999954838,
+        "mean": 0.7340184333297657,
+        "stddev": 0.010456896377374075,
+        "rounds": 3,
+        "median": 0.7348256999976002,
+        "iqr": 0.01565024999945308,
+        "q1": 0.7260923999965598,
+        "q3": 0.7417426499960129,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7231812999962131,
+        "hd15iqr": 0.7440482999954838,
+        "ops": 1.3623636064065154,
+        "total": 2.202055299989297,
+        "data": [0.7440482999954838, 0.7231812999962131, 0.7348256999976002],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7484088000055635,
+        "max": 0.761484400005429,
+        "mean": 0.752969400001651,
+        "stddev": 0.007380432806058085,
+        "rounds": 3,
+        "median": 0.7490149999939604,
+        "iqr": 0.009806699999899138,
+        "q1": 0.7485603500026627,
+        "q3": 0.7583670500025619,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7484088000055635,
+        "hd15iqr": 0.761484400005429,
+        "ops": 1.328075217927591,
+        "total": 2.258908200004953,
+        "data": [0.7484088000055635, 0.761484400005429, 0.7490149999939604],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7213203999999678,
+        "max": 0.7608910999988439,
+        "mean": 0.7382518333324697,
+        "stddev": 0.020393493953359498,
+        "rounds": 3,
+        "median": 0.7325439999985974,
+        "iqr": 0.02967802499915706,
+        "q1": 0.7241262999996252,
+        "q3": 0.7538043249987822,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7213203999999678,
+        "hd15iqr": 0.7608910999988439,
+        "ops": 1.3545513263218036,
+        "total": 2.214755499997409,
+        "data": [0.7213203999999678, 0.7608910999988439, 0.7325439999985974],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7437929000006989,
+        "max": 0.7548608999932185,
+        "mean": 0.7484464333295667,
+        "stddev": 0.005740280534587886,
+        "rounds": 3,
+        "median": 0.7466854999947827,
+        "iqr": 0.008300999994389713,
+        "q1": 0.7445160499992198,
+        "q3": 0.7528170499936095,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7437929000006989,
+        "hd15iqr": 0.7548608999932185,
+        "ops": 1.3361009625650333,
+        "total": 2.2453392999887,
+        "data": [0.7548608999932185, 0.7437929000006989, 0.7466854999947827],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.733747600010247,
+        "max": 0.7623308000038378,
+        "mean": 0.7483776666679963,
+        "stddev": 0.014303618755760182,
+        "rounds": 3,
+        "median": 0.7490545999899041,
+        "iqr": 0.021437399995193118,
+        "q1": 0.7375743500051613,
+        "q3": 0.7590117500003544,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.733747600010247,
+        "hd15iqr": 0.7623308000038378,
+        "ops": 1.3362237337363398,
+        "total": 2.245133000003989,
+        "data": [0.733747600010247, 0.7490545999899041, 0.7623308000038378],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7527415999938967,
+        "max": 0.7865664999990258,
+        "mean": 0.7696024333272362,
+        "stddev": 0.016912686301438704,
+        "rounds": 3,
+        "median": 0.7694991999887861,
+        "iqr": 0.025368675003846874,
+        "q1": 0.756930999992619,
+        "q3": 0.7822996749964659,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7527415999938967,
+        "hd15iqr": 0.7865664999990258,
+        "ops": 1.2993721910112495,
+        "total": 2.3088072999817086,
+        "data": [0.7865664999990258, 0.7527415999938967, 0.7694991999887861],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7576560000015888,
+        "max": 0.7675397999992128,
+        "mean": 0.7629058333356321,
+        "stddev": 0.004970597993712439,
+        "rounds": 3,
+        "median": 0.7635217000060948,
+        "iqr": 0.007412849998218007,
+        "q1": 0.7591224250027153,
+        "q3": 0.7665352750009333,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7576560000015888,
+        "hd15iqr": 0.7675397999992128,
+        "ops": 1.3107777609036328,
+        "total": 2.2887175000068964,
+        "data": [0.7675397999992128, 0.7635217000060948, 0.7576560000015888],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7675630000012461,
+        "max": 0.7848931000044104,
+        "mean": 0.7776584333381228,
+        "stddev": 0.0090122739077096,
+        "rounds": 3,
+        "median": 0.7805192000087118,
+        "iqr": 0.012997575002373196,
+        "q1": 0.7708020500031125,
+        "q3": 0.7837996250054857,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7675630000012461,
+        "hd15iqr": 0.7848931000044104,
+        "ops": 1.2859115996562518,
+        "total": 2.3329753000143683,
+        "data": [0.7848931000044104, 0.7675630000012461, 0.7805192000087118],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7503203999949619,
+        "max": 0.778691900006379,
+        "mean": 0.7611768666635422,
+        "stddev": 0.015312997284695712,
+        "rounds": 3,
+        "median": 0.7545182999892859,
+        "iqr": 0.021278625008562813,
+        "q1": 0.7513698749935429,
+        "q3": 0.7726485000021057,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7503203999949619,
+        "hd15iqr": 0.778691900006379,
+        "ops": 1.3137551123739328,
+        "total": 2.283530599990627,
+        "data": [0.7545182999892859, 0.778691900006379, 0.7503203999949619],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7439555999881122,
+        "max": 0.7651583000115352,
+        "mean": 0.7568768999966172,
+        "stddev": 0.011337333285816431,
+        "rounds": 3,
+        "median": 0.7615167999902042,
+        "iqr": 0.015902025017567212,
+        "q1": 0.7483458999886352,
+        "q3": 0.7642479250062024,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7439555999881122,
+        "hd15iqr": 0.7651583000115352,
+        "ops": 1.3212188137918721,
+        "total": 2.2706306999898516,
+        "data": [0.7615167999902042, 0.7439555999881122, 0.7651583000115352],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7748943000042345,
+        "max": 0.7891989999916404,
+        "mean": 0.7840761333306242,
+        "stddev": 0.007969474149866011,
+        "rounds": 3,
+        "median": 0.7881350999959977,
+        "iqr": 0.010728524990554433,
+        "q1": 0.7782045000021753,
+        "q3": 0.7889330249927298,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7748943000042345,
+        "hd15iqr": 0.7891989999916404,
+        "ops": 1.2753863527922567,
+        "total": 2.3522283999918727,
+        "data": [0.7748943000042345, 0.7891989999916404, 0.7881350999959977],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7491749999899184,
+        "max": 0.794278099987423,
+        "mean": 0.7675091666557515,
+        "stddev": 0.023705091728921417,
+        "rounds": 3,
+        "median": 0.7590743999899132,
+        "iqr": 0.03382732499812846,
+        "q1": 0.7516498499899171,
+        "q3": 0.7854771749880456,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7491749999899184,
+        "hd15iqr": 0.794278099987423,
+        "ops": 1.302916034680439,
+        "total": 2.3025274999672547,
+        "data": [0.7590743999899132, 0.7491749999899184, 0.794278099987423],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7625502000009874,
+        "max": 0.8012859000009485,
+        "mean": 0.7764560000020234,
+        "stddev": 0.02155494338184756,
+        "rounds": 3,
+        "median": 0.7655319000041345,
+        "iqr": 0.029051774999970803,
+        "q1": 0.7632956250017742,
+        "q3": 0.792347400001745,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7625502000009874,
+        "hd15iqr": 0.8012859000009485,
+        "ops": 1.2879029848406014,
+        "total": 2.3293680000060704,
+        "data": [0.7625502000009874, 0.7655319000041345, 0.8012859000009485],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.776618599993526,
+        "max": 0.8191458000073908,
+        "mean": 0.7972283666652705,
+        "stddev": 0.02129373568318683,
+        "rounds": 3,
+        "median": 0.7959206999948947,
+        "iqr": 0.03189540001039859,
+        "q1": 0.7814441249938682,
+        "q3": 0.8133395250042668,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.776618599993526,
+        "hd15iqr": 0.8191458000073908,
+        "ops": 1.2543457330587768,
+        "total": 2.3916850999958115,
+        "data": [0.8191458000073908, 0.7959206999948947, 0.776618599993526],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7697912000003271,
+        "max": 0.7936536999914097,
+        "mean": 0.7854708666660978,
+        "stddev": 0.013583320987780052,
+        "rounds": 3,
+        "median": 0.7929677000065567,
+        "iqr": 0.01789687499331194,
+        "q1": 0.7755853250018845,
+        "q3": 0.7934821999951964,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7697912000003271,
+        "hd15iqr": 0.7936536999914097,
+        "ops": 1.2731216935447436,
+        "total": 2.3564125999982934,
+        "data": [0.7929677000065567, 0.7936536999914097, 0.7697912000003271],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8017774000036297,
+        "max": 0.8257464999915101,
+        "mean": 0.812189699994633,
+        "stddev": 0.012290050804307387,
+        "rounds": 3,
+        "median": 0.8090451999887591,
+        "iqr": 0.017976824990910245,
+        "q1": 0.8035943499999121,
+        "q3": 0.8215711749908223,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8017774000036297,
+        "hd15iqr": 0.8257464999915101,
+        "ops": 1.2312394505946185,
+        "total": 2.436569099983899,
+        "data": [0.8090451999887591, 0.8257464999915101, 0.8017774000036297],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7934924000001047,
+        "max": 0.8172714999964228,
+        "mean": 0.8019090666639386,
+        "stddev": 0.013324569603564098,
+        "rounds": 3,
+        "median": 0.7949632999952883,
+        "iqr": 0.017834324997238582,
+        "q1": 0.7938601249989006,
+        "q3": 0.8116944499961392,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7934924000001047,
+        "hd15iqr": 0.8172714999964228,
+        "ops": 1.247024184625009,
+        "total": 2.4057271999918157,
+        "data": [0.7934924000001047, 0.8172714999964228, 0.7949632999952883],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8173351000004914,
+        "max": 0.8315149999980349,
+        "mean": 0.8222432999997787,
+        "stddev": 0.008034145266662398,
+        "rounds": 3,
+        "median": 0.8178798000008101,
+        "iqr": 0.010634924998157658,
+        "q1": 0.817471275000571,
+        "q3": 0.8281061999987287,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8173351000004914,
+        "hd15iqr": 0.8315149999980349,
+        "ops": 1.2161850391487155,
+        "total": 2.4667298999993363,
+        "data": [0.8315149999980349, 0.8178798000008101, 0.8173351000004914],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6926514999940991,
+        "max": 0.7137228999927174,
+        "mean": 0.7064937999966787,
+        "stddev": 0.011991738206795827,
+        "rounds": 3,
+        "median": 0.7131070000032196,
+        "iqr": 0.015803549998963717,
+        "q1": 0.6977653749963793,
+        "q3": 0.713568924995343,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6926514999940991,
+        "hd15iqr": 0.7137228999927174,
+        "ops": 1.415440588444939,
+        "total": 2.119481399990036,
+        "data": [0.7131070000032196, 0.7137228999927174, 0.6926514999940991],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6954226000088966,
+        "max": 0.7190556999994442,
+        "mean": 0.71001933333658,
+        "stddev": 0.012760059242661428,
+        "rounds": 3,
+        "median": 0.715579700001399,
+        "iqr": 0.017724824992910726,
+        "q1": 0.7004618750070222,
+        "q3": 0.7181866999999329,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6954226000088966,
+        "hd15iqr": 0.7190556999994442,
+        "ops": 1.4084123530844148,
+        "total": 2.1300580000097398,
+        "data": [0.7190556999994442, 0.6954226000088966, 0.715579700001399],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.37150029999611434,
+        "max": 0.3816028000001097,
+        "mean": 0.37509536666523974,
+        "stddev": 0.0056459309488769505,
+        "rounds": 3,
+        "median": 0.3721829999994952,
+        "iqr": 0.00757687500299653,
+        "q1": 0.37167097499695956,
+        "q3": 0.3792478499999561,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.37150029999611434,
+        "hd15iqr": 0.3816028000001097,
+        "ops": 2.665988676134374,
+        "total": 1.1252860999957193,
+        "data": [0.3816028000001097, 0.3721829999994952, 0.37150029999611434],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36290079999889713,
+        "max": 0.37923560000490397,
+        "mean": 0.37294336666915723,
+        "stddev": 0.008789492186641481,
+        "rounds": 3,
+        "median": 0.37669370000367053,
+        "iqr": 0.012251100004505133,
+        "q1": 0.3663490250000905,
+        "q3": 0.3786001250045956,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36290079999889713,
+        "hd15iqr": 0.37923560000490397,
+        "ops": 2.6813722655298298,
+        "total": 1.1188301000074716,
+        "data": [0.37923560000490397, 0.37669370000367053, 0.36290079999889713],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6015141999960179,
+        "max": 0.621671700006118,
+        "mean": 0.6129572999974092,
+        "stddev": 0.010352079713847181,
+        "rounds": 3,
+        "median": 0.6156859999900917,
+        "iqr": 0.015118125007575145,
+        "q1": 0.6050571499945363,
+        "q3": 0.6201752750021114,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6015141999960179,
+        "hd15iqr": 0.621671700006118,
+        "ops": 1.6314350118747696,
+        "total": 1.8388718999922276,
+        "data": [0.621671700006118, 0.6015141999960179, 0.6156859999900917],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7295656000060262,
+        "max": 0.7569507000007434,
+        "mean": 0.7398723999989064,
+        "stddev": 0.014895497128617138,
+        "rounds": 3,
+        "median": 0.7331008999899495,
+        "iqr": 0.020538824996037874,
+        "q1": 0.730449425002007,
+        "q3": 0.7509882499980449,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7295656000060262,
+        "hd15iqr": 0.7569507000007434,
+        "ops": 1.3515844083405166,
+        "total": 2.219617199996719,
+        "data": [0.7295656000060262, 0.7569507000007434, 0.7331008999899495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3710992999986047,
+        "max": 0.3829751000012038,
+        "mean": 0.37555646666927106,
+        "stddev": 0.006468104051016612,
+        "rounds": 3,
+        "median": 0.3725950000080047,
+        "iqr": 0.008906850001949351,
+        "q1": 0.3714732250009547,
+        "q3": 0.38038007500290405,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3710992999986047,
+        "hd15iqr": 0.3829751000012038,
+        "ops": 2.6627154336304826,
+        "total": 1.1266694000078132,
+        "data": [0.3725950000080047, 0.3710992999986047, 0.3829751000012038],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3642204999923706,
+        "max": 0.3758172999951057,
+        "mean": 0.371922233326283,
+        "stddev": 0.0066700431707889035,
+        "rounds": 3,
+        "median": 0.3757288999913726,
+        "iqr": 0.008697600002051331,
+        "q1": 0.3670975999921211,
+        "q3": 0.37579519999417244,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3642204999923706,
+        "hd15iqr": 0.3758172999951057,
+        "ops": 2.6887341234120625,
+        "total": 1.115766699978849,
+        "data": [0.3757288999913726, 0.3758172999951057, 0.3642204999923706],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3593456999951741,
+        "max": 0.37600340000062715,
+        "mean": 0.3667177666648058,
+        "stddev": 0.008492116662374689,
+        "rounds": 3,
+        "median": 0.36480419999861624,
+        "iqr": 0.01249327500408981,
+        "q1": 0.3607103249960346,
+        "q3": 0.3732036000001244,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3593456999951741,
+        "hd15iqr": 0.37600340000062715,
+        "ops": 2.7268926976042547,
+        "total": 1.1001532999944175,
+        "data": [0.37600340000062715, 0.36480419999861624, 0.3593456999951741],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6707305000018096,
+        "max": 0.6863677999936044,
+        "mean": 0.6807324333349243,
+        "stddev": 0.008685129023224636,
+        "rounds": 3,
+        "median": 0.6850990000093589,
+        "iqr": 0.011727974993846146,
+        "q1": 0.6743226250036969,
+        "q3": 0.686050599997543,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6707305000018096,
+        "hd15iqr": 0.6863677999936044,
+        "ops": 1.4690059574522936,
+        "total": 2.042197300004773,
+        "data": [0.6863677999936044, 0.6707305000018096, 0.6850990000093589],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8749218000011751,
+        "max": 0.9092945000011241,
+        "mean": 0.8931272333332648,
+        "stddev": 0.01727675371228657,
+        "rounds": 3,
+        "median": 0.8951653999974951,
+        "iqr": 0.025779524999961723,
+        "q1": 0.8799827000002551,
+        "q3": 0.9057622250002169,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8749218000011751,
+        "hd15iqr": 0.9092945000011241,
+        "ops": 1.1196613009636627,
+        "total": 2.6793816999997944,
+        "data": [0.8951653999974951, 0.9092945000011241, 0.8749218000011751],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3844171000091592,
+        "max": 0.4086745999957202,
+        "mean": 0.3953580333375915,
+        "stddev": 0.012302003970385271,
+        "rounds": 3,
+        "median": 0.3929824000078952,
+        "iqr": 0.01819312498992076,
+        "q1": 0.3865584250088432,
+        "q3": 0.40475154999876395,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3844171000091592,
+        "hd15iqr": 0.4086745999957202,
+        "ops": 2.5293529299456825,
+        "total": 1.1860741000127746,
+        "data": [0.3929824000078952, 0.4086745999957202, 0.3844171000091592],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6021771999949124,
+        "max": 0.6289532000082545,
+        "mean": 0.6194722999983545,
+        "stddev": 0.015001161132823328,
+        "rounds": 3,
+        "median": 0.6272864999918966,
+        "iqr": 0.020082000010006595,
+        "q1": 0.6084545249941584,
+        "q3": 0.628536525004165,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6021771999949124,
+        "hd15iqr": 0.6289532000082545,
+        "ops": 1.61427718398814,
+        "total": 1.8584168999950634,
+        "data": [0.6272864999918966, 0.6289532000082545, 0.6021771999949124],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8601582999981474,
+        "max": 0.8884446000010939,
+        "mean": 0.8777496666637793,
+        "stddev": 0.015352500983654614,
+        "rounds": 3,
+        "median": 0.8846460999920964,
+        "iqr": 0.02121472500220989,
+        "q1": 0.8662802499966347,
+        "q3": 0.8874949749988446,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8601582999981474,
+        "hd15iqr": 0.8884446000010939,
+        "ops": 1.1392769920390622,
+        "total": 2.6332489999913378,
+        "data": [0.8884446000010939, 0.8601582999981474, 0.8846460999920964],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3695676000061212,
+        "max": 0.3819755000004079,
+        "mean": 0.37511026666713104,
+        "stddev": 0.006308794062180089,
+        "rounds": 3,
+        "median": 0.37378769999486394,
+        "iqr": 0.009305924995715031,
+        "q1": 0.3706226250033069,
+        "q3": 0.3799285499990219,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3695676000061212,
+        "hd15iqr": 0.3819755000004079,
+        "ops": 2.6658827786427657,
+        "total": 1.125330800001393,
+        "data": [0.37378769999486394, 0.3819755000004079, 0.3695676000061212],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3651034000067739,
+        "max": 0.3755354000022635,
+        "mean": 0.36919736667186953,
+        "stddev": 0.005566285330020468,
+        "rounds": 3,
+        "median": 0.3669533000065712,
+        "iqr": 0.007823999996617204,
+        "q1": 0.3655658750067232,
+        "q3": 0.3733898750033404,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3651034000067739,
+        "hd15iqr": 0.3755354000022635,
+        "ops": 2.7085783655893922,
+        "total": 1.1075921000156086,
+        "data": [0.3755354000022635, 0.3669533000065712, 0.3651034000067739],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8228156999975909,
+        "max": 0.8383787000057055,
+        "mean": 0.8308915666663476,
+        "stddev": 0.007798185526967326,
+        "rounds": 3,
+        "median": 0.8314802999957465,
+        "iqr": 0.01167225000608596,
+        "q1": 0.8249818499971298,
+        "q3": 0.8366541000032157,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8228156999975909,
+        "hd15iqr": 0.8383787000057055,
+        "ops": 1.2035264770012517,
+        "total": 2.492674699999043,
+        "data": [0.8383787000057055, 0.8314802999957465, 0.8228156999975909],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1517539999913424,
+        "max": 1.1751298000017414,
+        "mean": 1.1605792666669004,
+        "stddev": 0.012696102365350787,
+        "rounds": 3,
+        "median": 1.1548540000076173,
+        "iqr": 0.01753185000779922,
+        "q1": 1.1525289999954111,
+        "q3": 1.1700608500032104,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1517539999913424,
+        "hd15iqr": 1.1751298000017414,
+        "ops": 0.8616386908857399,
+        "total": 3.481737800000701,
+        "data": [1.1751298000017414, 1.1517539999913424, 1.1548540000076173],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6833100999938324,
+        "max": 0.7257050000043819,
+        "mean": 0.7022426333326924,
+        "stddev": 0.021557398480418075,
+        "rounds": 3,
+        "median": 0.6977127999998629,
+        "iqr": 0.0317961750079121,
+        "q1": 0.68691077499534,
+        "q3": 0.7187069500032521,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6833100999938324,
+        "hd15iqr": 0.7257050000043819,
+        "ops": 1.4240092420111483,
+        "total": 2.106727899998077,
+        "data": [0.6833100999938324, 0.7257050000043819, 0.6977127999998629],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.367405900004087,
+        "max": 0.3827722999994876,
+        "mean": 0.3736752999975579,
+        "stddev": 0.008063997368584574,
+        "rounds": 3,
+        "median": 0.37084769998909906,
+        "iqr": 0.011524799996550428,
+        "q1": 0.36826635000034,
+        "q3": 0.37979114999689045,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.367405900004087,
+        "hd15iqr": 0.3827722999994876,
+        "ops": 2.6761201503191017,
+        "total": 1.1210258999926737,
+        "data": [0.37084769998909906, 0.3827722999994876, 0.367405900004087],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.353681399996276,
+        "max": 0.3572349000023678,
+        "mean": 0.35521069999958854,
+        "stddev": 0.0018277130738788556,
+        "rounds": 3,
+        "median": 0.3547158000001218,
+        "iqr": 0.0026651250045688357,
+        "q1": 0.35393999999723746,
+        "q3": 0.3566051250018063,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.353681399996276,
+        "hd15iqr": 0.3572349000023678,
+        "ops": 2.815230509669777,
+        "total": 1.0656320999987656,
+        "data": [0.3572349000023678, 0.353681399996276, 0.3547158000001218],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0148919000057504,
+        "max": 1.018919399997685,
+        "mean": 1.0166892999986885,
+        "stddev": 0.002048319071260829,
+        "rounds": 3,
+        "median": 1.01625659999263,
+        "iqr": 0.00302062499395106,
+        "q1": 1.0152330750024703,
+        "q3": 1.0182536999964213,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0148919000057504,
+        "hd15iqr": 1.018919399997685,
+        "ops": 0.9835846605263673,
+        "total": 3.0500678999960655,
+        "data": [1.0148919000057504, 1.018919399997685, 1.01625659999263],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0974093999975594,
+        "max": 1.1222133000119356,
+        "mean": 1.1124339333376458,
+        "stddev": 0.013207656642825905,
+        "rounds": 3,
+        "median": 1.1176791000034427,
+        "iqr": 0.0186029250107822,
+        "q1": 1.1024768249990302,
+        "q3": 1.1210797500098124,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0974093999975594,
+        "hd15iqr": 1.1222133000119356,
+        "ops": 0.8989297881265548,
+        "total": 3.3373018000129377,
+        "data": [1.1222133000119356, 1.0974093999975594, 1.1176791000034427],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.964311000003363,
+        "max": 0.9738545000000158,
+        "mean": 0.9703383000014583,
+        "stddev": 0.0052439312974415266,
+        "rounds": 3,
+        "median": 0.972849400000996,
+        "iqr": 0.00715762499748962,
+        "q1": 0.9664456000027712,
+        "q3": 0.9736032250002609,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.964311000003363,
+        "hd15iqr": 0.9738545000000158,
+        "ops": 1.0305684110361275,
+        "total": 2.911014900004375,
+        "data": [0.972849400000996, 0.964311000003363, 0.9738545000000158],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3652759000106016,
+        "max": 0.37761809999938123,
+        "mean": 0.3699772333347937,
+        "stddev": 0.006675561200021321,
+        "rounds": 3,
+        "median": 0.3670376999943983,
+        "iqr": 0.009256649991584709,
+        "q1": 0.3657163500065508,
+        "q3": 0.3749729999981355,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3652759000106016,
+        "hd15iqr": 0.37761809999938123,
+        "ops": 2.7028690143620175,
+        "total": 1.1099317000043811,
+        "data": [0.37761809999938123, 0.3652759000106016, 0.3670376999943983],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3568758999899728,
+        "max": 0.3727022999955807,
+        "mean": 0.364154266664021,
+        "stddev": 0.007989228645512244,
+        "rounds": 3,
+        "median": 0.3628846000065096,
+        "iqr": 0.0118698000042059,
+        "q1": 0.358378074994107,
+        "q3": 0.3702478749983129,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3568758999899728,
+        "hd15iqr": 0.3727022999955807,
+        "ops": 2.7460889286315244,
+        "total": 1.092462799992063,
+        "data": [0.3727022999955807, 0.3568758999899728, 0.3628846000065096],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2359949000092456,
+        "max": 1.2395584999903804,
+        "mean": 1.2374689999996917,
+        "stddev": 0.0018597981279186667,
+        "rounds": 3,
+        "median": 1.2368535999994492,
+        "iqr": 0.002672699985851068,
+        "q1": 1.2362095750067965,
+        "q3": 1.2388822749926476,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2359949000092456,
+        "hd15iqr": 1.2395584999903804,
+        "ops": 0.8081010514204793,
+        "total": 3.712406999999075,
+        "data": [1.2359949000092456, 1.2368535999994492, 1.2395584999903804],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.430488800004241,
+        "max": 1.4319108000054257,
+        "mean": 1.4309690000033395,
+        "stddev": 0.0008156757461829573,
+        "rounds": 3,
+        "median": 1.4305074000003515,
+        "iqr": 0.0010665000008884817,
+        "q1": 1.4304934500032687,
+        "q3": 1.4315599500041571,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.430488800004241,
+        "hd15iqr": 1.4319108000054257,
+        "ops": 0.6988271583784599,
+        "total": 4.292907000010018,
+        "data": [1.4305074000003515, 1.430488800004241, 1.4319108000054257],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3468981999903917,
+        "max": 1.364146099993377,
+        "mean": 1.3554389999965981,
+        "stddev": 0.00862515248522558,
+        "rounds": 3,
+        "median": 1.3552727000060258,
+        "iqr": 0.012935925002238946,
+        "q1": 1.3489918249943003,
+        "q3": 1.3619277499965392,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3468981999903917,
+        "hd15iqr": 1.364146099993377,
+        "ops": 0.7377683540185207,
+        "total": 4.066316999989795,
+        "data": [1.3552727000060258, 1.364146099993377, 1.3468981999903917],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3699059000064153,
+        "max": 0.38778129999991506,
+        "mean": 0.3776720666695231,
+        "stddev": 0.009165148786975929,
+        "rounds": 3,
+        "median": 0.3753290000022389,
+        "iqr": 0.013406549995124806,
+        "q1": 0.3712616750053712,
+        "q3": 0.384668225000496,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3699059000064153,
+        "hd15iqr": 0.38778129999991506,
+        "ops": 2.6477997401778635,
+        "total": 1.1330162000085693,
+        "data": [0.3753290000022389, 0.3699059000064153, 0.38778129999991506],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.35655949999636505,
+        "max": 0.3706750999990618,
+        "mean": 0.36287746666251525,
+        "stddev": 0.007173186248149723,
+        "rounds": 3,
+        "median": 0.36139779999211896,
+        "iqr": 0.010586700002022553,
+        "q1": 0.3577690749953035,
+        "q3": 0.3683557749973261,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.35655949999636505,
+        "hd15iqr": 0.3706750999990618,
+        "ops": 2.7557511608457737,
+        "total": 1.0886323999875458,
+        "data": [0.3706750999990618, 0.36139779999211896, 0.35655949999636505],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5820648000080837,
+        "max": 1.6078409999900032,
+        "mean": 1.5989333333321458,
+        "stddev": 0.014616246780032007,
+        "rounds": 3,
+        "median": 1.6068941999983508,
+        "iqr": 0.019332149986439617,
+        "q1": 1.5882721500056505,
+        "q3": 1.60760429999209,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5820648000080837,
+        "hd15iqr": 1.6078409999900032,
+        "ops": 0.6254169446302176,
+        "total": 4.796799999996438,
+        "data": [1.6068941999983508, 1.6078409999900032, 1.5820648000080837],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.214800500005367,
+        "max": 2.2166445999901043,
+        "mean": 2.2155796999965482,
+        "stddev": 0.000954669868040546,
+        "rounds": 3,
+        "median": 2.2152939999941736,
+        "iqr": 0.0013830749885528348,
+        "q1": 2.214923875002569,
+        "q3": 2.2163069499911217,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.214800500005367,
+        "hd15iqr": 2.2166445999901043,
+        "ops": 0.4513491435228251,
+        "total": 6.646739099989645,
+        "data": [2.2166445999901043, 2.2152939999941736, 2.214800500005367],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7649354000022868,
+        "max": 1.777289000005112,
+        "mean": 1.7702062000025762,
+        "stddev": 0.006373018614719139,
+        "rounds": 3,
+        "median": 1.7683942000003299,
+        "iqr": 0.009265200002118945,
+        "q1": 1.7658001000017975,
+        "q3": 1.7750653000039165,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7649354000022868,
+        "hd15iqr": 1.777289000005112,
+        "ops": 0.564905941465206,
+        "total": 5.310618600007729,
+        "data": [1.7649354000022868, 1.777289000005112, 1.7683942000003299],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3713558000017656,
+        "max": 0.38271560000430327,
+        "mean": 0.3761383000043376,
+        "stddev": 0.0058887387696685035,
+        "rounds": 3,
+        "median": 0.37434350000694394,
+        "iqr": 0.00851985000190325,
+        "q1": 0.3721027250030602,
+        "q3": 0.38062257500496344,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3713558000017656,
+        "hd15iqr": 0.38271560000430327,
+        "ops": 2.658596585321059,
+        "total": 1.1284149000130128,
+        "data": [0.38271560000430327, 0.3713558000017656, 0.37434350000694394],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34759889999986626,
+        "max": 0.36306239999248646,
+        "mean": 0.3540481666617173,
+        "stddev": 0.008044516673793203,
+        "rounds": 3,
+        "median": 0.3514831999927992,
+        "iqr": 0.01159762499446515,
+        "q1": 0.3485699749980995,
+        "q3": 0.36016759999256465,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34759889999986626,
+        "hd15iqr": 0.36306239999248646,
+        "ops": 2.8244744477252746,
+        "total": 1.062144499985152,
+        "data": [0.3514831999927992, 0.34759889999986626, 0.36306239999248646],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.1965377000014996,
+        "max": 2.2319182000064757,
+        "mean": 2.210050533336471,
+        "stddev": 0.019112754254493762,
+        "rounds": 3,
+        "median": 2.201695700001437,
+        "iqr": 0.026535375003732042,
+        "q1": 2.197827200001484,
+        "q3": 2.224362575005216,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.1965377000014996,
+        "hd15iqr": 2.2319182000064757,
+        "ops": 0.4524783415202363,
+        "total": 6.6301516000094125,
+        "data": [2.1965377000014996, 2.2319182000064757, 2.201695700001437],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.105037399989669,
+        "max": 3.125441199998022,
+        "mean": 3.1131742333333627,
+        "stddev": 0.010810747644447491,
+        "rounds": 3,
+        "median": 3.1090441000123974,
+        "iqr": 0.015302850006264634,
+        "q1": 3.1060390749953513,
+        "q3": 3.121341925001616,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.105037399989669,
+        "hd15iqr": 3.125441199998022,
+        "ops": 0.321215558478162,
+        "total": 9.339522700000089,
+        "data": [3.1090441000123974, 3.105037399989669, 3.125441199998022],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.6583099999988917,
+        "max": 2.714060199999949,
+        "mean": 2.681374099998114,
+        "stddev": 0.02909395750112348,
+        "rounds": 3,
+        "median": 2.6717520999955013,
+        "iqr": 0.04181265000079293,
+        "q1": 2.661670524998044,
+        "q3": 2.703483174998837,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.6583099999988917,
+        "hd15iqr": 2.714060199999949,
+        "ops": 0.37294311151909143,
+        "total": 8.044122299994342,
+        "data": [2.6583099999988917, 2.6717520999955013, 2.714060199999949],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3602170000085607,
+        "max": 0.3883629000047222,
+        "mean": 0.37803703333581024,
+        "stddev": 0.015497413399521997,
+        "rounds": 3,
+        "median": 0.38553119999414776,
+        "iqr": 0.021109424997121096,
+        "q1": 0.3665455500049575,
+        "q3": 0.3876549750020786,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3602170000085607,
+        "hd15iqr": 0.3883629000047222,
+        "ops": 2.645243486268977,
+        "total": 1.1341111000074307,
+        "data": [0.3883629000047222, 0.3602170000085607, 0.38553119999414776],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3422069999942323,
+        "max": 0.3876793999952497,
+        "mean": 0.3602169999988594,
+        "stddev": 0.024164968232264324,
+        "rounds": 3,
+        "median": 0.3507646000070963,
+        "iqr": 0.03410430000076303,
+        "q1": 0.3443463999974483,
+        "q3": 0.37845069999821135,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3422069999942323,
+        "hd15iqr": 0.3876793999952497,
+        "ops": 2.7761044037432057,
+        "total": 1.0806509999965783,
+        "data": [0.3876793999952497, 0.3422069999942323, 0.3507646000070963],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.2096114000014495,
+        "max": 3.2790205999917816,
+        "mean": 3.2343649666630276,
+        "stddev": 0.0387489155208636,
+        "rounds": 3,
+        "median": 3.2144628999958513,
+        "iqr": 0.052056899992749095,
+        "q1": 3.21082427500005,
+        "q3": 3.262881174992799,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.2096114000014495,
+        "hd15iqr": 3.2790205999917816,
+        "ops": 0.3091797030660161,
+        "total": 9.703094899989082,
+        "data": [3.2790205999917816, 3.2096114000014495, 3.2144628999958513],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.906408100010594,
+        "max": 8.956561099999817,
+        "mean": 8.927107166668671,
+        "stddev": 0.026197645310736217,
+        "rounds": 3,
+        "median": 8.918352299995604,
+        "iqr": 0.03761474999191705,
+        "q1": 8.909394150006847,
+        "q3": 8.947008899998764,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.906408100010594,
+        "hd15iqr": 8.956561099999817,
+        "ops": 0.11201837071405629,
+        "total": 26.781321500006015,
+        "data": [8.918352299995604, 8.906408100010594, 8.956561099999817],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.801935900002718,
+        "max": 3.8911251000099583,
+        "mean": 3.8483119666731604,
+        "stddev": 0.04470122168283409,
+        "rounds": 3,
+        "median": 3.8518749000068055,
+        "iqr": 0.06689190000543022,
+        "q1": 3.81442065000374,
+        "q3": 3.88131255000917,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.801935900002718,
+        "hd15iqr": 3.8911251000099583,
+        "ops": 0.25985419286692946,
+        "total": 11.544935900019482,
+        "data": [3.8518749000068055, 3.8911251000099583, 3.801935900002718],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36334810001426376,
+        "max": 0.4001713000034215,
+        "mean": 0.38527880000765435,
+        "stddev": 0.019394308669434094,
+        "rounds": 3,
+        "median": 0.3923170000052778,
+        "iqr": 0.027617399991868297,
+        "q1": 0.3705903250120173,
+        "q3": 0.39820772500388557,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36334810001426376,
+        "hd15iqr": 0.4001713000034215,
+        "ops": 2.595523034177154,
+        "total": 1.155836400022963,
+        "data": [0.36334810001426376, 0.3923170000052778, 0.4001713000034215],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.34579669999948237,
+        "max": 0.35240810000686906,
+        "mean": 0.34924686667121324,
+        "stddev": 0.0033151567638559413,
+        "rounds": 3,
+        "median": 0.34953580000728834,
+        "iqr": 0.004958550005540019,
+        "q1": 0.34673147500143386,
+        "q3": 0.3516900250069739,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.34579669999948237,
+        "hd15iqr": 0.35240810000686906,
+        "ops": 2.8633041422284724,
+        "total": 1.0477406000136398,
+        "data": [0.35240810000686906, 0.34953580000728834, 0.34579669999948237],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.569464000000153,
+        "max": 6.608169099999941,
+        "mean": 6.588424966670573,
+        "stddev": 0.019364431414585027,
+        "rounds": 3,
+        "median": 6.587641800011625,
+        "iqr": 0.029028824999841163,
+        "q1": 6.574008450003021,
+        "q3": 6.603037275002862,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.569464000000153,
+        "hd15iqr": 6.608169099999941,
+        "ops": 0.15178134456395653,
+        "total": 19.76527490001172,
+        "data": [6.587641800011625, 6.608169099999941, 6.569464000000153],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 17.346255900003598,
+        "max": 17.361289899999974,
+        "mean": 17.353478200001216,
+        "stddev": 0.007534310402669218,
+        "rounds": 3,
+        "median": 17.352888800000073,
+        "iqr": 0.011275499997282168,
+        "q1": 17.347914125002717,
+        "q3": 17.359189625,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 17.346255900003598,
+        "hd15iqr": 17.361289899999974,
+        "ops": 0.05762533530597514,
+        "total": 52.060434600003646,
+        "data": [17.352888800000073, 17.346255900003598, 17.361289899999974],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 13.089032000003499,
+        "max": 13.286074200004805,
+        "mean": 13.186646033335515,
+        "stddev": 0.09853362601245684,
+        "rounds": 3,
+        "median": 13.184831899998244,
+        "iqr": 0.14778165000097943,
+        "q1": 13.112981975002185,
+        "q3": 13.260763625003165,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 13.089032000003499,
+        "hd15iqr": 13.286074200004805,
+        "ops": 0.0758342945940935,
+        "total": 39.55993810000655,
+        "data": [13.089032000003499, 13.184831899998244, 13.286074200004805],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7055491000064649,
+        "max": 0.7184930000075838,
+        "mean": 0.7113601333403494,
+        "stddev": 0.006572409705017435,
+        "rounds": 3,
+        "median": 0.7100383000069996,
+        "iqr": 0.009707925000839168,
+        "q1": 0.7066714000065986,
+        "q3": 0.7163793250074377,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7055491000064649,
+        "hd15iqr": 0.7184930000075838,
+        "ops": 1.4057577212041361,
+        "total": 2.1340804000210483,
+        "data": [0.7184930000075838, 0.7100383000069996, 0.7055491000064649],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7020751000090968,
+        "max": 0.716449499988812,
+        "mean": 0.7085788333351957,
+        "stddev": 0.007284038971313775,
+        "rounds": 3,
+        "median": 0.7072119000076782,
+        "iqr": 0.010780799984786427,
+        "q1": 0.7033593000087421,
+        "q3": 0.7141400999935286,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7020751000090968,
+        "hd15iqr": 0.716449499988812,
+        "ops": 1.4112755743678087,
+        "total": 2.125736500005587,
+        "data": [0.7072119000076782, 0.716449499988812, 0.7020751000090968],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3386802000022726,
+        "max": 1.42148140000063,
+        "mean": 1.3840632000016437,
+        "stddev": 0.041971278388638456,
+        "rounds": 3,
+        "median": 1.3920280000020284,
+        "iqr": 0.062100899998768,
+        "q1": 1.3520171500022116,
+        "q3": 1.4141180500009796,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3386802000022726,
+        "hd15iqr": 1.42148140000063,
+        "ops": 0.7225103593526744,
+        "total": 4.152189600004931,
+        "data": [1.3920280000020284, 1.42148140000063, 1.3386802000022726],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4372245999984443,
+        "max": 1.486604499994428,
+        "mean": 1.4664487333308596,
+        "stddev": 0.025908880455045198,
+        "rounds": 3,
+        "median": 1.4755170999997063,
+        "iqr": 0.037034924996987684,
+        "q1": 1.4467977249987598,
+        "q3": 1.4838326499957475,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4372245999984443,
+        "hd15iqr": 1.486604499994428,
+        "ops": 0.6819195088590803,
+        "total": 4.3993461999925785,
+        "data": [1.4372245999984443, 1.4755170999997063, 1.486604499994428],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8746986000041943,
+        "max": 1.8859287000086624,
+        "mean": 1.880229633335451,
+        "stddev": 0.00561693536820525,
+        "rounds": 3,
+        "median": 1.8800615999934962,
+        "iqr": 0.008422575003351085,
+        "q1": 1.8760393500015198,
+        "q3": 1.8844619250048709,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8746986000041943,
+        "hd15iqr": 1.8859287000086624,
+        "ops": 0.53184993059919,
+        "total": 5.640688900006353,
+        "data": [1.8859287000086624, 1.8800615999934962, 1.8746986000041943],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9167195999907563,
+        "max": 1.9467647999990731,
+        "mean": 1.935037166661156,
+        "stddev": 0.01607012529135557,
+        "rounds": 3,
+        "median": 1.9416270999936387,
+        "iqr": 0.022533900006237673,
+        "q1": 1.9229464749914769,
+        "q3": 1.9454803749977145,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9167195999907563,
+        "hd15iqr": 1.9467647999990731,
+        "ops": 0.5167859394274414,
+        "total": 5.805111499983468,
+        "data": [1.9167195999907563, 1.9467647999990731, 1.9416270999936387],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.4057982999947853,
+        "max": 2.4531699000071967,
+        "mean": 2.4261063333348525,
+        "stddev": 0.02439764424870975,
+        "rounds": 3,
+        "median": 2.419350800002576,
+        "iqr": 0.03552870000930852,
+        "q1": 2.409186424996733,
+        "q3": 2.4447151250060415,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.4057982999947853,
+        "hd15iqr": 2.4531699000071967,
+        "ops": 0.4121830878803363,
+        "total": 7.278319000004558,
+        "data": [2.4531699000071967, 2.419350800002576, 2.4057982999947853],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.776465200004168,
+        "max": 2.816562199994223,
+        "mean": 2.8000882666674443,
+        "stddev": 0.0209827293898551,
+        "rounds": 3,
+        "median": 2.8072374000039417,
+        "iqr": 0.030072749992541503,
+        "q1": 2.7841582500041113,
+        "q3": 2.814230999996653,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.776465200004168,
+        "hd15iqr": 2.816562199994223,
+        "ops": 0.35713159899425634,
+        "total": 8.400264800002333,
+        "data": [2.816562199994223, 2.8072374000039417, 2.776465200004168],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.973304300001473,
+        "max": 2.9885687999922084,
+        "mean": 2.981894833331656,
+        "stddev": 0.007810644073387462,
+        "rounds": 3,
+        "median": 2.9838114000012865,
+        "iqr": 0.011448374993051402,
+        "q1": 2.9759310750014265,
+        "q3": 2.987379449994478,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.973304300001473,
+        "hd15iqr": 2.9885687999922084,
+        "ops": 0.3353572328648174,
+        "total": 8.945684499994968,
+        "data": [2.9838114000012865, 2.9885687999922084, 2.973304300001473],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.053421300006448,
+        "max": 4.083941200005938,
+        "mean": 4.073036133335942,
+        "stddev": 0.01702237058819627,
+        "rounds": 3,
+        "median": 4.08174589999544,
+        "iqr": 0.022889924999617506,
+        "q1": 4.060502450003696,
+        "q3": 4.083392375003314,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.053421300006448,
+        "hd15iqr": 4.083941200005938,
+        "ops": 0.24551709517513393,
+        "total": 12.219108400007826,
+        "data": [4.08174589999544, 4.083941200005938, 4.053421300006448],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.928318299993407,
+        "max": 4.955670600000303,
+        "mean": 4.943448599995463,
+        "stddev": 0.013906140211150239,
+        "rounds": 3,
+        "median": 4.946356899992679,
+        "iqr": 0.020514225005172193,
+        "q1": 4.932827949993225,
+        "q3": 4.953342174998397,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.928318299993407,
+        "hd15iqr": 4.955670600000303,
+        "ops": 0.20228793316489985,
+        "total": 14.83034579998639,
+        "data": [4.955670600000303, 4.928318299993407, 4.946356899992679],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1322557999956189,
+        "max": 1.155650999993668,
+        "mean": 1.1444418666602967,
+        "stddev": 0.011728156069371767,
+        "rounds": 3,
+        "median": 1.145418799991603,
+        "iqr": 0.0175463999985368,
+        "q1": 1.135546549994615,
+        "q3": 1.1530929499931517,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1322557999956189,
+        "hd15iqr": 1.155650999993668,
+        "ops": 0.8737883759165452,
+        "total": 3.43332559998089,
+        "data": [1.155650999993668, 1.145418799991603, 1.1322557999956189],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.23406889999751,
+        "max": 1.265793600003235,
+        "mean": 1.244715633331604,
+        "stddev": 0.01825437260822516,
+        "rounds": 3,
+        "median": 1.234284399994067,
+        "iqr": 0.02379352500429377,
+        "q1": 1.2341227749966492,
+        "q3": 1.257916300000943,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.23406889999751,
+        "hd15iqr": 1.265793600003235,
+        "ops": 0.8033963527262862,
+        "total": 3.734146899994812,
+        "data": [1.265793600003235, 1.234284399994067, 1.23406889999751],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.597616700004437,
+        "max": 1.6187988000019686,
+        "mean": 1.6050560000003316,
+        "stddev": 0.01191515523684666,
+        "rounds": 3,
+        "median": 1.598752499994589,
+        "iqr": 0.015886574998148717,
+        "q1": 1.597900650001975,
+        "q3": 1.6137872250001237,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.597616700004437,
+        "hd15iqr": 1.6187988000019686,
+        "ops": 0.6230312213404351,
+        "total": 4.815168000000995,
+        "data": [1.598752499994589, 1.597616700004437, 1.6187988000019686],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7086858999973629,
+        "max": 1.7319155000004685,
+        "mean": 1.7223510999998932,
+        "stddev": 0.012145616475424217,
+        "rounds": 3,
+        "median": 1.7264519000018481,
+        "iqr": 0.01742220000232919,
+        "q1": 1.7131273999984842,
+        "q3": 1.7305496000008134,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7086858999973629,
+        "hd15iqr": 1.7319155000004685,
+        "ops": 0.5806017135530973,
+        "total": 5.167053299999679,
+        "data": [1.7264519000018481, 1.7319155000004685, 1.7086858999973629],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.1366135999996914,
+        "max": 2.1425342000002274,
+        "mean": 2.139523600000151,
+        "stddev": 0.002961581733048939,
+        "rounds": 3,
+        "median": 2.1394230000005336,
+        "iqr": 0.004440450000402052,
+        "q1": 2.137315949999902,
+        "q3": 2.141756400000304,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.1366135999996914,
+        "hd15iqr": 2.1425342000002274,
+        "ops": 0.4673937693418897,
+        "total": 6.418570800000452,
+        "data": [2.1366135999996914, 2.1425342000002274, 2.1394230000005336],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.381143799997517,
+        "max": 2.4022620000032475,
+        "mean": 2.391725433335523,
+        "stddev": 0.010559172132515306,
+        "rounds": 3,
+        "median": 2.391770500005805,
+        "iqr": 0.01583865000429796,
+        "q1": 2.383800474999589,
+        "q3": 2.399639125003887,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.381143799997517,
+        "hd15iqr": 2.4022620000032475,
+        "ops": 0.41810819338296307,
+        "total": 7.175176300006569,
+        "data": [2.4022620000032475, 2.381143799997517, 2.391770500005805],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.552759199999855,
+        "max": 2.575650900005712,
+        "mean": 2.5618771333344434,
+        "stddev": 0.01213528204590838,
+        "rounds": 3,
+        "median": 2.5572212999977637,
+        "iqr": 0.017168775004392955,
+        "q1": 2.553874724999332,
+        "q3": 2.571043500003725,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.552759199999855,
+        "hd15iqr": 2.575650900005712,
+        "ops": 0.3903387820548745,
+        "total": 7.685631400003331,
+        "data": [2.552759199999855, 2.5572212999977637, 2.575650900005712],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.421916200008127,
+        "max": 3.441914800001541,
+        "mean": 3.4351725000014994,
+        "stddev": 0.011480860044394858,
+        "rounds": 3,
+        "median": 3.4416864999948302,
+        "iqr": 0.014998949995060684,
+        "q1": 3.4268587750048027,
+        "q3": 3.4418577249998634,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.421916200008127,
+        "hd15iqr": 3.441914800001541,
+        "ops": 0.2911061962680371,
+        "total": 10.305517500004498,
+        "data": [3.421916200008127, 3.4416864999948302, 3.441914800001541],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.311605099996086,
+        "max": 4.325048500002595,
+        "mean": 4.317901333333187,
+        "stddev": 0.006761975790090552,
+        "rounds": 3,
+        "median": 4.3170504000008805,
+        "iqr": 0.010082550004881341,
+        "q1": 4.312966424997285,
+        "q3": 4.323048975002166,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.311605099996086,
+        "hd15iqr": 4.325048500002595,
+        "ops": 0.23159399041386938,
+        "total": 12.953703999999561,
+        "data": [4.3170504000008805, 4.311605099996086, 4.325048500002595],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.624257999996189,
+        "max": 0.6728968999959761,
+        "mean": 0.6538792999975461,
+        "stddev": 0.025995470540295634,
+        "rounds": 3,
+        "median": 0.6644830000004731,
+        "iqr": 0.036479174999840325,
+        "q1": 0.63431424999726,
+        "q3": 0.6707934249971004,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.624257999996189,
+        "hd15iqr": 0.6728968999959761,
+        "ops": 1.5293342364619171,
+        "total": 1.9616378999926383,
+        "data": [0.6644830000004731, 0.624257999996189, 0.6728968999959761],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6168572000024142,
+        "max": 0.7052089999924647,
+        "mean": 0.6465125999966403,
+        "stddev": 0.05083350176006065,
+        "rounds": 3,
+        "median": 0.6174715999950422,
+        "iqr": 0.06626384999253787,
+        "q1": 0.6170108000005712,
+        "q3": 0.683274649993109,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6168572000024142,
+        "hd15iqr": 0.7052089999924647,
+        "ops": 1.5467602642318132,
+        "total": 1.939537799989921,
+        "data": [0.6174715999950422, 0.6168572000024142, 0.7052089999924647],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9232695999962743,
+        "max": 0.9514152000047034,
+        "mean": 0.9345750000017384,
+        "stddev": 0.014866714775560567,
+        "rounds": 3,
+        "median": 0.9290402000042377,
+        "iqr": 0.02110920000632177,
+        "q1": 0.9247122499982652,
+        "q3": 0.945821450004587,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9232695999962743,
+        "hd15iqr": 0.9514152000047034,
+        "ops": 1.0700050825221517,
+        "total": 2.8037250000052154,
+        "data": [0.9514152000047034, 0.9232695999962743, 0.9290402000042377],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1109416999970563,
+        "max": 1.1379144999955315,
+        "mean": 1.1261417999970338,
+        "stddev": 0.013809174052674003,
+        "rounds": 3,
+        "median": 1.1295691999985138,
+        "iqr": 0.02022959999885643,
+        "q1": 1.1155985749974207,
+        "q3": 1.135828174996277,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1109416999970563,
+        "hd15iqr": 1.1379144999955315,
+        "ops": 0.8879876406351614,
+        "total": 3.3784253999911016,
+        "data": [1.1379144999955315, 1.1295691999985138, 1.1109416999970563],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1951880999986315,
+        "max": 1.2188250000035623,
+        "mean": 1.2061194000028383,
+        "stddev": 0.01191792204283131,
+        "rounds": 3,
+        "median": 1.2043451000063214,
+        "iqr": 0.017727675003698096,
+        "q1": 1.197477350000554,
+        "q3": 1.215205025004252,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1951880999986315,
+        "hd15iqr": 1.2188250000035623,
+        "ops": 0.829105310798953,
+        "total": 3.6183582000085153,
+        "data": [1.2188250000035623, 1.1951880999986315, 1.2043451000063214],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2493395000055898,
+        "max": 1.3053081999969436,
+        "mean": 1.276870433333291,
+        "stddev": 0.027995367557953864,
+        "rounds": 3,
+        "median": 1.2759635999973398,
+        "iqr": 0.04197652499351534,
+        "q1": 1.2559955250035273,
+        "q3": 1.2979720499970426,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2493395000055898,
+        "hd15iqr": 1.3053081999969436,
+        "ops": 0.7831648175841018,
+        "total": 3.830611299999873,
+        "data": [1.3053081999969436, 1.2493395000055898, 1.2759635999973398],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6004509000049438,
+        "max": 1.6426182000141125,
+        "mean": 1.6205007000050198,
+        "stddev": 0.021159556588248155,
+        "rounds": 3,
+        "median": 1.6184329999960028,
+        "iqr": 0.03162547500687651,
+        "q1": 1.6049464250027086,
+        "q3": 1.636571900009585,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6004509000049438,
+        "hd15iqr": 1.6426182000141125,
+        "ops": 0.6170932230988252,
+        "total": 4.861502100015059,
+        "data": [1.6004509000049438, 1.6426182000141125, 1.6184329999960028],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7039617000118596,
+        "max": 1.7406933000020217,
+        "mean": 1.720823466675938,
+        "stddev": 0.018549634989444362,
+        "rounds": 3,
+        "median": 1.717815400013933,
+        "iqr": 0.02754869999262155,
+        "q1": 1.707425125012378,
+        "q3": 1.7349738250049995,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7039617000118596,
+        "hd15iqr": 1.7406933000020217,
+        "ops": 0.5811171333754934,
+        "total": 5.162470400027814,
+        "data": [1.7406933000020217, 1.717815400013933, 1.7039617000118596],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.691063899997971,
+        "max": 1.7361819999932777,
+        "mean": 1.7084032333320163,
+        "stddev": 0.02430323153289846,
+        "rounds": 3,
+        "median": 1.6979638000047999,
+        "iqr": 0.03383857499648002,
+        "q1": 1.6927888749996782,
+        "q3": 1.7266274499961582,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.691063899997971,
+        "hd15iqr": 1.7361819999932777,
+        "ops": 0.5853419031815055,
+        "total": 5.125209699996049,
+        "data": [1.6979638000047999, 1.691063899997971, 1.7361819999932777],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7584574999928009,
+        "max": 1.8108995000075083,
+        "mean": 1.7810641666631757,
+        "stddev": 0.026957949807024158,
+        "rounds": 3,
+        "median": 1.773835499989218,
+        "iqr": 0.039331500011030585,
+        "q1": 1.7623019999919052,
+        "q3": 1.8016335000029358,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7584574999928009,
+        "hd15iqr": 1.8108995000075083,
+        "ops": 0.5614620847004632,
+        "total": 5.343192499989527,
+        "data": [1.773835499989218, 1.8108995000075083, 1.7584574999928009],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.897165499991388,
+        "max": 1.9423734000010882,
+        "mean": 1.9233458999951836,
+        "stddev": 0.023437396178044852,
+        "rounds": 3,
+        "median": 1.9304987999930745,
+        "iqr": 0.03390592500727507,
+        "q1": 1.9054988249918097,
+        "q3": 1.9394047499990847,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.897165499991388,
+        "hd15iqr": 1.9423734000010882,
+        "ops": 0.5199272788126692,
+        "total": 5.770037699985551,
+        "data": [1.897165499991388, 1.9423734000010882, 1.9304987999930745],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.933711299992865,
+        "max": 1.9908583000069484,
+        "mean": 1.962495366669221,
+        "stddev": 0.028575827505412547,
+        "rounds": 3,
+        "median": 1.9629165000078501,
+        "iqr": 0.042860250010562595,
+        "q1": 1.9410125999966112,
+        "q3": 1.9838728500071738,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.933711299992865,
+        "hd15iqr": 1.9908583000069484,
+        "ops": 0.5095553431533528,
+        "total": 5.8874861000076635,
+        "data": [1.9629165000078501, 1.9908583000069484, 1.933711299992865],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.771597599989036,
+        "max": 3.8329813000018476,
+        "mean": 3.803923033333073,
+        "stddev": 0.030821996047930875,
+        "rounds": 3,
+        "median": 3.8071902000083355,
+        "iqr": 0.046037775009608595,
+        "q1": 3.780495749993861,
+        "q3": 3.8265335250034695,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.771597599989036,
+        "hd15iqr": 3.8329813000018476,
+        "ops": 0.2628864967133102,
+        "total": 11.41176909999922,
+        "data": [3.771597599989036, 3.8071902000083355, 3.8329813000018476],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.004776899993885,
+        "max": 4.07034580000618,
+        "mean": 4.038403333334524,
+        "stddev": 0.03281687020439731,
+        "rounds": 3,
+        "median": 4.040087300003506,
+        "iqr": 0.04917667500922107,
+        "q1": 4.0136044999962905,
+        "q3": 4.062781175005512,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.004776899993885,
+        "hd15iqr": 4.07034580000618,
+        "ops": 0.2476226165290668,
+        "total": 12.115210000003572,
+        "data": [4.040087300003506, 4.004776899993885, 4.07034580000618],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.214834400001564,
+        "max": 4.263547299997299,
+        "mean": 4.237010533329642,
+        "stddev": 0.024647474492131945,
+        "rounds": 3,
+        "median": 4.232649899990065,
+        "iqr": 0.036534674996801186,
+        "q1": 4.219288274998689,
+        "q3": 4.2558229499954905,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.214834400001564,
+        "hd15iqr": 4.263547299997299,
+        "ops": 0.2360154623486746,
+        "total": 12.711031599988928,
+        "data": [4.263547299997299, 4.232649899990065, 4.214834400001564],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.160828499996569,
+        "max": 6.223939100003918,
+        "mean": 6.183035699999891,
+        "stddev": 0.035466856065510526,
+        "rounds": 3,
+        "median": 6.164339499999187,
+        "iqr": 0.04733295000551152,
+        "q1": 6.1617062499972235,
+        "q3": 6.209039200002735,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.160828499996569,
+        "hd15iqr": 6.223939100003918,
+        "ops": 0.1617328523592412,
+        "total": 18.549107099999674,
+        "data": [6.160828499996569, 6.223939100003918, 6.164339499999187],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.3741369000053965,
+        "max": 6.451578399995924,
+        "mean": 6.407503766667408,
+        "stddev": 0.039815683849884306,
+        "rounds": 3,
+        "median": 6.396796000000904,
+        "iqr": 0.05808112499289564,
+        "q1": 6.379801675004273,
+        "q3": 6.437882799997169,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.3741369000053965,
+        "hd15iqr": 6.451578399995924,
+        "ops": 0.156067017112361,
+        "total": 19.222511300002225,
+        "data": [6.396796000000904, 6.451578399995924, 6.3741369000053965],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.566844600005425,
+        "max": 9.640324100008002,
+        "mean": 9.603593700002724,
+        "stddev": 0.03673975357054608,
+        "rounds": 3,
+        "median": 9.603612399994745,
+        "iqr": 0.05510962500193273,
+        "q1": 9.576036550002755,
+        "q3": 9.631146175004687,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.566844600005425,
+        "hd15iqr": 9.640324100008002,
+        "ops": 0.10412768711776263,
+        "total": 28.81078110000817,
+        "data": [9.640324100008002, 9.603612399994745, 9.566844600005425],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 12.34410490001028,
+        "max": 12.431599999996251,
+        "mean": 12.390083266669535,
+        "stddev": 0.04391785239950072,
+        "rounds": 3,
+        "median": 12.394544900002074,
+        "iqr": 0.06562132498947904,
+        "q1": 12.356714900008228,
+        "q3": 12.422336224997707,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 12.34410490001028,
+        "hd15iqr": 12.431599999996251,
+        "ops": 0.0807097077943045,
+        "total": 37.170249800008605,
+        "data": [12.34410490001028, 12.394544900002074, 12.431599999996251],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.36403640000207815,
+        "max": 0.3783849999890663,
+        "mean": 0.3728918999937984,
+        "stddev": 0.007742730829543018,
+        "rounds": 3,
+        "median": 0.37625429999025073,
+        "iqr": 0.01076144999024109,
+        "q1": 0.3670908749991213,
+        "q3": 0.3778523249893624,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.36403640000207815,
+        "hd15iqr": 0.3783849999890663,
+        "ops": 2.6817423495029824,
+        "total": 1.1186756999813952,
+        "data": [0.37625429999025073, 0.36403640000207815, 0.3783849999890663],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3768634000007296,
+        "max": 0.3848587999964366,
+        "mean": 0.38092606666517287,
+        "stddev": 0.003999283345318402,
+        "rounds": 3,
+        "median": 0.3810559999983525,
+        "iqr": 0.005996549996780232,
+        "q1": 0.3779115500001353,
+        "q3": 0.38390809999691555,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3768634000007296,
+        "hd15iqr": 0.3848587999964366,
+        "ops": 2.6251813344109682,
+        "total": 1.1427781999955187,
+        "data": [0.3768634000007296, 0.3848587999964366, 0.3810559999983525],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5025643999979366,
+        "max": 0.536727200000314,
+        "mean": 0.5161548333368652,
+        "stddev": 0.01812001022934713,
+        "rounds": 3,
+        "median": 0.509172900012345,
+        "iqr": 0.02562210000178311,
+        "q1": 0.5042165250015387,
+        "q3": 0.5298386250033218,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5025643999979366,
+        "hd15iqr": 0.536727200000314,
+        "ops": 1.9374031500105247,
+        "total": 1.5484645000105957,
+        "data": [0.509172900012345, 0.5025643999979366, 0.536727200000314],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.674742300005164,
+        "max": 0.7220880999957444,
+        "mean": 0.6960322666661037,
+        "stddev": 0.024030008489696515,
+        "rounds": 3,
+        "median": 0.6912663999974029,
+        "iqr": 0.03550934999293531,
+        "q1": 0.6788733250032237,
+        "q3": 0.714382674996159,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.674742300005164,
+        "hd15iqr": 0.7220880999957444,
+        "ops": 1.4367150028688451,
+        "total": 2.0880967999983113,
+        "data": [0.6912663999974029, 0.7220880999957444, 0.674742300005164],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7733864000038011,
+        "max": 0.7939248000038788,
+        "mean": 0.7851082333363593,
+        "stddev": 0.010572932395368669,
+        "rounds": 3,
+        "median": 0.7880135000013979,
+        "iqr": 0.015403800000058254,
+        "q1": 0.7770431750032003,
+        "q3": 0.7924469750032586,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7733864000038011,
+        "hd15iqr": 0.7939248000038788,
+        "ops": 1.2737097352175848,
+        "total": 2.355324700009078,
+        "data": [0.7939248000038788, 0.7880135000013979, 0.7733864000038011],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8389805000042543,
+        "max": 0.8916212000040105,
+        "mean": 0.8597867000013745,
+        "stddev": 0.02799961383438754,
+        "rounds": 3,
+        "median": 0.8487583999958588,
+        "iqr": 0.039480524999817135,
+        "q1": 0.8414249750021554,
+        "q3": 0.8809055000019725,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8389805000042543,
+        "hd15iqr": 0.8916212000040105,
+        "ops": 1.1630791683546644,
+        "total": 2.5793601000041235,
+        "data": [0.8389805000042543, 0.8487583999958588, 0.8916212000040105],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2979856999882031,
+        "max": 1.3360658000019612,
+        "mean": 1.3134367999979684,
+        "stddev": 0.020029108580009367,
+        "rounds": 3,
+        "median": 1.3062589000037406,
+        "iqr": 0.028560075010318542,
+        "q1": 1.3000539999920875,
+        "q3": 1.328614075002406,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2979856999882031,
+        "hd15iqr": 1.3360658000019612,
+        "ops": 0.7613613384378654,
+        "total": 3.940310399993905,
+        "data": [1.2979856999882031, 1.3360658000019612, 1.3062589000037406],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4412513999996008,
+        "max": 1.4800848000013502,
+        "mean": 1.4643454666705413,
+        "stddev": 0.020434708605759504,
+        "rounds": 3,
+        "median": 1.4717002000106731,
+        "iqr": 0.029125050001312047,
+        "q1": 1.448863600002369,
+        "q3": 1.477988650003681,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4412513999996008,
+        "hd15iqr": 1.4800848000013502,
+        "ops": 0.6828989625471944,
+        "total": 4.393036400011624,
+        "data": [1.4717002000106731, 1.4800848000013502, 1.4412513999996008],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.124858700000914,
+        "max": 2.14680890001182,
+        "mean": 2.138729233338381,
+        "stddev": 0.01206662432787702,
+        "rounds": 3,
+        "median": 2.14452010000241,
+        "iqr": 0.01646265000817948,
+        "q1": 2.129774050001288,
+        "q3": 2.1462367000094673,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.124858700000914,
+        "hd15iqr": 2.14680890001182,
+        "ops": 0.46756736870290116,
+        "total": 6.4161877000151435,
+        "data": [2.14680890001182, 2.14452010000241, 2.124858700000914],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.1817918000015197,
+        "max": 3.1920826000132365,
+        "mean": 3.187787366672031,
+        "stddev": 0.005351961443559578,
+        "rounds": 3,
+        "median": 3.1894877000013366,
+        "iqr": 0.007718100008787587,
+        "q1": 3.183715775001474,
+        "q3": 3.1914338750102615,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.1817918000015197,
+        "hd15iqr": 3.1920826000132365,
+        "ops": 0.31369720905945325,
+        "total": 9.563362100016093,
+        "data": [3.1817918000015197, 3.1920826000132365, 3.1894877000013366],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.927820700002485,
+        "max": 3.946445199995651,
+        "mean": 3.9373912000010023,
+        "stddev": 0.009322986602444355,
+        "rounds": 3,
+        "median": 3.937907700004871,
+        "iqr": 0.013968374994874466,
+        "q1": 3.9303424500030815,
+        "q3": 3.944310824997956,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.927820700002485,
+        "hd15iqr": 3.946445199995651,
+        "ops": 0.2539752717483966,
+        "total": 11.812173600003007,
+        "data": [3.946445199995651, 3.927820700002485, 3.937907700004871],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.365483000001404,
+        "max": 4.397824200001196,
+        "mean": 4.377705299998827,
+        "stddev": 0.017557207155046207,
+        "rounds": 3,
+        "median": 4.369808699993882,
+        "iqr": 0.024255899999843678,
+        "q1": 4.366564424999524,
+        "q3": 4.390820324999368,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.365483000001404,
+        "hd15iqr": 4.397824200001196,
+        "ops": 0.2284301777920656,
+        "total": 13.133115899996483,
+        "data": [4.365483000001404, 4.369808699993882, 4.397824200001196],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.404826600002707,
+        "max": 7.5139234000089345,
+        "mean": 7.47189626666659,
+        "stddev": 0.05870156981946901,
+        "rounds": 3,
+        "median": 7.496938799988129,
+        "iqr": 0.08182260000467068,
+        "q1": 7.4278546499990625,
+        "q3": 7.509677250003733,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.404826600002707,
+        "hd15iqr": 7.5139234000089345,
+        "ops": 0.1338348344664756,
+        "total": 22.41568879999977,
+        "data": [7.404826600002707, 7.496938799988129, 7.5139234000089345],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.875348500005202,
+        "max": 7.903785399990738,
+        "mean": 7.890297566666656,
+        "stddev": 0.0142746531427747,
+        "rounds": 3,
+        "median": 7.891758800004027,
+        "iqr": 0.021327674989152,
+        "q1": 7.8794510750049085,
+        "q3": 7.9007787499940605,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.875348500005202,
+        "hd15iqr": 7.903785399990738,
+        "ops": 0.12673793244814988,
+        "total": 23.670892699999968,
+        "data": [7.903785399990738, 7.875348500005202, 7.891758800004027],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 8.916060599993216,
+        "max": 8.99660290000611,
+        "mean": 8.948898400000568,
+        "stddev": 0.042279186362427536,
+        "rounds": 3,
+        "median": 8.934031700002379,
+        "iqr": 0.06040672500967048,
+        "q1": 8.920553374995507,
+        "q3": 8.980960100005177,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 8.916060599993216,
+        "hd15iqr": 8.99660290000611,
+        "ops": 0.11174559764807884,
+        "total": 26.846695200001705,
+        "data": [8.916060599993216, 8.99660290000611, 8.934031700002379],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 11.937022300000535,
+        "max": 11.973714299994754,
+        "mean": 11.960579533328806,
+        "stddev": 0.020446187282458717,
+        "rounds": 3,
+        "median": 11.971001999991131,
+        "iqr": 0.027518999995663762,
+        "q1": 11.945517224998184,
+        "q3": 11.973036224993848,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 11.937022300000535,
+        "hd15iqr": 11.973714299994754,
+        "ops": 0.08360798882808693,
+        "total": 35.88173859998642,
+        "data": [11.937022300000535, 11.971001999991131, 11.973714299994754],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 14.073782399995252,
+        "max": 14.142805400013458,
+        "mean": 14.10330510000737,
+        "stddev": 0.03557679031486731,
+        "rounds": 3,
+        "median": 14.093327500013402,
+        "iqr": 0.05176725001365412,
+        "q1": 14.07866867499979,
+        "q3": 14.130435925013444,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 14.073782399995252,
+        "hd15iqr": 14.142805400013458,
+        "ops": 0.07090536529621538,
+        "total": 42.30991530002211,
+        "data": [14.093327500013402, 14.073782399995252, 14.142805400013458],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 17.551444900003844,
+        "max": 17.6820269000018,
+        "mean": 17.635550666668376,
+        "stddev": 0.072971919358779,
+        "rounds": 3,
+        "median": 17.67318019999948,
+        "iqr": 0.09793649999846821,
+        "q1": 17.581878725002753,
+        "q3": 17.67981522500122,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 17.551444900003844,
+        "hd15iqr": 17.6820269000018,
+        "ops": 0.05670364475150893,
+        "total": 52.906652000005124,
+        "data": [17.6820269000018, 17.551444900003844, 17.67318019999948],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_write_zarr_python_benchmark.py::test_write_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 19.297967899998184,
+        "max": 19.384788900002604,
+        "mean": 19.329172199999448,
+        "stddev": 0.048285043914562085,
+        "rounds": 3,
+        "median": 19.304759799997555,
+        "iqr": 0.06511575000331504,
+        "q1": 19.299665874998027,
+        "q3": 19.364781625001342,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 19.297967899998184,
+        "hd15iqr": 19.384788900002604,
+        "ops": 0.05173527296735597,
+        "total": 57.987516599998344,
+        "data": [19.297967899998184, 19.304759799997555, 19.384788900002604],
+        "iterations": 1
+      }
+    }
+  ],
+  "datetime": "2025-05-02T15:06:30.454913+00:00",
+  "version": "5.1.0"
+}

--- a/example_results/0003_tensorstore.json
+++ b/example_results/0003_tensorstore.json
@@ -1,0 +1,18131 @@
+{
+  "machine_info": {
+    "node": "FLDSMDFR-2",
+    "processor": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "machine": "AMD64",
+    "python_compiler": "MSC v.1942 64 bit (AMD64)",
+    "python_implementation": "CPython",
+    "python_implementation_version": "3.13.2",
+    "python_version": "3.13.2",
+    "python_build": ["main", "Feb 17 2025 13:52:56"],
+    "release": "11",
+    "system": "Windows",
+    "cpu": {
+      "python_version": "3.13.2.final.0 (64 bit)",
+      "cpuinfo_version": [9, 0, 0],
+      "cpuinfo_version_string": "9.0.0",
+      "arch": "X86_64",
+      "bits": 64,
+      "count": 24,
+      "arch_string_raw": "AMD64",
+      "vendor_id_raw": "GenuineIntel",
+      "brand_raw": "13th Gen Intel(R) Core(TM) i7-13700K",
+      "hz_actual_friendly": "3.4000 GHz",
+      "hz_actual": [3400000000, 0],
+      "l2_cache_size": 25165824,
+      "stepping": 1,
+      "model": 183,
+      "family": 6,
+      "l3_cache_size": 31457280,
+      "hz_advertised_friendly": "3.4180 GHz",
+      "hz_advertised": [3418000000, 0],
+      "flags": [
+        "3dnow",
+        "3dnowprefetch",
+        "abm",
+        "acpi",
+        "adx",
+        "aes",
+        "apic",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "clflush",
+        "clflushopt",
+        "clwb",
+        "cmov",
+        "cx16",
+        "cx8",
+        "de",
+        "dts",
+        "erms",
+        "est",
+        "f16c",
+        "fma",
+        "fpu",
+        "fxsr",
+        "gfni",
+        "ht",
+        "hypervisor",
+        "ia64",
+        "intel_pt",
+        "invpcid",
+        "lahf_lm",
+        "mca",
+        "mce",
+        "mmx",
+        "monitor",
+        "movbe",
+        "msr",
+        "mtrr",
+        "osxsave",
+        "pae",
+        "pat",
+        "pbe",
+        "pcid",
+        "pclmulqdq",
+        "pdcm",
+        "pge",
+        "pni",
+        "popcnt",
+        "pse",
+        "pse36",
+        "rdpid",
+        "rdrnd",
+        "rdseed",
+        "sep",
+        "serial",
+        "sha",
+        "smap",
+        "smep",
+        "ss",
+        "sse",
+        "sse2",
+        "sse4_1",
+        "sse4_2",
+        "ssse3",
+        "tm",
+        "tm2",
+        "tsc",
+        "tscdeadline",
+        "umip",
+        "vaes",
+        "vme",
+        "vpclmulqdq",
+        "x2apic",
+        "xsave",
+        "xtpr"
+      ],
+      "l2_cache_line_size": 2048,
+      "l2_cache_associativity": 7
+    }
+  },
+  "commit_info": {
+    "id": "unknown",
+    "time": null,
+    "author_time": null,
+    "dirty": false,
+    "error": "FileNotFoundError(2, 'The system cannot find the file specified', None, 2, None)",
+    "project": "zarr-benchmarks",
+    "branch": "(unknown)"
+  },
+  "benchmarks": [
+    {
+      "group": "read",
+      "name": "test_read_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.914224325937538
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13234250000095926,
+        "max": 0.18257760000415146,
+        "mean": 0.16576243333596116,
+        "stddev": 0.028942702450309006,
+        "rounds": 3,
+        "median": 0.18236720000277273,
+        "iqr": 0.03767632500239415,
+        "q1": 0.14484867500141263,
+        "q3": 0.18252500000380678,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13234250000095926,
+        "hd15iqr": 0.18257760000415146,
+        "ops": 6.0327299731009445,
+        "total": 0.49728730000788346,
+        "data": [0.18257760000415146, 0.18236720000277273, 0.13234250000095926],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.913018675035653
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13654130000213627,
+        "max": 0.1711829999985639,
+        "mean": 0.1496366000016375,
+        "stddev": 0.018803660894503575,
+        "rounds": 3,
+        "median": 0.14118550000421237,
+        "iqr": 0.025981274997320725,
+        "q1": 0.1377023500026553,
+        "q3": 0.16368362499997602,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13654130000213627,
+        "hd15iqr": 0.1711829999985639,
+        "ops": 6.68285700148932,
+        "total": 0.44890980000491254,
+        "data": [0.13654130000213627, 0.1711829999985639, 0.14118550000421237],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9117313324079923
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1426628999906825,
+        "max": 0.1717318000009982,
+        "mean": 0.1617257333273301,
+        "stddev": 0.016515719897817825,
+        "rounds": 3,
+        "median": 0.1707824999903096,
+        "iqr": 0.021801675007736776,
+        "q1": 0.14969279999058926,
+        "q3": 0.17149447499832604,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1426628999906825,
+        "hd15iqr": 0.1717318000009982,
+        "ops": 6.183307872075109,
+        "total": 0.48517719998199027,
+        "data": [0.1707824999903096, 0.1426628999906825, 0.1717318000009982],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9118831378833097
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13725470000645146,
+        "max": 0.1746053000097163,
+        "mean": 0.1540339000057429,
+        "stddev": 0.018961867413511895,
+        "rounds": 3,
+        "median": 0.15024170000106096,
+        "iqr": 0.028012950002448633,
+        "q1": 0.14050145000510383,
+        "q3": 0.16851440000755247,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13725470000645146,
+        "hd15iqr": 0.1746053000097163,
+        "ops": 6.492077393110975,
+        "total": 0.4621017000172287,
+        "data": [0.1746053000097163, 0.13725470000645146, 0.15024170000106096],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4642344877110156
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10993150000285823,
+        "max": 0.16376349999336526,
+        "mean": 0.12792229999710494,
+        "stddev": 0.03103946908241831,
+        "rounds": 3,
+        "median": 0.11007189999509137,
+        "iqr": 0.04037399999288027,
+        "q1": 0.10996660000091651,
+        "q3": 0.1503405999937968,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10993150000285823,
+        "hd15iqr": 0.16376349999336526,
+        "ops": 7.817245312370332,
+        "total": 0.38376689999131486,
+        "data": [0.11007189999509137, 0.16376349999336526, 0.10993150000285823],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5200616451088684
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1013678000017535,
+        "max": 0.10616910000680946,
+        "mean": 0.10321663333646332,
+        "stddev": 0.0025839166664742485,
+        "rounds": 3,
+        "median": 0.10211300000082701,
+        "iqr": 0.003600975003791973,
+        "q1": 0.10155410000152187,
+        "q3": 0.10515507500531385,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1013678000017535,
+        "hd15iqr": 0.10616910000680946,
+        "ops": 9.688360951865402,
+        "total": 0.30964990000938997,
+        "data": [0.10616910000680946, 0.1013678000017535, 0.10211300000082701],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.6866312356489352
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10675760000594892,
+        "max": 0.13794999998935964,
+        "mean": 0.11723613333015237,
+        "stddev": 0.017939146873256002,
+        "rounds": 3,
+        "median": 0.10700079999514855,
+        "iqr": 0.023394299987558043,
+        "q1": 0.10681840000324883,
+        "q3": 0.13021269999080687,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10675760000594892,
+        "hd15iqr": 0.13794999998935964,
+        "ops": 8.529793431380652,
+        "total": 0.3517083999904571,
+        "data": [0.10700079999514855, 0.13794999998935964, 0.10675760000594892],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8606572672738344
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09125939999648836,
+        "max": 0.14255009999033064,
+        "mean": 0.1110089333281697,
+        "stddev": 0.027603730525328288,
+        "rounds": 3,
+        "median": 0.09921729999769013,
+        "iqr": 0.03846802499538171,
+        "q1": 0.0932488749967888,
+        "q3": 0.1317168999921705,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09125939999648836,
+        "hd15iqr": 0.14255009999033064,
+        "ops": 9.00828401840196,
+        "total": 0.3330267999845091,
+        "data": [0.14255009999033064, 0.09921729999769013, 0.09125939999648836],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8171489936212863
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2603969000047073,
+        "max": 0.2798832999978913,
+        "mean": 0.2702245666635766,
+        "stddev": 0.009744298334138759,
+        "rounds": 3,
+        "median": 0.2703934999881312,
+        "iqr": 0.014614799994888017,
+        "q1": 0.26289605000056326,
+        "q3": 0.2775108499954513,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2603969000047073,
+        "hd15iqr": 0.2798832999978913,
+        "ops": 3.7006257881985136,
+        "total": 0.8106736999907298,
+        "data": [0.2798832999978913, 0.2703934999881312, 0.2603969000047073],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5304642401510202
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10790459999407176,
+        "max": 0.11418839999532793,
+        "mean": 0.1107311333277418,
+        "stddev": 0.003189028695046728,
+        "rounds": 3,
+        "median": 0.1101003999938257,
+        "iqr": 0.004712850000942126,
+        "q1": 0.10845354999401025,
+        "q3": 0.11316639999495237,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10790459999407176,
+        "hd15iqr": 0.11418839999532793,
+        "ops": 9.030883816931611,
+        "total": 0.3321933999832254,
+        "data": [0.11418839999532793, 0.1101003999938257, 0.10790459999407176],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.523365051290682
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11249110000790097,
+        "max": 0.11477190000005066,
+        "mean": 0.1136176000048484,
+        "stddev": 0.001140654102247802,
+        "rounds": 3,
+        "median": 0.11358980000659358,
+        "iqr": 0.0017105999941122718,
+        "q1": 0.11276577500757412,
+        "q3": 0.11447637500168639,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11249110000790097,
+        "hd15iqr": 0.11477190000005066,
+        "ops": 8.801453295592646,
+        "total": 0.3408528000145452,
+        "data": [0.11249110000790097, 0.11358980000659358, 0.11477190000005066],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.6966832929881526
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11391490000823978,
+        "max": 0.12557299999753013,
+        "mean": 0.11967233333659048,
+        "stddev": 0.00583036968645611,
+        "rounds": 3,
+        "median": 0.11952910000400152,
+        "iqr": 0.008743574991967762,
+        "q1": 0.11531845000718022,
+        "q3": 0.12406202499914798,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11391490000823978,
+        "hd15iqr": 0.12557299999753013,
+        "ops": 8.356150265637417,
+        "total": 0.35901700000977144,
+        "data": [0.12557299999753013, 0.11952910000400152, 0.11391490000823978],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8872980780955457
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11336440000741277,
+        "max": 0.1580921999993734,
+        "mean": 0.12960606666456442,
+        "stddev": 0.024750540321281957,
+        "rounds": 3,
+        "median": 0.1173615999869071,
+        "iqr": 0.03354584999397048,
+        "q1": 0.11436370000228635,
+        "q3": 0.14790954999625683,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11336440000741277,
+        "hd15iqr": 0.1580921999993734,
+        "ops": 7.715688206078473,
+        "total": 0.38881819999369327,
+        "data": [0.1580921999993734, 0.1173615999869071, 0.11336440000741277],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8683566239149063
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1792496999987634,
+        "max": 0.2144681999925524,
+        "mean": 0.19121079999604262,
+        "stddev": 0.020144241874729144,
+        "rounds": 3,
+        "median": 0.17991449999681208,
+        "iqr": 0.026413874995341757,
+        "q1": 0.17941589999827556,
+        "q3": 0.20582977499361732,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1792496999987634,
+        "hd15iqr": 0.2144681999925524,
+        "ops": 5.229830114306809,
+        "total": 0.5736323999881279,
+        "data": [0.1792496999987634, 0.2144681999925524, 0.17991449999681208],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5897156177527803
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12743870000122115,
+        "max": 0.1893502000020817,
+        "mean": 0.14920463333449638,
+        "stddev": 0.03480828420386304,
+        "rounds": 3,
+        "median": 0.13082500000018626,
+        "iqr": 0.04643362500064541,
+        "q1": 0.12828527500096243,
+        "q3": 0.17471890000160784,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12743870000122115,
+        "hd15iqr": 0.1893502000020817,
+        "ops": 6.702204734876677,
+        "total": 0.4476139000034891,
+        "data": [0.12743870000122115, 0.1893502000020817, 0.13082500000018626],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5340090617551165
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12440210000204388,
+        "max": 0.13029629999073222,
+        "mean": 0.12696016666692836,
+        "stddev": 0.003023150537263216,
+        "rounds": 3,
+        "median": 0.126182100008009,
+        "iqr": 0.004420649991516257,
+        "q1": 0.12484710000353516,
+        "q3": 0.12926774999505142,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12440210000204388,
+        "hd15iqr": 0.13029629999073222,
+        "ops": 7.876486194472587,
+        "total": 0.3808805000007851,
+        "data": [0.126182100008009, 0.12440210000204388, 0.13029629999073222],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7601917840444248
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12857870000880212,
+        "max": 0.13997820000804495,
+        "mean": 0.13283560000612246,
+        "stddev": 0.006223551915554737,
+        "rounds": 3,
+        "median": 0.1299499000015203,
+        "iqr": 0.008549624999432126,
+        "q1": 0.12892150000698166,
+        "q3": 0.13747112500641379,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12857870000880212,
+        "hd15iqr": 0.13997820000804495,
+        "ops": 7.528102405935679,
+        "total": 0.39850680001836736,
+        "data": [0.13997820000804495, 0.12857870000880212, 0.1299499000015203],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9075788286648292
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12242539999715518,
+        "max": 0.12998139999399427,
+        "mean": 0.125246299993402,
+        "stddev": 0.004125700574512783,
+        "rounds": 3,
+        "median": 0.12333209998905659,
+        "iqr": 0.005666999997629318,
+        "q1": 0.12265207499513053,
+        "q3": 0.12831907499275985,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12242539999715518,
+        "hd15iqr": 0.12998139999399427,
+        "ops": 7.984267799149996,
+        "total": 0.37573889998020604,
+        "data": [0.12998139999399427, 0.12242539999715518, 0.12333209998905659],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9100529767800518
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1454295000003185,
+        "max": 0.2093178000068292,
+        "mean": 0.1710165666687923,
+        "stddev": 0.03378855198150033,
+        "rounds": 3,
+        "median": 0.15830239999922924,
+        "iqr": 0.04791622500488302,
+        "q1": 0.1486477250000462,
+        "q3": 0.1965639500049292,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1454295000003185,
+        "hd15iqr": 0.2093178000068292,
+        "ops": 5.847386715093512,
+        "total": 0.513049700006377,
+        "data": [0.15830239999922924, 0.1454295000003185, 0.2093178000068292],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904694144113216
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13245389999065083,
+        "max": 0.14068199999746867,
+        "mean": 0.13725476665907385,
+        "stddev": 0.004282587865365076,
+        "rounds": 3,
+        "median": 0.13862839998910204,
+        "iqr": 0.00617107500511338,
+        "q1": 0.13399752499026363,
+        "q3": 0.140168599995377,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13245389999065083,
+        "hd15iqr": 0.14068199999746867,
+        "ops": 7.2857214677570585,
+        "total": 0.4117642999772215,
+        "data": [0.14068199999746867, 0.13862839998910204, 0.13245389999065083],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5805273943657068
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13105260000156704,
+        "max": 0.14442650000273716,
+        "mean": 0.13590586666638652,
+        "stddev": 0.007402869986560455,
+        "rounds": 3,
+        "median": 0.13223849999485537,
+        "iqr": 0.010030425000877585,
+        "q1": 0.13134907499988913,
+        "q3": 0.1413795000007667,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13105260000156704,
+        "hd15iqr": 0.14442650000273716,
+        "ops": 7.358034090277643,
+        "total": 0.4077175999991596,
+        "data": [0.14442650000273716, 0.13105260000156704, 0.13223849999485537],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.79111622676226
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1334315999993123,
+        "max": 0.13704729999881238,
+        "mean": 0.13517739999709497,
+        "stddev": 0.00181104175264643,
+        "rounds": 3,
+        "median": 0.13505329999316018,
+        "iqr": 0.0027117749996250495,
+        "q1": 0.13383702499777428,
+        "q3": 0.13654879999739933,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1334315999993123,
+        "hd15iqr": 0.13704729999881238,
+        "ops": 7.397686299791908,
+        "total": 0.40553219999128487,
+        "data": [0.1334315999993123, 0.13704729999881238, 0.13505329999316018],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9550630388778114
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13201410000328906,
+        "max": 0.1349320000008447,
+        "mean": 0.1331118666663921,
+        "stddev": 0.0015874178104208357,
+        "rounds": 3,
+        "median": 0.13238949999504257,
+        "iqr": 0.002188424998166738,
+        "q1": 0.13210795000122744,
+        "q3": 0.13429637499939417,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13201410000328906,
+        "hd15iqr": 0.1349320000008447,
+        "ops": 7.512478226349436,
+        "total": 0.39933559999917634,
+        "data": [0.13238949999504257, 0.1349320000008447, 0.13201410000328906],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9737899612298675
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14343250000092667,
+        "max": 0.15800599999784026,
+        "mean": 0.14836053332934776,
+        "stddev": 0.008353882841441038,
+        "rounds": 3,
+        "median": 0.14364309998927638,
+        "iqr": 0.010930124997685198,
+        "q1": 0.1434851499980141,
+        "q3": 0.1544152749956993,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14343250000092667,
+        "hd15iqr": 0.15800599999784026,
+        "ops": 6.740337052982177,
+        "total": 0.4450815999880433,
+        "data": [0.15800599999784026, 0.14343250000092667, 0.14364309998927638],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5904694144113216
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13992770000186283,
+        "max": 0.1960990999941714,
+        "mean": 0.16070413332878766,
+        "stddev": 0.03080718555791338,
+        "rounds": 3,
+        "median": 0.14608559999032877,
+        "iqr": 0.042128549994231435,
+        "q1": 0.14146717499897932,
+        "q3": 0.18359572499321075,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13992770000186283,
+        "hd15iqr": 0.1960990999941714,
+        "ops": 6.222615307311859,
+        "total": 0.482112399986363,
+        "data": [0.1960990999941714, 0.14608559999032877, 0.13992770000186283],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5840497836680558
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13477509999938775,
+        "max": 0.1465835999988485,
+        "mean": 0.1396997000022869,
+        "stddev": 0.006143232895486752,
+        "rounds": 3,
+        "median": 0.13774040000862442,
+        "iqr": 0.008856374999595573,
+        "q1": 0.13551642500169692,
+        "q3": 0.1443728000012925,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13477509999938775,
+        "hd15iqr": 0.1465835999988485,
+        "ops": 7.1582115064214875,
+        "total": 0.4190991000068607,
+        "data": [0.1465835999988485, 0.13477509999938775, 0.13774040000862442],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8143134100785718
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13128349999897182,
+        "max": 0.13559689999965485,
+        "mean": 0.13338230000226758,
+        "stddev": 0.0021590303658000714,
+        "rounds": 3,
+        "median": 0.13326650000817608,
+        "iqr": 0.003235050000512274,
+        "q1": 0.13177925000127289,
+        "q3": 0.13501430000178516,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13128349999897182,
+        "hd15iqr": 0.13559689999965485,
+        "ops": 7.497246636045408,
+        "total": 0.40014690000680275,
+        "data": [0.13128349999897182, 0.13326650000817608, 0.13559689999965485],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9714590877102465
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12996090001252014,
+        "max": 0.16359229999943636,
+        "mean": 0.14343786666965266,
+        "stddev": 0.01778227170929694,
+        "rounds": 3,
+        "median": 0.1367603999970015,
+        "iqr": 0.025223549990187166,
+        "q1": 0.13166077500864048,
+        "q3": 0.15688432499882765,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12996090001252014,
+        "hd15iqr": 0.16359229999943636,
+        "ops": 6.971659738241012,
+        "total": 0.430313600008958,
+        "data": [0.16359229999943636, 0.1367603999970015, 0.12996090001252014],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9821304913956985
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14295760000823066,
+        "max": 0.20155009999871254,
+        "mean": 0.1763007000020783,
+        "stddev": 0.030123101575324603,
+        "rounds": 3,
+        "median": 0.18439439999929164,
+        "iqr": 0.04394437499286141,
+        "q1": 0.1533168000059959,
+        "q3": 0.1972611749988573,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14295760000823066,
+        "hd15iqr": 0.20155009999871254,
+        "ops": 5.672127223477909,
+        "total": 0.5289021000062348,
+        "data": [0.14295760000823066, 0.20155009999871254, 0.18439439999929164],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5851198582727186
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14581680000992492,
+        "max": 0.15205889999924693,
+        "mean": 0.14938700000251023,
+        "stddev": 0.0032165447659063704,
+        "rounds": 3,
+        "median": 0.15028529999835882,
+        "iqr": 0.004681574991991511,
+        "q1": 0.1469339250070334,
+        "q3": 0.1516154999990249,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14581680000992492,
+        "hd15iqr": 0.15205889999924693,
+        "ops": 6.694022906833904,
+        "total": 0.4481610000075307,
+        "data": [0.15205889999924693, 0.15028529999835882, 0.14581680000992492],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5886827425956431
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.15120909998950083,
+        "max": 0.2089648999972269,
+        "mean": 0.17116703332673447,
+        "stddev": 0.03275103852757116,
+        "rounds": 3,
+        "median": 0.1533270999934757,
+        "iqr": 0.04331685000579455,
+        "q1": 0.15173859999049455,
+        "q3": 0.1950554499962891,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.15120909998950083,
+        "hd15iqr": 0.2089648999972269,
+        "ops": 5.842246492004898,
+        "total": 0.5135010999802034,
+        "data": [0.15120909998950083, 0.2089648999972269, 0.1533270999934757],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8340812828523834
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13438040000619367,
+        "max": 0.1411091000045417,
+        "mean": 0.13696686666905103,
+        "stddev": 0.0036241079415077412,
+        "rounds": 3,
+        "median": 0.13541109999641776,
+        "iqr": 0.005046524998761015,
+        "q1": 0.1346380750037497,
+        "q3": 0.1396846000025107,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13438040000619367,
+        "hd15iqr": 0.1411091000045417,
+        "ops": 7.301035822161795,
+        "total": 0.4109006000071531,
+        "data": [0.1411091000045417, 0.13541109999641776, 0.13438040000619367],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9823656805842107
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12860399999772198,
+        "max": 0.13110079999023583,
+        "mean": 0.12970323332895836,
+        "stddev": 0.00127485474957516,
+        "rounds": 3,
+        "median": 0.12940489999891724,
+        "iqr": 0.0018725999943853822,
+        "q1": 0.1288042249980208,
+        "q3": 0.13067682499240618,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12860399999772198,
+        "hd15iqr": 0.13110079999023583,
+        "ops": 7.709908028767188,
+        "total": 0.38910969998687506,
+        "data": [0.13110079999023583, 0.12860399999772198, 0.12940489999891724],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9897964965379633
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13703060000261758,
+        "max": 0.1399742000066908,
+        "mean": 0.138805666671639,
+        "stddev": 0.0015627243070699336,
+        "rounds": 3,
+        "median": 0.1394122000056086,
+        "iqr": 0.0022077000030549243,
+        "q1": 0.13762600000336533,
+        "q3": 0.13983370000642026,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13703060000261758,
+        "hd15iqr": 0.1399742000066908,
+        "ops": 7.204316826384449,
+        "total": 0.416417000014917,
+        "data": [0.13703060000261758, 0.1394122000056086, 0.1399742000066908],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5977234138374985
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14958159999514464,
+        "max": 0.15539960000023711,
+        "mean": 0.15176456666570934,
+        "stddev": 0.003169172480673574,
+        "rounds": 3,
+        "median": 0.15031250000174623,
+        "iqr": 0.004363500003819354,
+        "q1": 0.14976432499679504,
+        "q3": 0.1541278250006144,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14958159999514464,
+        "hd15iqr": 0.15539960000023711,
+        "ops": 6.589153331177049,
+        "total": 0.455293699997128,
+        "data": [0.15539960000023711, 0.15031250000174623, 0.14958159999514464],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5925617390351816
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14482699999643955,
+        "max": 0.1479488000040874,
+        "mean": 0.14611146666963273,
+        "stddev": 0.0016326833681973667,
+        "rounds": 3,
+        "median": 0.14555860000837129,
+        "iqr": 0.002341350005735876,
+        "q1": 0.1450098999994225,
+        "q3": 0.14735125000515836,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14482699999643955,
+        "hd15iqr": 0.1479488000040874,
+        "ops": 6.844089808920084,
+        "total": 0.43833440000889823,
+        "data": [0.14482699999643955, 0.1479488000040874, 0.14555860000837129],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.850185027991414
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13090509999892674,
+        "max": 0.13868319999892265,
+        "mean": 0.13506629999998646,
+        "stddev": 0.003917512829808963,
+        "rounds": 3,
+        "median": 0.13561060000211,
+        "iqr": 0.005833574999996927,
+        "q1": 0.13208147499972256,
+        "q3": 0.13791504999971949,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13090509999892674,
+        "hd15iqr": 0.13868319999892265,
+        "ops": 7.403771333042367,
+        "total": 0.4051988999999594,
+        "data": [0.13868319999892265, 0.13090509999892674, 0.13561060000211],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9868239148614102
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12772119999863207,
+        "max": 0.16372799999953713,
+        "mean": 0.14124023333230676,
+        "stddev": 0.0196074232060875,
+        "rounds": 3,
+        "median": 0.1322714999987511,
+        "iqr": 0.027005100000678794,
+        "q1": 0.12885877499866183,
+        "q3": 0.15586387499934062,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12772119999863207,
+        "hd15iqr": 0.16372799999953713,
+        "ops": 7.0801355704873625,
+        "total": 0.4237206999969203,
+        "data": [0.12772119999863207, 0.16372799999953713, 0.1322714999987511],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9890810719617387
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14215270000568125,
+        "max": 0.15204929999890737,
+        "mean": 0.1472101333347382,
+        "stddev": 0.004951909036849498,
+        "rounds": 3,
+        "median": 0.14742839999962598,
+        "iqr": 0.007422449994919589,
+        "q1": 0.14347162500416744,
+        "q3": 0.15089407499908702,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14215270000568125,
+        "hd15iqr": 0.15204929999890737,
+        "ops": 6.793010626015261,
+        "total": 0.4416304000042146,
+        "data": [0.15204929999890737, 0.14215270000568125, 0.14742839999962598],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.6036520604079338
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14693190000252798,
+        "max": 0.2068899000005331,
+        "mean": 0.1683890666657438,
+        "stddev": 0.03341564560425212,
+        "rounds": 3,
+        "median": 0.1513453999941703,
+        "iqr": 0.04496849999850383,
+        "q1": 0.14803527500043856,
+        "q3": 0.1930037749989424,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14693190000252798,
+        "hd15iqr": 0.2068899000005331,
+        "ops": 5.938627844437331,
+        "total": 0.5051671999972314,
+        "data": [0.2068899000005331, 0.1513453999941703, 0.14693190000252798],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.599450353881047
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13963760000478942,
+        "max": 0.14892419999523554,
+        "mean": 0.1453152666654205,
+        "stddev": 0.004976944649195967,
+        "rounds": 3,
+        "median": 0.14738399999623653,
+        "iqr": 0.00696494999283459,
+        "q1": 0.1415742000026512,
+        "q3": 0.1485391499954858,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13963760000478942,
+        "hd15iqr": 0.14892419999523554,
+        "ops": 6.881589408650632,
+        "total": 0.4359457999962615,
+        "data": [0.13963760000478942, 0.14738399999623653, 0.14892419999523554],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8626931031095444
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13256160001037642,
+        "max": 0.1886808999988716,
+        "mean": 0.15458343333254257,
+        "stddev": 0.029945110590823883,
+        "rounds": 3,
+        "median": 0.1425077999883797,
+        "iqr": 0.04208947499137139,
+        "q1": 0.13504815000487724,
+        "q3": 0.17713762499624863,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13256160001037642,
+        "hd15iqr": 0.1886808999988716,
+        "ops": 6.468998510654001,
+        "total": 0.46375029999762774,
+        "data": [0.13256160001037642, 0.1886808999988716, 0.1425077999883797],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9924407667977913
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12590369999816176,
+        "max": 0.1296526000078302,
+        "mean": 0.12827203333533058,
+        "stddev": 0.002060418660975682,
+        "rounds": 3,
+        "median": 0.1292597999999998,
+        "iqr": 0.002811675007251324,
+        "q1": 0.12674272499862127,
+        "q3": 0.1295544000058726,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12590369999816176,
+        "hd15iqr": 0.1296526000078302,
+        "ops": 7.7959316150059434,
+        "total": 0.38481610000599176,
+        "data": [0.12590369999816176, 0.1296526000078302, 0.1292597999999998],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9965860955133594
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13536650000605732,
+        "max": 0.1465401000023121,
+        "mean": 0.1405742000012348,
+        "stddev": 0.0056252541858822745,
+        "rounds": 3,
+        "median": 0.139815999995335,
+        "iqr": 0.008380199997191085,
+        "q1": 0.13647887500337674,
+        "q3": 0.14485907500056783,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13536650000605732,
+        "hd15iqr": 0.1465401000023121,
+        "ops": 7.113680888749258,
+        "total": 0.42172260000370443,
+        "data": [0.1465401000023121, 0.139815999995335, 0.13536650000605732],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.6049171183627222
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14667439999175258,
+        "max": 0.1532260999956634,
+        "mean": 0.14992386666320576,
+        "stddev": 0.0032761687190522404,
+        "rounds": 3,
+        "median": 0.14987110000220127,
+        "iqr": 0.004913775002933107,
+        "q1": 0.14747357499436475,
+        "q3": 0.15238734999729786,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14667439999175258,
+        "hd15iqr": 0.1532260999956634,
+        "ops": 6.670052088814086,
+        "total": 0.44977159998961724,
+        "data": [0.14987110000220127, 0.1532260999956634, 0.14667439999175258],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.6047558743161043
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14706970000406727,
+        "max": 0.15437530000053812,
+        "mean": 0.15022436666671032,
+        "stddev": 0.003753312974852201,
+        "rounds": 3,
+        "median": 0.14922809999552555,
+        "iqr": 0.005479199997353135,
+        "q1": 0.14760930000193184,
+        "q3": 0.15308849999928498,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14706970000406727,
+        "hd15iqr": 0.15437530000053812,
+        "ops": 6.656709708210071,
+        "total": 0.45067310000013094,
+        "data": [0.15437530000053812, 0.14706970000406727, 0.14922809999552555],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8749824694439143
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1294188000028953,
+        "max": 0.13597580000350717,
+        "mean": 0.13160963333696904,
+        "stddev": 0.003781219192602312,
+        "rounds": 3,
+        "median": 0.12943430000450462,
+        "iqr": 0.004917750000458909,
+        "q1": 0.12942267500329763,
+        "q3": 0.13434042500375654,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1294188000028953,
+        "hd15iqr": 0.13597580000350717,
+        "ops": 7.598227991712677,
+        "total": 0.3948289000109071,
+        "data": [0.13597580000350717, 0.1294188000028953, 0.12943430000450462],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9960917590792622
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1253646000113804,
+        "max": 0.1318467000091914,
+        "mean": 0.12779290001102103,
+        "stddev": 0.0035335665805699165,
+        "rounds": 3,
+        "median": 0.12616740001249127,
+        "iqr": 0.0048615749983582646,
+        "q1": 0.1255653000116581,
+        "q3": 0.13042687501001637,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1253646000113804,
+        "hd15iqr": 0.1318467000091914,
+        "ops": 7.825160865069646,
+        "total": 0.38337870003306307,
+        "data": [0.1318467000091914, 0.12616740001249127, 0.1253646000113804],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.0392735252266267
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13409530000353698,
+        "max": 0.18230070000572596,
+        "mean": 0.15411800000098688,
+        "stddev": 0.025117311707903368,
+        "rounds": 3,
+        "median": 0.14595799999369774,
+        "iqr": 0.036154050001641735,
+        "q1": 0.13706097500107717,
+        "q3": 0.1732150250027189,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13409530000353698,
+        "hd15iqr": 0.18230070000572596,
+        "ops": 6.4885347590391556,
+        "total": 0.4623540000029607,
+        "data": [0.18230070000572596, 0.14595799999369774, 0.13409530000353698],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070709290101393
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1799040000041714,
+        "max": 0.2661087000014959,
+        "mean": 0.2167964333348209,
+        "stddev": 0.04442411248948218,
+        "rounds": 3,
+        "median": 0.20437659999879543,
+        "iqr": 0.06465352499799337,
+        "q1": 0.1860221500028274,
+        "q3": 0.2506756750008208,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1799040000041714,
+        "hd15iqr": 0.2661087000014959,
+        "ops": 4.612622009586282,
+        "total": 0.6503893000044627,
+        "data": [0.2661087000014959, 0.20437659999879543, 0.1799040000041714],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9066549975769849
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.22135229999548756,
+        "max": 0.26536780000606086,
+        "mean": 0.24133293333579786,
+        "stddev": 0.022286064394941272,
+        "rounds": 3,
+        "median": 0.23727870000584517,
+        "iqr": 0.03301162500792998,
+        "q1": 0.22533389999807696,
+        "q3": 0.25834552500600694,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.22135229999548756,
+        "hd15iqr": 0.26536780000606086,
+        "ops": 4.143653276731071,
+        "total": 0.7239988000073936,
+        "data": [0.23727870000584517, 0.22135229999548756, 0.26536780000606086],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.90742772874481
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1955613999889465,
+        "max": 0.2583373999950709,
+        "mean": 0.2222074999929949,
+        "stddev": 0.03244477447901546,
+        "rounds": 3,
+        "median": 0.21272369999496732,
+        "iqr": 0.04708200000459328,
+        "q1": 0.1998519749904517,
+        "q3": 0.246933974995045,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1955613999889465,
+        "hd15iqr": 0.2583373999950709,
+        "ops": 4.500298144893962,
+        "total": 0.6666224999789847,
+        "data": [0.2583373999950709, 0.21272369999496732, 0.1955613999889465],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9077847304955309
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.20954079998773523,
+        "max": 0.2387651999888476,
+        "mean": 0.2242960333242081,
+        "stddev": 0.014614299999035348,
+        "rounds": 3,
+        "median": 0.2245820999960415,
+        "iqr": 0.02191830000083428,
+        "q1": 0.2133011249898118,
+        "q3": 0.23521942499064608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.20954079998773523,
+        "hd15iqr": 0.2387651999888476,
+        "ops": 4.45839360232712,
+        "total": 0.6728880999726243,
+        "data": [0.2387651999888476, 0.20954079998773523, 0.2245820999960415],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9070611549286578
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.22125050000613555,
+        "max": 0.29668719999608584,
+        "mean": 0.24877163333197436,
+        "stddev": 0.04164881282504194,
+        "rounds": 3,
+        "median": 0.22837719999370165,
+        "iqr": 0.05657752499246271,
+        "q1": 0.22303217500302708,
+        "q3": 0.2796096999954898,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.22125050000613555,
+        "hd15iqr": 0.29668719999608584,
+        "ops": 4.019750912136939,
+        "total": 0.746314899995923,
+        "data": [0.22837719999370165, 0.29668719999608584, 0.22125050000613555],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9047157435705993
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.21243959999992512,
+        "max": 0.2973490000003949,
+        "mean": 0.24645613333268557,
+        "stddev": 0.044899994679667536,
+        "rounds": 3,
+        "median": 0.2295797999977367,
+        "iqr": 0.06368205000035232,
+        "q1": 0.21672464999937802,
+        "q3": 0.28040669999973034,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.21243959999992512,
+        "hd15iqr": 0.2973490000003949,
+        "ops": 4.057517199826075,
+        "total": 0.7393683999980567,
+        "data": [0.2973490000003949, 0.2295797999977367, 0.21243959999992512],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9046914030002062
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.20313979999627918,
+        "max": 0.21642150000843685,
+        "mean": 0.2076304000026236,
+        "stddev": 0.007613909244751402,
+        "rounds": 3,
+        "median": 0.20332990000315476,
+        "iqr": 0.009961275009118253,
+        "q1": 0.20318732499799808,
+        "q3": 0.21314860000711633,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.20313979999627918,
+        "hd15iqr": 0.21642150000843685,
+        "ops": 4.816250414136678,
+        "total": 0.6228912000078708,
+        "data": [0.21642150000843685, 0.20313979999627918, 0.20332990000315476],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9052431406993005
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.19127529999241233,
+        "max": 0.23817460000282153,
+        "mean": 0.20896306666448558,
+        "stddev": 0.02548497565234158,
+        "rounds": 3,
+        "median": 0.19743929999822285,
+        "iqr": 0.035174475007806905,
+        "q1": 0.19281629999386496,
+        "q3": 0.22799077500167186,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.19127529999241233,
+        "hd15iqr": 0.23817460000282153,
+        "ops": 4.785534668696339,
+        "total": 0.6268891999934567,
+        "data": [0.19743929999822285, 0.19127529999241233, 0.23817460000282153],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9057202448077557
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.20888380000542384,
+        "max": 0.2638888999936171,
+        "mean": 0.22781430000031833,
+        "stddev": 0.031254285782021135,
+        "rounds": 3,
+        "median": 0.21067020000191405,
+        "iqr": 0.04125382499114494,
+        "q1": 0.2093304000045464,
+        "q3": 0.25058422499569133,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.20888380000542384,
+        "hd15iqr": 0.2638888999936171,
+        "ops": 4.389540077153202,
+        "total": 0.683442900000955,
+        "data": [0.21067020000191405, 0.2638888999936171, 0.20888380000542384],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9046380993808971
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.20337229999131523,
+        "max": 0.26822259998880327,
+        "mean": 0.22585773332684767,
+        "stddev": 0.03671218128191006,
+        "rounds": 3,
+        "median": 0.2059783000004245,
+        "iqr": 0.04863772499811603,
+        "q1": 0.20402379999359255,
+        "q3": 0.2526615249917086,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.20337229999131523,
+        "hd15iqr": 0.26822259998880327,
+        "ops": 4.427565907397381,
+        "total": 0.677573199980543,
+        "data": [0.26822259998880327, 0.2059783000004245, 0.20337229999131523],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9050638265971864
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.20931750000454485,
+        "max": 0.2736567000101786,
+        "mean": 0.23159920000277148,
+        "stddev": 0.036444407854203956,
+        "rounds": 3,
+        "median": 0.211823399993591,
+        "iqr": 0.04825440000422532,
+        "q1": 0.2099439750018064,
+        "q3": 0.2581983750060317,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.20931750000454485,
+        "hd15iqr": 0.2736567000101786,
+        "ops": 4.3178042065259,
+        "total": 0.6947976000083145,
+        "data": [0.2736567000101786, 0.211823399993591, 0.20931750000454485],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9055022405557527
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.18852559999504592,
+        "max": 0.22988500000792556,
+        "mean": 0.20969343333369275,
+        "stddev": 0.02069697598216661,
+        "rounds": 3,
+        "median": 0.2106696999981068,
+        "iqr": 0.031019550009659724,
+        "q1": 0.19406162499581114,
+        "q3": 0.22508117500547087,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.18852559999504592,
+        "hd15iqr": 0.22988500000792556,
+        "ops": 4.768866550096797,
+        "total": 0.6290803000010783,
+        "data": [0.2106696999981068, 0.18852559999504592, 0.22988500000792556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9053311653831582
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.17656199999328237,
+        "max": 0.24887549999402836,
+        "mean": 0.20259226666530594,
+        "stddev": 0.04018641019533206,
+        "rounds": 3,
+        "median": 0.1823393000086071,
+        "iqr": 0.05423512500055949,
+        "q1": 0.17800632499711355,
+        "q3": 0.23224144999767304,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.17656199999328237,
+        "hd15iqr": 0.24887549999402836,
+        "ops": 4.936022566212053,
+        "total": 0.6077767999959178,
+        "data": [0.1823393000086071, 0.17656199999328237, 0.24887549999402836],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9036043855747928
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.2136335999966832,
+        "max": 0.27008309999655467,
+        "mean": 0.2341142999988127,
+        "stddev": 0.03124975909770251,
+        "rounds": 3,
+        "median": 0.2186262000032002,
+        "iqr": 0.04233712499990361,
+        "q1": 0.21488174999831244,
+        "q3": 0.25721887499821605,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.2136335999966832,
+        "hd15iqr": 0.27008309999655467,
+        "ops": 4.27141785019143,
+        "total": 0.7023428999964381,
+        "data": [0.2186262000032002, 0.27008309999655467, 0.2136335999966832],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.902568132436745
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.19852800000808202,
+        "max": 0.2832622999994783,
+        "mean": 0.22768103333752757,
+        "stddev": 0.04815406562862565,
+        "rounds": 3,
+        "median": 0.20125280000502244,
+        "iqr": 0.06355072499354719,
+        "q1": 0.19920920000731712,
+        "q3": 0.2627599250008643,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.19852800000808202,
+        "hd15iqr": 0.2832622999994783,
+        "ops": 4.392109370469792,
+        "total": 0.6830431000125827,
+        "data": [0.2832622999994783, 0.20125280000502244, 0.19852800000808202],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9023347621157678
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.18583469999430235,
+        "max": 0.2546215000038501,
+        "mean": 0.20931843333043312,
+        "stddev": 0.03924243168244146,
+        "rounds": 3,
+        "median": 0.18749909999314696,
+        "iqr": 0.0515901000071608,
+        "q1": 0.1862507999940135,
+        "q3": 0.2378409000011743,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.18583469999430235,
+        "hd15iqr": 0.2546215000038501,
+        "ops": 4.777410111900586,
+        "total": 0.6279552999912994,
+        "data": [0.2546215000038501, 0.18749909999314696, 0.18583469999430235],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9022021757600505
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1553185999946436,
+        "max": 0.18817599999601953,
+        "mean": 0.1663276999994802,
+        "stddev": 0.01892137352460706,
+        "rounds": 3,
+        "median": 0.15548850000777747,
+        "iqr": 0.024643050001031952,
+        "q1": 0.15536107499792706,
+        "q3": 0.18000412499895901,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1553185999946436,
+        "hd15iqr": 0.18817599999601953,
+        "ops": 6.012227668651254,
+        "total": 0.4989830999984406,
+        "data": [0.18817599999601953, 0.1553185999946436, 0.15548850000777747],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9022814371204082
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1432929000002332,
+        "max": 0.18421599999419414,
+        "mean": 0.1581247666666362,
+        "stddev": 0.022666164904691692,
+        "rounds": 3,
+        "median": 0.1468654000054812,
+        "iqr": 0.0306923249954707,
+        "q1": 0.1441860250015452,
+        "q3": 0.1748783499970159,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1432929000002332,
+        "hd15iqr": 0.18421599999419414,
+        "ops": 6.324120003972767,
+        "total": 0.47437429999990854,
+        "data": [0.18421599999419414, 0.1468654000054812, 0.1432929000002332],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9018531072328322
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14960639999480918,
+        "max": 0.1962123999983305,
+        "mean": 0.1666836666651458,
+        "stddev": 0.02567701453876735,
+        "rounds": 3,
+        "median": 0.15423220000229776,
+        "iqr": 0.034954500002641,
+        "q1": 0.15076284999668133,
+        "q3": 0.18571734999932232,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14960639999480918,
+        "hd15iqr": 0.1962123999983305,
+        "ops": 5.999388062472373,
+        "total": 0.5000509999954375,
+        "data": [0.14960639999480918, 0.1962123999983305, 0.15423220000229776],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9020116464471548
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.16140440000162926,
+        "max": 0.2018563999881735,
+        "mean": 0.17631723333033733,
+        "stddev": 0.022221167740335973,
+        "rounds": 3,
+        "median": 0.16569090000120923,
+        "iqr": 0.03033899998990819,
+        "q1": 0.16247602500152425,
+        "q3": 0.19281502499143244,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.16140440000162926,
+        "hd15iqr": 0.2018563999881735,
+        "ops": 5.671595346136474,
+        "total": 0.528951699991012,
+        "data": [0.16140440000162926, 0.2018563999881735, 0.16569090000120923],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.900868875026947
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.15449879999505356,
+        "max": 0.1982680000073742,
+        "mean": 0.17088710000098217,
+        "stddev": 0.02386553285613531,
+        "rounds": 3,
+        "median": 0.15989450000051875,
+        "iqr": 0.03282690000924049,
+        "q1": 0.15584772499641986,
+        "q3": 0.18867462500566035,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.15449879999505356,
+        "hd15iqr": 0.1982680000073742,
+        "ops": 5.851816784264304,
+        "total": 0.5126613000029465,
+        "data": [0.15449879999505356, 0.1982680000073742, 0.15989450000051875],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9015658109218445
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.16215060000831727,
+        "max": 0.1915076000004774,
+        "mean": 0.1720019000058528,
+        "stddev": 0.016892718597453973,
+        "rounds": 3,
+        "median": 0.16234750000876375,
+        "iqr": 0.022017749994120095,
+        "q1": 0.1621998250084289,
+        "q3": 0.18421757500254898,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.16215060000831727,
+        "hd15iqr": 0.1915076000004774,
+        "ops": 5.813889264978889,
+        "total": 0.5160057000175584,
+        "data": [0.16234750000876375, 0.1915076000004774, 0.16215060000831727],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9014097665605154
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.15945819999615196,
+        "max": 0.21145919999980833,
+        "mean": 0.17865403333174376,
+        "stddev": 0.028547092070136212,
+        "rounds": 3,
+        "median": 0.16504469999927096,
+        "iqr": 0.03900075000274228,
+        "q1": 0.1608548249969317,
+        "q3": 0.199855574999674,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.15945819999615196,
+        "hd15iqr": 0.21145919999980833,
+        "ops": 5.597410712486373,
+        "total": 0.5359620999952313,
+        "data": [0.15945819999615196, 0.21145919999980833, 0.16504469999927096],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9003563537873824
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.155459300003713,
+        "max": 0.19935270000132732,
+        "mean": 0.17192966666577073,
+        "stddev": 0.023908749889595265,
+        "rounds": 3,
+        "median": 0.16097699999227189,
+        "iqr": 0.03292004999821074,
+        "q1": 0.15683872500085272,
+        "q3": 0.18975877499906346,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.155459300003713,
+        "hd15iqr": 0.19935270000132732,
+        "ops": 5.8163318721718245,
+        "total": 0.5157889999973122,
+        "data": [0.155459300003713, 0.19935270000132732, 0.16097699999227189],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8997579145954129
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1491880000103265,
+        "max": 0.1879884999943897,
+        "mean": 0.16468349999922793,
+        "stddev": 0.020545338096856852,
+        "rounds": 3,
+        "median": 0.15687399999296758,
+        "iqr": 0.029100374988047406,
+        "q1": 0.15110950000598677,
+        "q3": 0.18020987499403418,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1491880000103265,
+        "hd15iqr": 0.1879884999943897,
+        "ops": 6.072253747368062,
+        "total": 0.4940504999976838,
+        "data": [0.1879884999943897, 0.15687399999296758, 0.1491880000103265],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.899889322790915
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1453858000022592,
+        "max": 0.18341189999773633,
+        "mean": 0.1597833666698231,
+        "stddev": 0.020625327375095575,
+        "rounds": 3,
+        "median": 0.15055240000947379,
+        "iqr": 0.028519574996607844,
+        "q1": 0.14667745000406285,
+        "q3": 0.1751970250006707,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1453858000022592,
+        "hd15iqr": 0.18341189999773633,
+        "ops": 6.25847371251354,
+        "total": 0.4793501000094693,
+        "data": [0.15055240000947379, 0.18341189999773633, 0.1453858000022592],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8987527342641044
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13608460000250489,
+        "max": 0.1748477999935858,
+        "mean": 0.14949563332872154,
+        "stddev": 0.021967917913303808,
+        "rounds": 3,
+        "median": 0.13755449999007396,
+        "iqr": 0.029072399993310682,
+        "q1": 0.13645207499939715,
+        "q3": 0.16552447499270784,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13608460000250489,
+        "hd15iqr": 0.1748477999935858,
+        "ops": 6.689158591014691,
+        "total": 0.44848689998616464,
+        "data": [0.13755449999007396, 0.13608460000250489, 0.1748477999935858],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8972295198726976
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1309897000028286,
+        "max": 0.1320488000055775,
+        "mean": 0.1315459000034025,
+        "stddev": 0.0005315579661031008,
+        "rounds": 3,
+        "median": 0.13159920000180136,
+        "iqr": 0.0007943250020616688,
+        "q1": 0.1311420750025718,
+        "q3": 0.13193640000463347,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1309897000028286,
+        "hd15iqr": 0.1320488000055775,
+        "ops": 7.601909295342041,
+        "total": 0.3946377000102075,
+        "data": [0.1309897000028286, 0.13159920000180136, 0.1320488000055775],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964319033643926
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13170389999868348,
+        "max": 0.13725719999638386,
+        "mean": 0.13475913333240896,
+        "stddev": 0.0028182638697477344,
+        "rounds": 3,
+        "median": 0.13531630000215955,
+        "iqr": 0.004164974998275284,
+        "q1": 0.1326069999995525,
+        "q3": 0.13677197499782778,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13170389999868348,
+        "hd15iqr": 0.13725719999638386,
+        "ops": 7.420647308062677,
+        "total": 0.4042773999972269,
+        "data": [0.13725719999638386, 0.13170389999868348, 0.13531630000215955],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8954560612641809
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1296658000064781,
+        "max": 0.17094640000141226,
+        "mean": 0.14426826666749548,
+        "stddev": 0.02313845885493823,
+        "rounds": 3,
+        "median": 0.1321925999945961,
+        "iqr": 0.030960449996200623,
+        "q1": 0.1302975000035076,
+        "q3": 0.16125794999970822,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1296658000064781,
+        "hd15iqr": 0.17094640000141226,
+        "ops": 6.931531258393542,
+        "total": 0.43280480000248645,
+        "data": [0.17094640000141226, 0.1296658000064781, 0.1321925999945961],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962518252002305
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1250722999975551,
+        "max": 0.1542838000023039,
+        "mean": 0.1369644000030045,
+        "stddev": 0.015343390174576576,
+        "rounds": 3,
+        "median": 0.13153710000915453,
+        "iqr": 0.02190862500356161,
+        "q1": 0.12668850000045495,
+        "q3": 0.14859712500401656,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1250722999975551,
+        "hd15iqr": 0.1542838000023039,
+        "ops": 7.301167310469462,
+        "total": 0.4108932000090135,
+        "data": [0.1542838000023039, 0.1250722999975551, 0.13153710000915453],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8958802630787008
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12921720001031645,
+        "max": 0.1613091000035638,
+        "mean": 0.14076226666899552,
+        "stddev": 0.017839460859552597,
+        "rounds": 3,
+        "median": 0.13176049999310635,
+        "iqr": 0.024068924994935514,
+        "q1": 0.12985302500601392,
+        "q3": 0.15392195000094944,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12921720001031645,
+        "hd15iqr": 0.1613091000035638,
+        "ops": 7.104176592662537,
+        "total": 0.4222868000069866,
+        "data": [0.12921720001031645, 0.1613091000035638, 0.13176049999310635],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964951928598563
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11664610001025721,
+        "max": 0.14298089999647345,
+        "mean": 0.1261732333320348,
+        "stddev": 0.014599145416554453,
+        "rounds": 3,
+        "median": 0.1188926999893738,
+        "iqr": 0.01975109998966218,
+        "q1": 0.11720775000503636,
+        "q3": 0.13695884999469854,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11664610001025721,
+        "hd15iqr": 0.14298089999647345,
+        "ops": 7.925611269455393,
+        "total": 0.37851969999610446,
+        "data": [0.1188926999893738, 0.11664610001025721, 0.14298089999647345],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8962702560278395
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11624800000572577,
+        "max": 0.12749780000012834,
+        "mean": 0.12047663333457119,
+        "stddev": 0.0061227593294200106,
+        "rounds": 3,
+        "median": 0.11768409999785945,
+        "iqr": 0.008437349995801924,
+        "q1": 0.11660702500375919,
+        "q3": 0.12504437499956111,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11624800000572577,
+        "hd15iqr": 0.12749780000012834,
+        "ops": 8.300364745609524,
+        "total": 0.36142990000371356,
+        "data": [0.11624800000572577, 0.11768409999785945, 0.12749780000012834],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8960874520477597
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12112770001112949,
+        "max": 0.1288295999984257,
+        "mean": 0.12397863333656763,
+        "stddev": 0.00422254850341255,
+        "rounds": 3,
+        "median": 0.12197860000014771,
+        "iqr": 0.005776424990472151,
+        "q1": 0.12134042500838405,
+        "q3": 0.1271168499988562,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12112770001112949,
+        "hd15iqr": 0.1288295999984257,
+        "ops": 8.065905979825388,
+        "total": 0.3719359000097029,
+        "data": [0.12197860000014771, 0.12112770001112949, 0.1288295999984257],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8958088489260803
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11224119999678805,
+        "max": 0.12091310000687372,
+        "mean": 0.11627913333359174,
+        "stddev": 0.004366566643242265,
+        "rounds": 3,
+        "median": 0.11568309999711346,
+        "iqr": 0.0065039250075642485,
+        "q1": 0.1131016749968694,
+        "q3": 0.11960560000443365,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11224119999678805,
+        "hd15iqr": 0.12091310000687372,
+        "ops": 8.599995298650125,
+        "total": 0.34883740000077523,
+        "data": [0.11568309999711346, 0.12091310000687372, 0.11224119999678805],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8967713351576252
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10992660000920296,
+        "max": 0.11306970000441652,
+        "mean": 0.11168150000351791,
+        "stddev": 0.0016033156454224907,
+        "rounds": 3,
+        "median": 0.11204819999693427,
+        "iqr": 0.0023573249964101706,
+        "q1": 0.11045700000613579,
+        "q3": 0.11281432500254596,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10992660000920296,
+        "hd15iqr": 0.11306970000441652,
+        "ops": 8.954034463796605,
+        "total": 0.33504450001055375,
+        "data": [0.11306970000441652, 0.11204819999693427, 0.10992660000920296],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8964487305253723
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11373120000644121,
+        "max": 0.12037089999648742,
+        "mean": 0.11749283333483618,
+        "stddev": 0.003406893237304387,
+        "rounds": 3,
+        "median": 0.1183764000015799,
+        "iqr": 0.004979774992534658,
+        "q1": 0.11489250000522588,
+        "q3": 0.11987227499776054,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11373120000644121,
+        "hd15iqr": 0.12037089999648742,
+        "ops": 8.511157418003162,
+        "total": 0.35247850000450853,
+        "data": [0.1183764000015799, 0.12037089999648742, 0.11373120000644121],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.895066909895131
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11898030000156723,
+        "max": 0.12307810000493191,
+        "mean": 0.1209374666699053,
+        "stddev": 0.002055051393574683,
+        "rounds": 3,
+        "median": 0.12075400000321679,
+        "iqr": 0.0030733500025235116,
+        "q1": 0.11942372500197962,
+        "q3": 0.12249707500450313,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11898030000156723,
+        "hd15iqr": 0.12307810000493191,
+        "ops": 8.26873612897371,
+        "total": 0.36281240000971593,
+        "data": [0.12307810000493191, 0.12075400000321679, 0.11898030000156723],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8935410838562292
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12213690001226496,
+        "max": 0.1310978000110481,
+        "mean": 0.12614850000439523,
+        "stddev": 0.004553448493721508,
+        "rounds": 3,
+        "median": 0.1252107999898726,
+        "iqr": 0.0067206749990873504,
+        "q1": 0.12290537500666687,
+        "q3": 0.12962605000575422,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12213690001226496,
+        "hd15iqr": 0.1310978000110481,
+        "ops": 7.927165205810282,
+        "total": 0.37844550001318567,
+        "data": [0.1310978000110481, 0.1252107999898726, 0.12213690001226496],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8939795586621289
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11309610000171233,
+        "max": 0.12410240000463091,
+        "mean": 0.11701476667076349,
+        "stddev": 0.006149505852554241,
+        "rounds": 3,
+        "median": 0.11384580000594724,
+        "iqr": 0.008254725002188934,
+        "q1": 0.11328352500277106,
+        "q3": 0.12153825000495999,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11309610000171233,
+        "hd15iqr": 0.12410240000463091,
+        "ops": 8.545929957828589,
+        "total": 0.3510443000122905,
+        "data": [0.12410240000463091, 0.11384580000594724, 0.11309610000171233],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.893036989856331
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10616540000773966,
+        "max": 0.12693020000006072,
+        "mean": 0.11398606666868243,
+        "stddev": 0.011290777773146191,
+        "rounds": 3,
+        "median": 0.10886259999824688,
+        "iqr": 0.015573599994240794,
+        "q1": 0.10683970000536647,
+        "q3": 0.12241329999960726,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10616540000773966,
+        "hd15iqr": 0.12693020000006072,
+        "ops": 8.773002080216083,
+        "total": 0.34195820000604726,
+        "data": [0.10886259999824688, 0.10616540000773966, 0.12693020000006072],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892782363990376
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11337799999455456,
+        "max": 0.11799579999933485,
+        "mean": 0.11612646666374833,
+        "stddev": 0.002431188142602663,
+        "rounds": 3,
+        "median": 0.1170055999973556,
+        "iqr": 0.0034633500035852194,
+        "q1": 0.11428489999525482,
+        "q3": 0.11774824999884004,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11337799999455456,
+        "hd15iqr": 0.11799579999933485,
+        "ops": 8.611301357300093,
+        "total": 0.348379399991245,
+        "data": [0.11337799999455456, 0.11799579999933485, 0.1170055999973556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8915076809089844
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11359710000397172,
+        "max": 0.11662309999519493,
+        "mean": 0.1148011666664388,
+        "stddev": 0.0016048328260925126,
+        "rounds": 3,
+        "median": 0.11418330000014976,
+        "iqr": 0.002269499993417412,
+        "q1": 0.11374365000301623,
+        "q3": 0.11601314999643364,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11359710000397172,
+        "hd15iqr": 0.11662309999519493,
+        "ops": 8.710712870240734,
+        "total": 0.3444034999993164,
+        "data": [0.11418330000014976, 0.11662309999519493, 0.11359710000397172],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.891806187925884
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1104168000019854,
+        "max": 0.12267629998677876,
+        "mean": 0.11702996666038719,
+        "stddev": 0.006186671963843052,
+        "rounds": 3,
+        "median": 0.11799679999239743,
+        "iqr": 0.009194624988595024,
+        "q1": 0.1123117999995884,
+        "q3": 0.12150642498818343,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1104168000019854,
+        "hd15iqr": 0.12267629998677876,
+        "ops": 8.544820002401012,
+        "total": 0.3510898999811616,
+        "data": [0.1104168000019854, 0.12267629998677876, 0.11799679999239743],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8913841997289507
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10924799999338575,
+        "max": 0.1298730999988038,
+        "mean": 0.12046419999872644,
+        "stddev": 0.0104306489510549,
+        "rounds": 3,
+        "median": 0.12227150000398979,
+        "iqr": 0.015468825004063547,
+        "q1": 0.11250387499603676,
+        "q3": 0.1279727000001003,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10924799999338575,
+        "hd15iqr": 0.1298730999988038,
+        "ops": 8.301221441810696,
+        "total": 0.36139259999617934,
+        "data": [0.10924799999338575, 0.12227150000398979, 0.1298730999988038],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8908073619784975
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11128789999929722,
+        "max": 0.1189788000046974,
+        "mean": 0.11637396666628774,
+        "stddev": 0.004405096462781656,
+        "rounds": 3,
+        "median": 0.1188551999948686,
+        "iqr": 0.005768175004050136,
+        "q1": 0.11317972499819007,
+        "q3": 0.1189479000022402,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11128789999929722,
+        "hd15iqr": 0.1189788000046974,
+        "ops": 8.592987148642832,
+        "total": 0.3491218999988632,
+        "data": [0.11128789999929722, 0.1189788000046974, 0.1188551999948686],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8912813400376618
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11452390000340529,
+        "max": 0.12196379998931661,
+        "mean": 0.11892216666213547,
+        "stddev": 0.003901072730326009,
+        "rounds": 3,
+        "median": 0.12027879999368452,
+        "iqr": 0.0055799249894334935,
+        "q1": 0.1159626250009751,
+        "q3": 0.12154254999040859,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11452390000340529,
+        "hd15iqr": 0.12196379998931661,
+        "ops": 8.40886125831407,
+        "total": 0.3567664999864064,
+        "data": [0.11452390000340529, 0.12027879999368452, 0.12196379998931661],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8911695245758624
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12404830000014044,
+        "max": 0.1251633999927435,
+        "mean": 0.12453609999890129,
+        "stddev": 0.000570488549268621,
+        "rounds": 3,
+        "median": 0.12439660000381991,
+        "iqr": 0.0008363249944522977,
+        "q1": 0.12413537500106031,
+        "q3": 0.12497169999551261,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12404830000014044,
+        "hd15iqr": 0.1251633999927435,
+        "ops": 8.029800194552603,
+        "total": 0.37360829999670386,
+        "data": [0.12404830000014044, 0.1251633999927435, 0.12439660000381991],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8915381876698416
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12312240000755992,
+        "max": 0.12756929999159183,
+        "mean": 0.12477766666658378,
+        "stddev": 0.0024315070978028807,
+        "rounds": 3,
+        "median": 0.12364130000059959,
+        "iqr": 0.0033351749880239367,
+        "q1": 0.12325212500581983,
+        "q3": 0.12658729999384377,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12312240000755992,
+        "hd15iqr": 0.12756929999159183,
+        "ops": 8.01425468767646,
+        "total": 0.37433299999975134,
+        "data": [0.12756929999159183, 0.12364130000059959, 0.12312240000755992],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8916271105624076
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1217739999992773,
+        "max": 0.13598500000080094,
+        "mean": 0.12706289999672057,
+        "stddev": 0.007770986872785021,
+        "rounds": 3,
+        "median": 0.12342969999008346,
+        "iqr": 0.010658250001142733,
+        "q1": 0.12218792499697884,
+        "q3": 0.13284617499812157,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1217739999992773,
+        "hd15iqr": 0.13598500000080094,
+        "ops": 7.870117870958475,
+        "total": 0.3811886999901617,
+        "data": [0.13598500000080094, 0.12342969999008346, 0.1217739999992773],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.89157497885332
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11270539999532048,
+        "max": 0.12367580000136513,
+        "mean": 0.11781766666778519,
+        "stddev": 0.005523102106631612,
+        "rounds": 3,
+        "median": 0.11707180000666995,
+        "iqr": 0.008227800004533492,
+        "q1": 0.11379699999815784,
+        "q3": 0.12202480000269134,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11270539999532048,
+        "hd15iqr": 0.12367580000136513,
+        "ops": 8.487691432726612,
+        "total": 0.35345300000335556,
+        "data": [0.11270539999532048, 0.12367580000136513, 0.11707180000666995],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8917732539999919
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10391330000129528,
+        "max": 0.12542009999742731,
+        "mean": 0.11397866667054284,
+        "stddev": 0.010819232001537876,
+        "rounds": 3,
+        "median": 0.1126026000129059,
+        "iqr": 0.016130099997099023,
+        "q1": 0.10608562500419794,
+        "q3": 0.12221572500129696,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10391330000129528,
+        "hd15iqr": 0.12542009999742731,
+        "ops": 8.77357166223497,
+        "total": 0.3419360000116285,
+        "data": [0.10391330000129528, 0.1126026000129059, 0.12542009999742731],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8921594706393086
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11175150000781287,
+        "max": 0.11606010000105016,
+        "mean": 0.1143951000024875,
+        "stddev": 0.0023150058185075636,
+        "rounds": 3,
+        "median": 0.11537369999859948,
+        "iqr": 0.0032314499949279707,
+        "q1": 0.11265705000550952,
+        "q3": 0.11588850000043749,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11175150000781287,
+        "hd15iqr": 0.11606010000105016,
+        "ops": 8.74163316416748,
+        "total": 0.3431853000074625,
+        "data": [0.11175150000781287, 0.11537369999859948, 0.11606010000105016],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.892462288350252
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11253549999673851,
+        "max": 0.11526370000501629,
+        "mean": 0.11405473333434202,
+        "stddev": 0.0013903121501113538,
+        "rounds": 3,
+        "median": 0.11436500000127126,
+        "iqr": 0.002046150006208336,
+        "q1": 0.1129928749978717,
+        "q3": 0.11503902500408003,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11253549999673851,
+        "hd15iqr": 0.11526370000501629,
+        "ops": 8.76772029327869,
+        "total": 0.34216420000302605,
+        "data": [0.11253549999673851, 0.11526370000501629, 0.11436500000127126],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8924990705654088
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11629520000133198,
+        "max": 0.12089360000391025,
+        "mean": 0.11795050000364427,
+        "stddev": 0.0025554143053475938,
+        "rounds": 3,
+        "median": 0.11666270000569057,
+        "iqr": 0.003448800001933705,
+        "q1": 0.11638707500242162,
+        "q3": 0.11983587500435533,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11629520000133198,
+        "hd15iqr": 0.12089360000391025,
+        "ops": 8.47813277577546,
+        "total": 0.3538515000109328,
+        "data": [0.12089360000391025, 0.11666270000569057, 0.11629520000133198],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8924542133011382
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1187424999952782,
+        "max": 0.12171209999360144,
+        "mean": 0.1199492666637525,
+        "stddev": 0.0015609415864886213,
+        "rounds": 3,
+        "median": 0.11939320000237785,
+        "iqr": 0.002227199998742435,
+        "q1": 0.11890517499705311,
+        "q3": 0.12113237499579554,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1187424999952782,
+        "hd15iqr": 0.12171209999360144,
+        "ops": 8.336857971822768,
+        "total": 0.3598477999912575,
+        "data": [0.12171209999360144, 0.1187424999952782, 0.11939320000237785],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8926649452309476
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12006990000372753,
+        "max": 0.12269340000057127,
+        "mean": 0.12094666666719907,
+        "stddev": 0.0015127192612686964,
+        "rounds": 3,
+        "median": 0.12007669999729842,
+        "iqr": 0.001967624997632811,
+        "q1": 0.12007160000212025,
+        "q3": 0.12203922499975306,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12006990000372753,
+        "hd15iqr": 0.12269340000057127,
+        "ops": 8.268107154632329,
+        "total": 0.3628400000015972,
+        "data": [0.12269340000057127, 0.12006990000372753, 0.12007669999729842],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8922360277536132
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11864329999662004,
+        "max": 0.12480960000539199,
+        "mean": 0.12156326666687771,
+        "stddev": 0.0030960782210979272,
+        "rounds": 3,
+        "median": 0.12123689999862108,
+        "iqr": 0.004624725006578956,
+        "q1": 0.1192916999971203,
+        "q3": 0.12391642500369926,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11864329999662004,
+        "hd15iqr": 0.12480960000539199,
+        "ops": 8.226169199124275,
+        "total": 0.3646898000006331,
+        "data": [0.12480960000539199, 0.12123689999862108, 0.11864329999662004],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8905708543255488
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11777579999761656,
+        "max": 0.12618360000487883,
+        "mean": 0.12094750000202718,
+        "stddev": 0.004568269448675541,
+        "rounds": 3,
+        "median": 0.11888310000358615,
+        "iqr": 0.0063058500054467,
+        "q1": 0.11805262499910896,
+        "q3": 0.12435847500455566,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11777579999761656,
+        "hd15iqr": 0.12618360000487883,
+        "ops": 8.268050186926056,
+        "total": 0.36284250000608154,
+        "data": [0.11888310000358615, 0.11777579999761656, 0.12618360000487883],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8878848582845826
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1190128000016557,
+        "max": 0.13152579999587033,
+        "mean": 0.12394179999925352,
+        "stddev": 0.0066656253239960155,
+        "rounds": 3,
+        "median": 0.12128680000023451,
+        "iqr": 0.009384749995660968,
+        "q1": 0.1195813000013004,
+        "q3": 0.12896604999696137,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1190128000016557,
+        "hd15iqr": 0.13152579999587033,
+        "ops": 8.068303026146328,
+        "total": 0.37182539999776054,
+        "data": [0.13152579999587033, 0.1190128000016557, 0.12128680000023451],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.888248300423944
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10506560000067111,
+        "max": 0.11379540000052657,
+        "mean": 0.10949766666938861,
+        "stddev": 0.004366450056230809,
+        "rounds": 3,
+        "median": 0.10963200000696816,
+        "iqr": 0.006547349999891594,
+        "q1": 0.10620720000224537,
+        "q3": 0.11275455000213697,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10506560000067111,
+        "hd15iqr": 0.11379540000052657,
+        "ops": 9.132614697803072,
+        "total": 0.32849300000816584,
+        "data": [0.10506560000067111, 0.11379540000052657, 0.10963200000696816],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8867102616161417
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10779520000505727,
+        "max": 0.11061879999761004,
+        "mean": 0.10944060000474565,
+        "stddev": 0.0014686340981566012,
+        "rounds": 3,
+        "median": 0.10990780001156963,
+        "iqr": 0.002117699994414579,
+        "q1": 0.10832335000668536,
+        "q3": 0.11044105000109994,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10779520000505727,
+        "hd15iqr": 0.11061879999761004,
+        "ops": 9.137376804921,
+        "total": 0.32832180001423694,
+        "data": [0.11061879999761004, 0.10779520000505727, 0.10990780001156963],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.4146559099664453
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10087999999814201,
+        "max": 0.10365389999060426,
+        "mean": 0.10207023332865599,
+        "stddev": 0.001428188584101601,
+        "rounds": 3,
+        "median": 0.10167679999722168,
+        "iqr": 0.0020804249943466857,
+        "q1": 0.10107919999791193,
+        "q3": 0.10315962499225861,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10087999999814201,
+        "hd15iqr": 0.10365389999060426,
+        "ops": 9.797175605351068,
+        "total": 0.30621069998596795,
+        "data": [0.10087999999814201, 0.10167679999722168, 0.10365389999060426],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5072492531867474
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.0917187000013655,
+        "max": 0.10391020000679418,
+        "mean": 0.09580210000179552,
+        "stddev": 0.007021881919448158,
+        "rounds": 3,
+        "median": 0.0917773999972269,
+        "iqr": 0.00914362500407151,
+        "q1": 0.09173337500033085,
+        "q3": 0.10087700000440236,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.0917187000013655,
+        "hd15iqr": 0.10391020000679418,
+        "ops": 10.438184548994833,
+        "total": 0.2874063000053866,
+        "data": [0.0917187000013655, 0.10391020000679418, 0.0917773999972269],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.6710597193866155
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.08446129999356344,
+        "max": 0.09646780000184663,
+        "mean": 0.09085216666668809,
+        "stddev": 0.006040674685699154,
+        "rounds": 3,
+        "median": 0.09162740000465419,
+        "iqr": 0.009004875006212387,
+        "q1": 0.08625282499633613,
+        "q3": 0.09525770000254852,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.08446129999356344,
+        "hd15iqr": 0.09646780000184663,
+        "ops": 11.006892148964683,
+        "total": 0.27255650000006426,
+        "data": [0.08446129999356344, 0.09646780000184663, 0.09162740000465419],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8302375912600906
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09988510000403039,
+        "max": 0.1034460999944713,
+        "mean": 0.10129663333160958,
+        "stddev": 0.0018917160036514282,
+        "rounds": 3,
+        "median": 0.10055869999632705,
+        "iqr": 0.002670749992830679,
+        "q1": 0.10005350000210456,
+        "q3": 0.10272424999493524,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09988510000403039,
+        "hd15iqr": 0.1034460999944713,
+        "ops": 9.871996404128767,
+        "total": 0.30388989999482874,
+        "data": [0.09988510000403039, 0.1034460999944713, 0.10055869999632705],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.7853665259727918
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.19213930000842083,
+        "max": 0.20109400000364985,
+        "mean": 0.19605490000685677,
+        "stddev": 0.004581850301556134,
+        "rounds": 3,
+        "median": 0.19493140000849962,
+        "iqr": 0.0067160249964217655,
+        "q1": 0.19283732500844053,
+        "q3": 0.1995533500048623,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.19213930000842083,
+        "hd15iqr": 0.20109400000364985,
+        "ops": 5.100612124282669,
+        "total": 0.5881647000205703,
+        "data": [0.19213930000842083, 0.20109400000364985, 0.19493140000849962],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.515787940695624
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09059540000453126,
+        "max": 0.09582459999364801,
+        "mean": 0.09237660000023122,
+        "stddev": 0.0029866033894436466,
+        "rounds": 3,
+        "median": 0.09070980000251438,
+        "iqr": 0.003921899991837563,
+        "q1": 0.09062400000402704,
+        "q3": 0.0945458999958646,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09059540000453126,
+        "hd15iqr": 0.09582459999364801,
+        "ops": 10.825252282477349,
+        "total": 0.27712980000069365,
+        "data": [0.09070980000251438, 0.09582459999364801, 0.09059540000453126],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5120099393805138
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.08891540000331588,
+        "max": 0.09904020000249147,
+        "mean": 0.09302270000140804,
+        "stddev": 0.005325837191878611,
+        "rounds": 3,
+        "median": 0.09111249999841675,
+        "iqr": 0.007593599999381695,
+        "q1": 0.0894646750020911,
+        "q3": 0.0970582750014728,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.08891540000331588,
+        "hd15iqr": 0.09904020000249147,
+        "ops": 10.750064231471066,
+        "total": 0.2790681000042241,
+        "data": [0.08891540000331588, 0.09904020000249147, 0.09111249999841675],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.6833105410456584
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09596639999654144,
+        "max": 0.0966612000047462,
+        "mean": 0.09639343333644017,
+        "stddev": 0.00037377957054993464,
+        "rounds": 3,
+        "median": 0.09655270000803284,
+        "iqr": 0.0005211000061535742,
+        "q1": 0.09611297499941429,
+        "q3": 0.09663407500556787,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09596639999654144,
+        "hd15iqr": 0.0966612000047462,
+        "ops": 10.374150659306004,
+        "total": 0.2891803000093205,
+        "data": [0.0966612000047462, 0.09655270000803284, 0.09596639999654144],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.858308773910476
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09134970000013709,
+        "max": 0.09606900000653695,
+        "mean": 0.09412416667328216,
+        "stddev": 0.0024666103759196666,
+        "rounds": 3,
+        "median": 0.09495380001317244,
+        "iqr": 0.003539475004799897,
+        "q1": 0.09225072500339593,
+        "q3": 0.09579020000819582,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09134970000013709,
+        "hd15iqr": 0.09606900000653695,
+        "ops": 10.624264047629092,
+        "total": 0.2823725000198465,
+        "data": [0.09134970000013709, 0.09606900000653695, 0.09495380001317244],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8363359922219478
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12417280000227038,
+        "max": 0.13637089999974705,
+        "mean": 0.1295689999969909,
+        "stddev": 0.006219357303737554,
+        "rounds": 3,
+        "median": 0.12816329998895526,
+        "iqr": 0.009148574998107506,
+        "q1": 0.1251704249989416,
+        "q3": 0.1343189999970491,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12417280000227038,
+        "hd15iqr": 0.13637089999974705,
+        "ops": 7.717895484438592,
+        "total": 0.3887069999909727,
+        "data": [0.12417280000227038, 0.13637089999974705, 0.12816329998895526],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.7894013756757658
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1125599999941187,
+        "max": 0.12590210000053048,
+        "mean": 0.11823216666622709,
+        "stddev": 0.006891749550927303,
+        "rounds": 3,
+        "median": 0.11623440000403207,
+        "iqr": 0.010006575004808838,
+        "q1": 0.11347859999659704,
+        "q3": 0.12348517500140588,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1125599999941187,
+        "hd15iqr": 0.12590210000053048,
+        "ops": 8.457935164319789,
+        "total": 0.35469649999868125,
+        "data": [0.1125599999941187, 0.12590210000053048, 0.11623440000403207],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.5385813870830776
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1181877000053646,
+        "max": 0.12709059999906458,
+        "mean": 0.1222984666674165,
+        "stddev": 0.00449039001405036,
+        "rounds": 3,
+        "median": 0.12161709999782033,
+        "iqr": 0.0066771749952749815,
+        "q1": 0.11904505000347854,
+        "q3": 0.12572222499875352,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1181877000053646,
+        "hd15iqr": 0.12709059999906458,
+        "ops": 8.176717396788312,
+        "total": 0.3668954000022495,
+        "data": [0.12709059999906458, 0.1181877000053646, 0.12161709999782033],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5472974625503095
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09776399999100249,
+        "max": 0.10052300000097603,
+        "mean": 0.09959746666330223,
+        "stddev": 0.0015878531005266933,
+        "rounds": 3,
+        "median": 0.10050539999792818,
+        "iqr": 0.00206925000748015,
+        "q1": 0.09844934999273391,
+        "q3": 0.10051860000021406,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09776399999100249,
+        "hd15iqr": 0.10052300000097603,
+        "ops": 10.040416021630206,
+        "total": 0.2987923999899067,
+        "data": [0.09776399999100249, 0.10052300000097603, 0.10050539999792818],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5232794929726954
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.0883142999955453,
+        "max": 0.10195220001332927,
+        "mean": 0.09498880000319332,
+        "stddev": 0.006823538424625906,
+        "rounds": 3,
+        "median": 0.09469990000070538,
+        "iqr": 0.010228425013337983,
+        "q1": 0.08991069999683532,
+        "q3": 0.1001391250101733,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.0883142999955453,
+        "hd15iqr": 0.10195220001332927,
+        "ops": 10.52755693267398,
+        "total": 0.28496640000957996,
+        "data": [0.0883142999955453, 0.10195220001332927, 0.09469990000070538],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7516536524034039
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.08808949998638127,
+        "max": 0.09804780001286417,
+        "mean": 0.09228040000016335,
+        "stddev": 0.005162939960846477,
+        "rounds": 3,
+        "median": 0.09070390000124462,
+        "iqr": 0.007468725019862177,
+        "q1": 0.08874309999009711,
+        "q3": 0.09621182500995928,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.08808949998638127,
+        "hd15iqr": 0.09804780001286417,
+        "ops": 10.836537336186556,
+        "total": 0.27684120000049006,
+        "data": [0.08808949998638127, 0.09804780001286417, 0.09070390000124462],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.8774747414759445
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09684289999131579,
+        "max": 0.10219900000083726,
+        "mean": 0.10013349999887093,
+        "stddev": 0.0028805562563104436,
+        "rounds": 3,
+        "median": 0.10135860000445973,
+        "iqr": 0.004017075007141102,
+        "q1": 0.09797182499460177,
+        "q3": 0.10198890000174288,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09684289999131579,
+        "hd15iqr": 0.10219900000083726,
+        "ops": 9.986667798601623,
+        "total": 0.3004004999966128,
+        "data": [0.09684289999131579, 0.10219900000083726, 0.10135860000445973],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8847115454368135
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10682119999546558,
+        "max": 0.10903530000359751,
+        "mean": 0.10790523333222761,
+        "stddev": 0.0011077675805076625,
+        "rounds": 3,
+        "median": 0.10785919999761973,
+        "iqr": 0.0016605750060989521,
+        "q1": 0.10708069999600411,
+        "q3": 0.10874127500210307,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10682119999546558,
+        "hd15iqr": 0.10903530000359751,
+        "ops": 9.267391109021718,
+        "total": 0.3237156999966828,
+        "data": [0.10682119999546558, 0.10785919999761973, 0.10903530000359751],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.547359246504158
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10202900000149384,
+        "max": 0.10593340000195894,
+        "mean": 0.1033397666712214,
+        "stddev": 0.0022461956712085842,
+        "rounds": 3,
+        "median": 0.1020569000102114,
+        "iqr": 0.002928300000348827,
+        "q1": 0.10203597500367323,
+        "q3": 0.10496427500402206,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10202900000149384,
+        "hd15iqr": 0.10593340000195894,
+        "ops": 9.676816894521645,
+        "total": 0.3100193000136642,
+        "data": [0.1020569000102114, 0.10593340000195894, 0.10202900000149384],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5693785873601571
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.0911164999997709,
+        "max": 0.10295149999728892,
+        "mean": 0.09626739999900262,
+        "stddev": 0.006064637904536317,
+        "rounds": 3,
+        "median": 0.09473419999994803,
+        "iqr": 0.008876249998138519,
+        "q1": 0.09202092499981518,
+        "q3": 0.1008971749979537,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.0911164999997709,
+        "hd15iqr": 0.10295149999728892,
+        "ops": 10.38773250353038,
+        "total": 0.28880219999700785,
+        "data": [0.09473419999994803, 0.10295149999728892, 0.0911164999997709],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.7844923149626417
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09603479999350384,
+        "max": 0.10304060000635218,
+        "mean": 0.10015476666740142,
+        "stddev": 0.0036623247086142795,
+        "rounds": 3,
+        "median": 0.10138890000234824,
+        "iqr": 0.005254350009636255,
+        "q1": 0.09737332499571494,
+        "q3": 0.1026276750053512,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09603479999350384,
+        "hd15iqr": 0.10304060000635218,
+        "ops": 9.984547248967653,
+        "total": 0.30046430000220425,
+        "data": [0.09603479999350384, 0.10304060000635218, 0.10138890000234824],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.924077228236506
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10335150000173599,
+        "max": 0.11124220000056084,
+        "mean": 0.10604883333144244,
+        "stddev": 0.004498713531828364,
+        "rounds": 3,
+        "median": 0.10355279999203049,
+        "iqr": 0.005918024999118643,
+        "q1": 0.10340182499930961,
+        "q3": 0.10931984999842825,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10335150000173599,
+        "hd15iqr": 0.11124220000056084,
+        "ops": 9.42961811635046,
+        "total": 0.3181464999943273,
+        "data": [0.10335150000173599, 0.10355279999203049, 0.11124220000056084],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9503907402065146
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10355139999592211,
+        "max": 0.10674940000171773,
+        "mean": 0.10516839999763761,
+        "stddev": 0.001599303913938657,
+        "rounds": 3,
+        "median": 0.10520439999527298,
+        "iqr": 0.0023985000043467153,
+        "q1": 0.10396464999575983,
+        "q3": 0.10636315000010654,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10355139999592211,
+        "hd15iqr": 0.10674940000171773,
+        "ops": 9.508559605570332,
+        "total": 0.3155051999929128,
+        "data": [0.10520439999527298, 0.10355139999592211, 0.10674940000171773],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.547359246504158
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10146839999652002,
+        "max": 0.1017400999990059,
+        "mean": 0.10160923333023675,
+        "stddev": 0.0001361239275268697,
+        "rounds": 3,
+        "median": 0.10161919999518432,
+        "iqr": 0.00020377500186441466,
+        "q1": 0.1015060999961861,
+        "q3": 0.10170987499805051,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10146839999652002,
+        "hd15iqr": 0.1017400999990059,
+        "ops": 9.841625285666055,
+        "total": 0.30482769999071024,
+        "data": [0.10146839999652002, 0.1017400999990059, 0.10161919999518432],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.570027521140341
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09501619999355171,
+        "max": 0.0995002999989083,
+        "mean": 0.09776979999636144,
+        "stddev": 0.002410775481543892,
+        "rounds": 3,
+        "median": 0.09879289999662433,
+        "iqr": 0.003363075004017446,
+        "q1": 0.09596037499431986,
+        "q3": 0.09932344999833731,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09501619999355171,
+        "hd15iqr": 0.0995002999989083,
+        "ops": 10.228107248222003,
+        "total": 0.29330939998908434,
+        "data": [0.09501619999355171, 0.09879289999662433, 0.0995002999989083],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8059423337049214
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.093753299996024,
+        "max": 0.10198799999488983,
+        "mean": 0.09916406666161492,
+        "stddev": 0.004687360774968804,
+        "rounds": 3,
+        "median": 0.10175089999393094,
+        "iqr": 0.0061760249991493765,
+        "q1": 0.09575269999550073,
+        "q3": 0.10192872499465011,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.093753299996024,
+        "hd15iqr": 0.10198799999488983,
+        "ops": 10.084298008999328,
+        "total": 0.2974921999848448,
+        "data": [0.093753299996024, 0.10175089999393094, 0.10198799999488983],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.940937294192839
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10480599998845719,
+        "max": 0.10582810000050813,
+        "mean": 0.1052365666643406,
+        "stddev": 0.0005297214437333105,
+        "rounds": 3,
+        "median": 0.10507560000405647,
+        "iqr": 0.0007665750090382062,
+        "q1": 0.10487339999235701,
+        "q3": 0.10563997500139521,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10480599998845719,
+        "hd15iqr": 0.10582810000050813,
+        "ops": 9.502400464940767,
+        "total": 0.3157096999930218,
+        "data": [0.10507560000405647, 0.10480599998845719, 0.10582810000050813],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.957682494183593
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09838870000385214,
+        "max": 0.10375809999823105,
+        "mean": 0.1018136333344349,
+        "stddev": 0.002975138692314826,
+        "rounds": 3,
+        "median": 0.10329410000122152,
+        "iqr": 0.004027049995784182,
+        "q1": 0.09961505000319448,
+        "q3": 0.10364209999897867,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09838870000385214,
+        "hd15iqr": 0.10375809999823105,
+        "ops": 9.821867339860319,
+        "total": 0.3054409000033047,
+        "data": [0.10329410000122152, 0.10375809999823105, 0.09838870000385214],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5474500093149328
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10731560000567697,
+        "max": 0.10958589999063406,
+        "mean": 0.10849336666190841,
+        "stddev": 0.001137547381655958,
+        "rounds": 3,
+        "median": 0.10857859998941422,
+        "iqr": 0.0017027249887178186,
+        "q1": 0.10763135000161128,
+        "q3": 0.1093340749903291,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10731560000567697,
+        "hd15iqr": 0.10958589999063406,
+        "ops": 9.217153368613236,
+        "total": 0.32548009998572525,
+        "data": [0.10958589999063406, 0.10857859998941422, 0.10731560000567697],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5780164815012265
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10034720000112429,
+        "max": 0.10431220001191832,
+        "mean": 0.10289210000094802,
+        "stddev": 0.0022088883024256063,
+        "rounds": 3,
+        "median": 0.10401689998980146,
+        "iqr": 0.0029737500080955215,
+        "q1": 0.10126462499829358,
+        "q3": 0.1042383750063891,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10034720000112429,
+        "hd15iqr": 0.10431220001191832,
+        "ops": 9.718919139475103,
+        "total": 0.3086763000028441,
+        "data": [0.10034720000112429, 0.10401689998980146, 0.10431220001191832],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8240802971234913
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09149720000277739,
+        "max": 0.10174800000095274,
+        "mean": 0.09584523333372393,
+        "stddev": 0.005299303912860491,
+        "rounds": 3,
+        "median": 0.09429049999744166,
+        "iqr": 0.007688099998631515,
+        "q1": 0.09219552500144346,
+        "q3": 0.09988362500007497,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09149720000277739,
+        "hd15iqr": 0.10174800000095274,
+        "ops": 10.433487041740467,
+        "total": 0.2875357000011718,
+        "data": [0.09149720000277739, 0.10174800000095274, 0.09429049999744166],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.953695585882611
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10056829999666661,
+        "max": 0.10620490000292193,
+        "mean": 0.10412776666635182,
+        "stddev": 0.003096901514494358,
+        "rounds": 3,
+        "median": 0.10561009999946691,
+        "iqr": 0.004227450004691491,
+        "q1": 0.10182874999736669,
+        "q3": 0.10605620000205818,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10056829999666661,
+        "hd15iqr": 0.10620490000292193,
+        "ops": 9.603586363320545,
+        "total": 0.31238329999905545,
+        "data": [0.10056829999666661, 0.10620490000292193, 0.10561009999946691],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9665466720782574
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10220759999356233,
+        "max": 0.11577459999534767,
+        "mean": 0.10832069999499556,
+        "stddev": 0.006882163957647078,
+        "rounds": 3,
+        "median": 0.10697989999607671,
+        "iqr": 0.010175250001339009,
+        "q1": 0.10340067499419092,
+        "q3": 0.11357592499552993,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10220759999356233,
+        "hd15iqr": 0.11577459999534767,
+        "ops": 9.231845806445122,
+        "total": 0.3249620999849867,
+        "data": [0.10220759999356233, 0.10697989999607671, 0.11577459999534767],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5503214945497537
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09815919998800382,
+        "max": 0.10498760000336915,
+        "mean": 0.10202159999850362,
+        "stddev": 0.003501344230440094,
+        "rounds": 3,
+        "median": 0.10291800000413787,
+        "iqr": 0.005121300011523999,
+        "q1": 0.09934889999203733,
+        "q3": 0.10447020000356133,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09815919998800382,
+        "hd15iqr": 0.10498760000336915,
+        "ops": 9.80184588376057,
+        "total": 0.30606479999551084,
+        "data": [0.09815919998800382, 0.10498760000336915, 0.10291800000413787],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5830841551000332
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10256319999461994,
+        "max": 0.10738359999959357,
+        "mean": 0.10475816666439641,
+        "stddev": 0.0024388604335870176,
+        "rounds": 3,
+        "median": 0.10432769999897573,
+        "iqr": 0.0036153000037302263,
+        "q1": 0.10300432499570888,
+        "q3": 0.10661962499943911,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10256319999461994,
+        "hd15iqr": 0.10738359999959357,
+        "ops": 9.545795156988602,
+        "total": 0.31427449999318924,
+        "data": [0.10256319999461994, 0.10432769999897573, 0.10738359999959357],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8389550247444384
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.08905600001162384,
+        "max": 0.09994109999388456,
+        "mean": 0.09529773333633784,
+        "stddev": 0.005615819834003465,
+        "rounds": 3,
+        "median": 0.09689610000350513,
+        "iqr": 0.008163824986695545,
+        "q1": 0.09101602500959416,
+        "q3": 0.0991798499962897,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.08905600001162384,
+        "hd15iqr": 0.09994109999388456,
+        "ops": 10.49342901442013,
+        "total": 0.2858932000090135,
+        "data": [0.08905600001162384, 0.09689610000350513, 0.09994109999388456],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9583326914545736
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09237069998926017,
+        "max": 0.10594819999823812,
+        "mean": 0.09951319999527186,
+        "stddev": 0.0068163438744081135,
+        "rounds": 3,
+        "median": 0.10022069999831729,
+        "iqr": 0.010183125006733462,
+        "q1": 0.09433319999152445,
+        "q3": 0.10451632499825791,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09237069998926017,
+        "hd15iqr": 0.10594819999823812,
+        "ops": 10.0489181339512,
+        "total": 0.2985395999858156,
+        "data": [0.09237069998926017, 0.10022069999831729, 0.10594819999823812],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9654356608325494
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09926280000945553,
+        "max": 0.10689249999995809,
+        "mean": 0.10357210000317234,
+        "stddev": 0.003909798318227725,
+        "rounds": 3,
+        "median": 0.10456100000010338,
+        "iqr": 0.005722274992876919,
+        "q1": 0.1005873500071175,
+        "q3": 0.10630962499999441,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09926280000945553,
+        "hd15iqr": 0.10689249999995809,
+        "ops": 9.655109821750942,
+        "total": 0.310716300009517,
+        "data": [0.09926280000945553, 0.10456100000010338, 0.10689249999995809],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.5515118455774415
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10628780000843108,
+        "max": 0.10918860000674613,
+        "mean": 0.10748906667383078,
+        "stddev": 0.0015132291338472246,
+        "rounds": 3,
+        "median": 0.10699080000631511,
+        "iqr": 0.0021755999987362884,
+        "q1": 0.10646355000790209,
+        "q3": 0.10863915000663837,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10628780000843108,
+        "hd15iqr": 0.10918860000674613,
+        "ops": 9.303271773997638,
+        "total": 0.3224672000214923,
+        "data": [0.10628780000843108, 0.10918860000674613, 0.10699080000631511],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5896413554864708
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09187270000984427,
+        "max": 0.10705770000640769,
+        "mean": 0.09857486667169724,
+        "stddev": 0.007747524544896696,
+        "rounds": 3,
+        "median": 0.09679419999883976,
+        "iqr": 0.011388749997422565,
+        "q1": 0.09310307500709314,
+        "q3": 0.1044918250045157,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09187270000984427,
+        "hd15iqr": 0.10705770000640769,
+        "ops": 10.14457370082469,
+        "total": 0.2957246000150917,
+        "data": [0.09187270000984427, 0.10705770000640769, 0.09679419999883976],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.8508627655448866
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09370369999669492,
+        "max": 0.10044439999910537,
+        "mean": 0.09790586666107022,
+        "stddev": 0.0036653807461171435,
+        "rounds": 3,
+        "median": 0.09956949998741038,
+        "iqr": 0.005055525001807837,
+        "q1": 0.09517014999437379,
+        "q3": 0.10022567499618162,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09370369999669492,
+        "hd15iqr": 0.10044439999910537,
+        "ops": 10.213892528644807,
+        "total": 0.2937175999832107,
+        "data": [0.09956949998741038, 0.10044439999910537, 0.09370369999669492],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9635529846814963
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09148839999397751,
+        "max": 0.10295839999162126,
+        "mean": 0.09805363333240773,
+        "stddev": 0.005912536442262201,
+        "rounds": 3,
+        "median": 0.0997141000116244,
+        "iqr": 0.008602499998232815,
+        "q1": 0.09354482499838923,
+        "q3": 0.10214732499662205,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09148839999397751,
+        "hd15iqr": 0.10295839999162126,
+        "ops": 10.198500208655602,
+        "total": 0.29416089999722317,
+        "data": [0.09148839999397751, 0.0997141000116244, 0.10295839999162126],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.9747295128080071
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1022003000107361,
+        "max": 0.10814919999393169,
+        "mean": 0.10437463333558601,
+        "stddev": 0.00328144980058195,
+        "rounds": 3,
+        "median": 0.10277440000209026,
+        "iqr": 0.004461674987396691,
+        "q1": 0.10234382500857464,
+        "q3": 0.10680549999597133,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1022003000107361,
+        "hd15iqr": 0.10814919999393169,
+        "ops": 9.580871980501175,
+        "total": 0.31312390000675805,
+        "data": [0.1022003000107361, 0.10277440000209026, 0.10814919999393169],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {
+        "compression_ratio": 1.558833689083545
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09680060000391677,
+        "max": 0.10781580000184476,
+        "mean": 0.1027513333344056,
+        "stddev": 0.005560823607804253,
+        "rounds": 3,
+        "median": 0.10363759999745525,
+        "iqr": 0.008261399998445995,
+        "q1": 0.09850985000230139,
+        "q3": 0.10677125000074739,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09680060000391677,
+        "hd15iqr": 0.10781580000184476,
+        "ops": 9.732233807083423,
+        "total": 0.3082540000032168,
+        "data": [0.09680060000391677, 0.10781580000184476, 0.10363759999745525],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {
+        "compression_ratio": 1.5947112399972467
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10077760000422131,
+        "max": 0.10576310000033118,
+        "mean": 0.10343570000259206,
+        "stddev": 0.002509148146406701,
+        "rounds": 3,
+        "median": 0.10376640000322368,
+        "iqr": 0.003739124997082399,
+        "q1": 0.1015248000039719,
+        "q3": 0.1052639250010543,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10077760000422131,
+        "hd15iqr": 0.10576310000033118,
+        "ops": 9.6678419537446,
+        "total": 0.31030710000777617,
+        "data": [0.10077760000422131, 0.10576310000033118, 0.10376640000322368],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {
+        "compression_ratio": 1.862686145097008
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.08805769999162294,
+        "max": 0.09841059999598656,
+        "mean": 0.09410216666098374,
+        "stddev": 0.005390361159383442,
+        "rounds": 3,
+        "median": 0.09583819999534171,
+        "iqr": 0.007764675003272714,
+        "q1": 0.09000282499255263,
+        "q3": 0.09776749999582535,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.08805769999162294,
+        "hd15iqr": 0.09841059999598656,
+        "ops": 10.626747879277215,
+        "total": 0.2823064999829512,
+        "data": [0.08805769999162294, 0.09583819999534171, 0.09841059999598656],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {
+        "compression_ratio": 1.9677485708596696
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09231369999179151,
+        "max": 0.09814410000399221,
+        "mean": 0.09462323332748686,
+        "stddev": 0.0030982071303393994,
+        "rounds": 3,
+        "median": 0.09341189998667687,
+        "iqr": 0.004372800009150524,
+        "q1": 0.09258824999051285,
+        "q3": 0.09696104999966337,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09231369999179151,
+        "hd15iqr": 0.09814410000399221,
+        "ops": 10.568229015584828,
+        "total": 0.2838696999824606,
+        "data": [0.09341189998667687, 0.09814410000399221, 0.09231369999179151],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 2.022351451811714
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.0966020999912871,
+        "max": 0.10508229999686591,
+        "mean": 0.10106026665986671,
+        "stddev": 0.0042568893861411605,
+        "rounds": 3,
+        "median": 0.1014963999914471,
+        "iqr": 0.006360150004184106,
+        "q1": 0.0978256749913271,
+        "q3": 0.10418582499551121,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.0966020999912871,
+        "hd15iqr": 0.10508229999686591,
+        "ops": 9.895085705301453,
+        "total": 0.3031807999796001,
+        "data": [0.0966020999912871, 0.10508229999686591, 0.1014963999914471],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8830587101382212
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1026317000068957,
+        "max": 0.1136599000019487,
+        "mean": 0.10841433333795673,
+        "stddev": 0.005533681345757022,
+        "rounds": 3,
+        "median": 0.10895140000502579,
+        "iqr": 0.00827114999628975,
+        "q1": 0.10421162500642822,
+        "q3": 0.11248277500271797,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1026317000068957,
+        "hd15iqr": 0.1136599000019487,
+        "ops": 9.22387261177662,
+        "total": 0.3252430000138702,
+        "data": [0.1026317000068957, 0.10895140000502579, 0.1136599000019487],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {
+        "compression_ratio": 1.8822816223783132
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.10828109999420121,
+        "max": 0.11613690000376664,
+        "mean": 0.11227956666455914,
+        "stddev": 0.003929801192228846,
+        "rounds": 3,
+        "median": 0.11242069999570958,
+        "iqr": 0.005891850007174071,
+        "q1": 0.1093159999945783,
+        "q3": 0.11520785000175238,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.10828109999420121,
+        "hd15iqr": 0.11613690000376664,
+        "ops": 8.906340037698492,
+        "total": 0.33683869999367744,
+        "data": [0.10828109999420121, 0.11613690000376664, 0.11242069999570958],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.539129041351558
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11706550000235438,
+        "max": 0.12153570000373293,
+        "mean": 0.1191074333328288,
+        "stddev": 0.002260002677106127,
+        "rounds": 3,
+        "median": 0.1187210999923991,
+        "iqr": 0.0033526500010339078,
+        "q1": 0.11747939999986556,
+        "q3": 0.12083205000089947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11706550000235438,
+        "hd15iqr": 0.12153570000373293,
+        "ops": 8.395781623516662,
+        "total": 0.3573222999984864,
+        "data": [0.11706550000235438, 0.12153570000373293, 0.1187210999923991],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.547978101449816
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12093499999900814,
+        "max": 0.1257476000027964,
+        "mean": 0.12267240000073798,
+        "stddev": 0.0026706855542678555,
+        "rounds": 3,
+        "median": 0.12133460000040941,
+        "iqr": 0.0036094500028411858,
+        "q1": 0.12103489999935846,
+        "q3": 0.12464435000219964,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12093499999900814,
+        "hd15iqr": 0.1257476000027964,
+        "ops": 8.151792905282559,
+        "total": 0.36801720000221394,
+        "data": [0.1257476000027964, 0.12133460000040941, 0.12093499999900814],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.5557894845151836
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12754010000207927,
+        "max": 0.19666360001428984,
+        "mean": 0.1515867666748818,
+        "stddev": 0.03906680811127808,
+        "rounds": 3,
+        "median": 0.1305566000082763,
+        "iqr": 0.05184262500915793,
+        "q1": 0.12829422500362853,
+        "q3": 0.18013685001278645,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12754010000207927,
+        "hd15iqr": 0.19666360001428984,
+        "ops": 6.596881917435223,
+        "total": 0.4547603000246454,
+        "data": [0.19666360001428984, 0.1305566000082763, 0.12754010000207927],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.5823773658537128
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12411809999321122,
+        "max": 0.12594969999918249,
+        "mean": 0.12527793332992587,
+        "stddev": 0.0010086359350038976,
+        "rounds": 3,
+        "median": 0.12576599999738391,
+        "iqr": 0.0013737000044784509,
+        "q1": 0.12453007499425439,
+        "q3": 0.12590377499873284,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12411809999321122,
+        "hd15iqr": 0.12594969999918249,
+        "ops": 7.982251729571948,
+        "total": 0.3758337999897776,
+        "data": [0.12576599999738391, 0.12594969999918249, 0.12411809999321122],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.5893218834102492
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12334819999523461,
+        "max": 0.1543188000068767,
+        "mean": 0.13740690000122413,
+        "stddev": 0.015681201451063602,
+        "rounds": 3,
+        "median": 0.13455370000156108,
+        "iqr": 0.023227950008731568,
+        "q1": 0.12614957499681623,
+        "q3": 0.1493775250055478,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12334819999523461,
+        "hd15iqr": 0.1543188000068767,
+        "ops": 7.277654906639268,
+        "total": 0.4122207000036724,
+        "data": [0.1543188000068767, 0.13455370000156108, 0.12334819999523461],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.5925140157152458
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12301570001000073,
+        "max": 0.12361359999340493,
+        "mean": 0.12335606666844494,
+        "stddev": 0.00030743636478264307,
+        "rounds": 3,
+        "median": 0.12343890000192914,
+        "iqr": 0.0004484249875531532,
+        "q1": 0.12312150000798283,
+        "q3": 0.12356992499553598,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12301570001000073,
+        "hd15iqr": 0.12361359999340493,
+        "ops": 8.106613861868576,
+        "total": 0.3700682000053348,
+        "data": [0.12361359999340493, 0.12343890000192914, 0.12301570001000073],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.5938175940470354
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13250010000774637,
+        "max": 0.15852199999790173,
+        "mean": 0.1416789333355458,
+        "stddev": 0.014606169046992013,
+        "rounds": 3,
+        "median": 0.13401470000098925,
+        "iqr": 0.01951642499261652,
+        "q1": 0.1328787500060571,
+        "q3": 0.1523951749986736,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13250010000774637,
+        "hd15iqr": 0.15852199999790173,
+        "ops": 7.058212371147985,
+        "total": 0.42503680000663735,
+        "data": [0.13401470000098925, 0.15852199999790173, 0.13250010000774637],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.5951015655927216
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13468319999810774,
+        "max": 0.18329820000508334,
+        "mean": 0.15821996666879082,
+        "stddev": 0.024344129601003368,
+        "rounds": 3,
+        "median": 0.1566785000031814,
+        "iqr": 0.036461250005231705,
+        "q1": 0.14018202499937615,
+        "q3": 0.17664327500460786,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13468319999810774,
+        "hd15iqr": 0.18329820000508334,
+        "ops": 6.3203148190098295,
+        "total": 0.4746599000063725,
+        "data": [0.18329820000508334, 0.13468319999810774, 0.1566785000031814],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.5954083715163172
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11905079999996815,
+        "max": 0.12327630000072531,
+        "mean": 0.12147963333215255,
+        "stddev": 0.002182530316407102,
+        "rounds": 3,
+        "median": 0.12211179999576416,
+        "iqr": 0.003169125000567874,
+        "q1": 0.11981604999891715,
+        "q3": 0.12298517499948503,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11905079999996815,
+        "hd15iqr": 0.12327630000072531,
+        "ops": 8.231832551434987,
+        "total": 0.3644388999964576,
+        "data": [0.12327630000072531, 0.11905079999996815, 0.12211179999576416],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.489674750582664
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11994679999770597,
+        "max": 0.12610789999598637,
+        "mean": 0.12280649999835684,
+        "stddev": 0.0031042088303947788,
+        "rounds": 3,
+        "median": 0.12236480000137817,
+        "iqr": 0.0046208249987103045,
+        "q1": 0.12055129999862402,
+        "q3": 0.12517212499733432,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11994679999770597,
+        "hd15iqr": 0.12610789999598637,
+        "ops": 8.142891459437246,
+        "total": 0.3684194999950705,
+        "data": [0.12236480000137817, 0.12610789999598637, 0.11994679999770597],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.4986946840156732
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12723350001033396,
+        "max": 0.1295008000015514,
+        "mean": 0.12856523333660638,
+        "stddev": 0.0011844295378806305,
+        "rounds": 3,
+        "median": 0.12896139999793377,
+        "iqr": 0.0017004749934130814,
+        "q1": 0.1276654750072339,
+        "q3": 0.129365950000647,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12723350001033396,
+        "hd15iqr": 0.1295008000015514,
+        "ops": 7.77815256930172,
+        "total": 0.3856957000098191,
+        "data": [0.12896139999793377, 0.1295008000015514, 0.12723350001033396],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.506691747968883
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12321410000731703,
+        "max": 0.13253469999472145,
+        "mean": 0.12688880000011218,
+        "stddev": 0.004963125841308553,
+        "rounds": 3,
+        "median": 0.1249175999982981,
+        "iqr": 0.006990449990553316,
+        "q1": 0.1236399750050623,
+        "q3": 0.1306304249956156,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12321410000731703,
+        "hd15iqr": 0.13253469999472145,
+        "ops": 7.88091620378722,
+        "total": 0.3806664000003366,
+        "data": [0.12321410000731703, 0.13253469999472145, 0.1249175999982981],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.5284246722267707
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11489240000082646,
+        "max": 0.12334779999218881,
+        "mean": 0.120273399996222,
+        "stddev": 0.004675868894815817,
+        "rounds": 3,
+        "median": 0.12257999999565072,
+        "iqr": 0.006341549993521767,
+        "q1": 0.11681429999953252,
+        "q3": 0.12315584999305429,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11489240000082646,
+        "hd15iqr": 0.12334779999218881,
+        "ops": 8.314390380844076,
+        "total": 0.360820199988666,
+        "data": [0.12257999999565072, 0.12334779999218881, 0.11489240000082646],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.536387070740668
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12386170000536367,
+        "max": 0.1250034999975469,
+        "mean": 0.12433113333342287,
+        "stddev": 0.0005973384800112967,
+        "rounds": 3,
+        "median": 0.12412819999735802,
+        "iqr": 0.0008563499941374175,
+        "q1": 0.12392832500336226,
+        "q3": 0.12478467499749968,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12386170000536367,
+        "hd15iqr": 0.1250034999975469,
+        "ops": 8.04303775883927,
+        "total": 0.3729934000002686,
+        "data": [0.1250034999975469, 0.12412819999735802, 0.12386170000536367],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.5400158572255402
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12100719999580178,
+        "max": 0.12424079999618698,
+        "mean": 0.12301993333191301,
+        "stddev": 0.0017562265970249198,
+        "rounds": 3,
+        "median": 0.12381180000375025,
+        "iqr": 0.0024252000002888963,
+        "q1": 0.1217083499977889,
+        "q3": 0.1241335499980778,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12100719999580178,
+        "hd15iqr": 0.12424079999618698,
+        "ops": 8.128763956504168,
+        "total": 0.369059799995739,
+        "data": [0.12100719999580178, 0.12381180000375025, 0.12424079999618698],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.5412012857839792
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11905380000825971,
+        "max": 0.12214490000042133,
+        "mean": 0.12107743333520678,
+        "stddev": 0.0017534012102601959,
+        "rounds": 3,
+        "median": 0.1220335999969393,
+        "iqr": 0.0023183249941212125,
+        "q1": 0.11979875000542961,
+        "q3": 0.12211707499955082,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11905380000825971,
+        "hd15iqr": 0.12214490000042133,
+        "ops": 8.259177391310136,
+        "total": 0.36323230000562035,
+        "data": [0.11905380000825971, 0.1220335999969393, 0.12214490000042133],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.5423445714736699
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11105659999884665,
+        "max": 0.12753040000097826,
+        "mean": 0.11996156666524864,
+        "stddev": 0.008317779802060048,
+        "rounds": 3,
+        "median": 0.121297699995921,
+        "iqr": 0.012355350001598708,
+        "q1": 0.11361687499811524,
+        "q3": 0.12597222499971394,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11105659999884665,
+        "hd15iqr": 0.12753040000097826,
+        "ops": 8.336003170002677,
+        "total": 0.3598846999957459,
+        "data": [0.11105659999884665, 0.121297699995921, 0.12753040000097826],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.542762485027677
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11455489999207202,
+        "max": 0.12479970000276808,
+        "mean": 0.1197773333309063,
+        "stddev": 0.005125329435091424,
+        "rounds": 3,
+        "median": 0.11997739999787882,
+        "iqr": 0.00768360000802204,
+        "q1": 0.11591052499352372,
+        "q3": 0.12359412500154576,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11455489999207202,
+        "hd15iqr": 0.12479970000276808,
+        "ops": 8.34882504219159,
+        "total": 0.3593319999927189,
+        "data": [0.11455489999207202, 0.11997739999787882, 0.12479970000276808],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {
+        "compression_ratio": 1.5497949095396426
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1208796999999322,
+        "max": 0.1230202000006102,
+        "mean": 0.12173836667110056,
+        "stddev": 0.0011312548690610867,
+        "rounds": 3,
+        "median": 0.1213152000127593,
+        "iqr": 0.0016053750005085021,
+        "q1": 0.12098857500313898,
+        "q3": 0.12259395000364748,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1208796999999322,
+        "hd15iqr": 0.1230202000006102,
+        "ops": 8.214337249173802,
+        "total": 0.3652151000133017,
+        "data": [0.1213152000127593, 0.1230202000006102, 0.1208796999999322],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {
+        "compression_ratio": 1.552747676754335
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11942410000483505,
+        "max": 0.12181149999378249,
+        "mean": 0.12068243333487771,
+        "stddev": 0.0011989378970600842,
+        "rounds": 3,
+        "median": 0.1208117000060156,
+        "iqr": 0.0017905499917105772,
+        "q1": 0.11977100000513019,
+        "q3": 0.12156154999684077,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11942410000483505,
+        "hd15iqr": 0.12181149999378249,
+        "ops": 8.286210116638376,
+        "total": 0.36204730000463314,
+        "data": [0.1208117000060156, 0.12181149999378249, 0.11942410000483505],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {
+        "compression_ratio": 1.598402963660436
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12664600000425708,
+        "max": 0.13209870000719093,
+        "mean": 0.12873046667179247,
+        "stddev": 0.0029443211396917705,
+        "rounds": 3,
+        "median": 0.12744670000392944,
+        "iqr": 0.004089525002200389,
+        "q1": 0.12684617500417517,
+        "q3": 0.13093570000637555,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12664600000425708,
+        "hd15iqr": 0.13209870000719093,
+        "ops": 7.768168840322559,
+        "total": 0.38619140001537744,
+        "data": [0.13209870000719093, 0.12744670000392944, 0.12664600000425708],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {
+        "compression_ratio": 1.6253042798069568
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13152480000280775,
+        "max": 0.17680749999999534,
+        "mean": 0.1467072999997375,
+        "stddev": 0.026067874094386656,
+        "rounds": 3,
+        "median": 0.13178959999640938,
+        "iqr": 0.033962024997890694,
+        "q1": 0.13159100000120816,
+        "q3": 0.16555302499909885,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13152480000280775,
+        "hd15iqr": 0.17680749999999534,
+        "ops": 6.8162933950920594,
+        "total": 0.4401218999992125,
+        "data": [0.13152480000280775, 0.17680749999999534, 0.13178959999640938],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {
+        "compression_ratio": 1.6536234922978885
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12382409999554511,
+        "max": 0.13209210000059102,
+        "mean": 0.1272569666665125,
+        "stddev": 0.004308679596664665,
+        "rounds": 3,
+        "median": 0.12585470000340138,
+        "iqr": 0.006201000003784429,
+        "q1": 0.12433174999750918,
+        "q3": 0.1305327500012936,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12382409999554511,
+        "hd15iqr": 0.13209210000059102,
+        "ops": 7.85811595384466,
+        "total": 0.3817708999995375,
+        "data": [0.13209210000059102, 0.12382409999554511, 0.12585470000340138],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {
+        "compression_ratio": 1.657530729932747
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12642599998798687,
+        "max": 0.12995069999305997,
+        "mean": 0.12779349999133652,
+        "stddev": 0.0018903960159221262,
+        "rounds": 3,
+        "median": 0.12700379999296274,
+        "iqr": 0.0026435250038048252,
+        "q1": 0.12657044998923084,
+        "q3": 0.12921397499303566,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12642599998798687,
+        "hd15iqr": 0.12995069999305997,
+        "ops": 7.825124126561936,
+        "total": 0.3833804999740096,
+        "data": [0.12995069999305997, 0.12700379999296274, 0.12642599998798687],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {
+        "compression_ratio": 1.6605458150015706
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12229739999747835,
+        "max": 0.12728169999900274,
+        "mean": 0.12399296666262671,
+        "stddev": 0.0028485867826050135,
+        "rounds": 3,
+        "median": 0.12239979999139905,
+        "iqr": 0.0037382250011432916,
+        "q1": 0.12232299999595853,
+        "q3": 0.12606122499710182,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12229739999747835,
+        "hd15iqr": 0.12728169999900274,
+        "ops": 8.064973578065171,
+        "total": 0.37197889998788014,
+        "data": [0.12728169999900274, 0.12229739999747835, 0.12239979999139905],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {
+        "compression_ratio": 1.6612635016783475
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12169210000138264,
+        "max": 0.12754309999581892,
+        "mean": 0.12458343333370674,
+        "stddev": 0.0029260984803477275,
+        "rounds": 3,
+        "median": 0.12451510000391863,
+        "iqr": 0.004388249995827209,
+        "q1": 0.12239785000201664,
+        "q3": 0.12678609999784385,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12169210000138264,
+        "hd15iqr": 0.12754309999581892,
+        "ops": 8.02674940994297,
+        "total": 0.3737503000011202,
+        "data": [0.12754309999581892, 0.12169210000138264, 0.12451510000391863],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {
+        "compression_ratio": 1.6612635016783475
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.126890600004117,
+        "max": 0.15973749999830034,
+        "mean": 0.13815490000221567,
+        "stddev": 0.018697063832144832,
+        "rounds": 3,
+        "median": 0.1278366000042297,
+        "iqr": 0.0246351749956375,
+        "q1": 0.12712710000414518,
+        "q3": 0.15176227499978268,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.126890600004117,
+        "hd15iqr": 0.15973749999830034,
+        "ops": 7.238252135711164,
+        "total": 0.41446470000664704,
+        "data": [0.126890600004117, 0.15973749999830034, 0.1278366000042297],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {
+        "compression_ratio": 1.6632749536669988
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11718610000389162,
+        "max": 0.12141449999762699,
+        "mean": 0.11942696666907675,
+        "stddev": 0.0021255528601620867,
+        "rounds": 3,
+        "median": 0.11968030000571162,
+        "iqr": 0.003171299995301524,
+        "q1": 0.11780965000434662,
+        "q3": 0.12098094999964815,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11718610000389162,
+        "hd15iqr": 0.12141449999762699,
+        "ops": 8.37331825374855,
+        "total": 0.35828090000723023,
+        "data": [0.12141449999762699, 0.11968030000571162, 0.11718610000389162],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {
+        "compression_ratio": 1.6647577628121442
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1209035999927437,
+        "max": 0.12575779999315273,
+        "mean": 0.122556333328248,
+        "stddev": 0.002773039055835593,
+        "rounds": 3,
+        "median": 0.12100759999884758,
+        "iqr": 0.0036406500003067777,
+        "q1": 0.12092959999426967,
+        "q3": 0.12457024999457644,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1209035999927437,
+        "hd15iqr": 0.12575779999315273,
+        "ops": 8.159513040600327,
+        "total": 0.367668999984744,
+        "data": [0.12575779999315273, 0.12100759999884758, 0.1209035999927437],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {
+        "compression_ratio": 1.6647577628121442
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11746449999918696,
+        "max": 0.12060820001352113,
+        "mean": 0.11932600000485157,
+        "stddev": 0.001649970851233446,
+        "rounds": 3,
+        "median": 0.11990530000184663,
+        "iqr": 0.002357775010750629,
+        "q1": 0.11807469999985187,
+        "q3": 0.1204324750106025,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11746449999918696,
+        "hd15iqr": 0.12060820001352113,
+        "ops": 8.38040326466438,
+        "total": 0.3579780000145547,
+        "data": [0.11746449999918696, 0.11990530000184663, 0.12060820001352113],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {
+        "compression_ratio": 1.6711669800952194
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11694159999024123,
+        "max": 0.12768119999964256,
+        "mean": 0.12107146666191208,
+        "stddev": 0.00578334298667808,
+        "rounds": 3,
+        "median": 0.11859159999585245,
+        "iqr": 0.008054700007050997,
+        "q1": 0.11735409999164403,
+        "q3": 0.12540879999869503,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11694159999024123,
+        "hd15iqr": 0.12768119999964256,
+        "ops": 8.259584422087375,
+        "total": 0.36321439998573624,
+        "data": [0.12768119999964256, 0.11694159999024123, 0.11859159999585245],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {
+        "compression_ratio": 1.6733416378422943
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11724140000296757,
+        "max": 0.11949929999536835,
+        "mean": 0.11863056666819223,
+        "stddev": 0.0012155929575458776,
+        "rounds": 3,
+        "median": 0.11915100000624079,
+        "iqr": 0.0016934249943005852,
+        "q1": 0.11771880000378587,
+        "q3": 0.11941222499808646,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11724140000296757,
+        "hd15iqr": 0.11949929999536835,
+        "ops": 8.42953066891254,
+        "total": 0.3558917000045767,
+        "data": [0.11949929999536835, 0.11724140000296757, 0.11915100000624079],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {
+        "compression_ratio": 1.6743630832708416
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11571060000278521,
+        "max": 0.12102459999732673,
+        "mean": 0.11804289999903024,
+        "stddev": 0.002715868048616342,
+        "rounds": 3,
+        "median": 0.11739349999697879,
+        "iqr": 0.003985499995906139,
+        "q1": 0.11613132500133361,
+        "q3": 0.12011682499723975,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11571060000278521,
+        "hd15iqr": 0.12102459999732673,
+        "ops": 8.471496379775617,
+        "total": 0.35412869999709073,
+        "data": [0.12102459999732673, 0.11571060000278521, 0.11739349999697879],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {
+        "compression_ratio": 1.664111053343148
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11609779999707825,
+        "max": 0.12136069999542087,
+        "mean": 0.11921106665977277,
+        "stddev": 0.0027606106190269904,
+        "rounds": 3,
+        "median": 0.12017469998681918,
+        "iqr": 0.003947174998756964,
+        "q1": 0.11711702499451349,
+        "q3": 0.12106419999327045,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11609779999707825,
+        "hd15iqr": 0.12136069999542087,
+        "ops": 8.388482948936195,
+        "total": 0.3576331999793183,
+        "data": [0.12017469998681918, 0.11609779999707825, 0.12136069999542087],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {
+        "compression_ratio": 1.688169763510149
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1143014000117546,
+        "max": 0.11818099999800324,
+        "mean": 0.11575410000417226,
+        "stddev": 0.0021153305286385872,
+        "rounds": 3,
+        "median": 0.11477990000275895,
+        "iqr": 0.0029096999896864872,
+        "q1": 0.11442102500950568,
+        "q3": 0.11733072499919217,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1143014000117546,
+        "hd15iqr": 0.11818099999800324,
+        "ops": 8.639002851423456,
+        "total": 0.3472623000125168,
+        "data": [0.11818099999800324, 0.1143014000117546, 0.11477990000275895],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {
+        "compression_ratio": 1.722580949076892
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11862730000575539,
+        "max": 0.12668709999707062,
+        "mean": 0.1217045666659639,
+        "stddev": 0.004354609602527872,
+        "rounds": 3,
+        "median": 0.11979929999506567,
+        "iqr": 0.006044849993486423,
+        "q1": 0.11892030000308296,
+        "q3": 0.12496514999656938,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11862730000575539,
+        "hd15iqr": 0.12668709999707062,
+        "ops": 8.21661854928293,
+        "total": 0.36511369999789167,
+        "data": [0.12668709999707062, 0.11862730000575539, 0.11979929999506567],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {
+        "compression_ratio": 1.7310450272243336
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11861999999382533,
+        "max": 0.1639117000013357,
+        "mean": 0.13425476666695127,
+        "stddev": 0.02569631084026772,
+        "rounds": 3,
+        "median": 0.1202326000056928,
+        "iqr": 0.03396877500563278,
+        "q1": 0.1190231499967922,
+        "q3": 0.15299192500242498,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11861999999382533,
+        "hd15iqr": 0.1639117000013357,
+        "ops": 7.4485251051139345,
+        "total": 0.40276430000085384,
+        "data": [0.1202326000056928, 0.11861999999382533, 0.1639117000013357],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {
+        "compression_ratio": 1.5024052623907906
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.09580189999542199,
+        "max": 0.10787160000472795,
+        "mean": 0.1033647999962947,
+        "stddev": 0.006589705983691642,
+        "rounds": 3,
+        "median": 0.10642089998873416,
+        "iqr": 0.009052275006979471,
+        "q1": 0.09845664999375003,
+        "q3": 0.1075089250007295,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.09580189999542199,
+        "hd15iqr": 0.10787160000472795,
+        "ops": 9.674473322019168,
+        "total": 0.3100943999888841,
+        "data": [0.09580189999542199, 0.10787160000472795, 0.10642089998873416],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {
+        "compression_ratio": 1.507665814766714
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1135766999941552,
+        "max": 0.11546529999759514,
+        "mean": 0.11437666666461155,
+        "stddev": 0.0009768310113777582,
+        "rounds": 3,
+        "median": 0.1140880000020843,
+        "iqr": 0.0014164500025799498,
+        "q1": 0.11370452499613748,
+        "q3": 0.11512097499871743,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1135766999941552,
+        "hd15iqr": 0.11546529999759514,
+        "ops": 8.743041995902148,
+        "total": 0.34312999999383464,
+        "data": [0.1135766999941552, 0.1140880000020843, 0.11546529999759514],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {
+        "compression_ratio": 1.5480164144767568
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11114729999098927,
+        "max": 0.12416219999431632,
+        "mean": 0.11787823332997505,
+        "stddev": 0.006518952364477955,
+        "rounds": 3,
+        "median": 0.11832520000461955,
+        "iqr": 0.009761175002495293,
+        "q1": 0.11294177499439684,
+        "q3": 0.12270294999689213,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11114729999098927,
+        "hd15iqr": 0.12416219999431632,
+        "ops": 8.48333039740011,
+        "total": 0.35363469998992514,
+        "data": [0.11114729999098927, 0.11832520000461955, 0.12416219999431632],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {
+        "compression_ratio": 1.597955959867537
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.11798320000525564,
+        "max": 0.12470480000774842,
+        "mean": 0.12040340000142653,
+        "stddev": 0.0037348576622170983,
+        "rounds": 3,
+        "median": 0.11852219999127556,
+        "iqr": 0.0050412000018695835,
+        "q1": 0.11811795000176062,
+        "q3": 0.1231591500036302,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.11798320000525564,
+        "hd15iqr": 0.12470480000774842,
+        "ops": 8.305413302183759,
+        "total": 0.3612102000042796,
+        "data": [0.11798320000525564, 0.12470480000774842, 0.11852219999127556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {
+        "compression_ratio": 1.63725964449338
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12175829999614507,
+        "max": 0.1261679000017466,
+        "mean": 0.12457529999664985,
+        "stddev": 0.002446530106889476,
+        "rounds": 3,
+        "median": 0.12579969999205787,
+        "iqr": 0.0033072000042011496,
+        "q1": 0.12276864999512327,
+        "q3": 0.12607584999932442,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12175829999614507,
+        "hd15iqr": 0.1261679000017466,
+        "ops": 8.027273464538256,
+        "total": 0.37372589998994954,
+        "data": [0.12175829999614507, 0.1261679000017466, 0.12579969999205787],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {
+        "compression_ratio": 1.6428115875717515
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1245887999975821,
+        "max": 0.12687419999565464,
+        "mean": 0.1255954999990839,
+        "stddev": 0.0011667267399805407,
+        "rounds": 3,
+        "median": 0.12532350000401493,
+        "iqr": 0.001714049998554401,
+        "q1": 0.12477247499919031,
+        "q3": 0.1264865249977447,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1245887999975821,
+        "hd15iqr": 0.12687419999565464,
+        "ops": 7.962068704748929,
+        "total": 0.37678649999725167,
+        "data": [0.1245887999975821, 0.12687419999565464, 0.12532350000401493],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {
+        "compression_ratio": 1.6658641129918579
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.12575289999949746,
+        "max": 0.13214490000973456,
+        "mean": 0.12972880000112733,
+        "stddev": 0.0034697475479338363,
+        "rounds": 3,
+        "median": 0.13128859999415,
+        "iqr": 0.004794000007677823,
+        "q1": 0.1271368249981606,
+        "q3": 0.13193082500583841,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.12575289999949746,
+        "hd15iqr": 0.13214490000973456,
+        "ops": 7.708388576717815,
+        "total": 0.389186400003382,
+        "data": [0.13128859999415, 0.13214490000973456, 0.12575289999949746],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {
+        "compression_ratio": 1.6673554063571625
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.129613099998096,
+        "max": 0.13316549999581184,
+        "mean": 0.13191113332868554,
+        "stddev": 0.0019929416735723154,
+        "rounds": 3,
+        "median": 0.13295479999214876,
+        "iqr": 0.0026642999982868787,
+        "q1": 0.1304485249966092,
+        "q3": 0.13311282499489607,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.129613099998096,
+        "hd15iqr": 0.13316549999581184,
+        "ops": 7.58086125686056,
+        "total": 0.3957333999860566,
+        "data": [0.129613099998096, 0.13316549999581184, 0.13295479999214876],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {
+        "compression_ratio": 1.6778703985413987
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14370299999427516,
+        "max": 0.14921350000076927,
+        "mean": 0.14592769999580923,
+        "stddev": 0.0029044539062181443,
+        "rounds": 3,
+        "median": 0.14486659999238327,
+        "iqr": 0.004132875004870584,
+        "q1": 0.1439938999938022,
+        "q3": 0.14812677499867277,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14370299999427516,
+        "hd15iqr": 0.14921350000076927,
+        "ops": 6.852708567521574,
+        "total": 0.4377830999874277,
+        "data": [0.14486659999238327, 0.14921350000076927, 0.14370299999427516],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {
+        "compression_ratio": 1.6855273802872495
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14476809999905527,
+        "max": 0.15257439999550115,
+        "mean": 0.14777723333099857,
+        "stddev": 0.004199092438537767,
+        "rounds": 3,
+        "median": 0.1459891999984393,
+        "iqr": 0.005854724997334415,
+        "q1": 0.14507337499890127,
+        "q3": 0.1509280999962357,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14476809999905527,
+        "hd15iqr": 0.15257439999550115,
+        "ops": 6.766942224179768,
+        "total": 0.4433316999929957,
+        "data": [0.14476809999905527, 0.1459891999984393, 0.15257439999550115],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {
+        "compression_ratio": 1.6884532105362917
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14234580000629649,
+        "max": 0.14714129999629222,
+        "mean": 0.145357833331218,
+        "stddev": 0.0026232112127654696,
+        "rounds": 3,
+        "median": 0.14658639999106526,
+        "iqr": 0.0035966249924967997,
+        "q1": 0.14340595000248868,
+        "q3": 0.14700257499498548,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14234580000629649,
+        "hd15iqr": 0.14714129999629222,
+        "ops": 6.879574200320951,
+        "total": 0.43607349999365397,
+        "data": [0.14714129999629222, 0.14234580000629649, 0.14658639999106526],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {
+        "compression_ratio": 1.6887613645020771
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1485711999994237,
+        "max": 0.15561800000432413,
+        "mean": 0.15295640000355584,
+        "stddev": 0.0038265448260752346,
+        "rounds": 3,
+        "median": 0.15468000000691973,
+        "iqr": 0.005285100003675325,
+        "q1": 0.1500984000012977,
+        "q3": 0.15538350000497303,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1485711999994237,
+        "hd15iqr": 0.15561800000432413,
+        "ops": 6.537810774683194,
+        "total": 0.45886920001066756,
+        "data": [0.15561800000432413, 0.1485711999994237, 0.15468000000691973],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {
+        "compression_ratio": 1.6918243237704826
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13856269999814685,
+        "max": 0.16233229999488685,
+        "mean": 0.1466280333309745,
+        "stddev": 0.013601964851771368,
+        "rounds": 3,
+        "median": 0.13898909999988973,
+        "iqr": 0.017827199997555,
+        "q1": 0.13866929999858257,
+        "q3": 0.15649649999613757,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13856269999814685,
+        "hd15iqr": 0.16233229999488685,
+        "ops": 6.819978262565667,
+        "total": 0.43988409999292344,
+        "data": [0.13898909999988973, 0.16233229999488685, 0.13856269999814685],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {
+        "compression_ratio": 1.6965489886612366
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.13831140000547748,
+        "max": 0.14503589998639654,
+        "mean": 0.14113939999757955,
+        "stddev": 0.0034872617023360823,
+        "rounds": 3,
+        "median": 0.14007090000086464,
+        "iqr": 0.005043374985689297,
+        "q1": 0.13875127500432427,
+        "q3": 0.14379464999001357,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.13831140000547748,
+        "hd15iqr": 0.14503589998639654,
+        "ops": 7.085193787256778,
+        "total": 0.42341819999273866,
+        "data": [0.13831140000547748, 0.14503589998639654, 0.14007090000086464],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {
+        "compression_ratio": 1.6996530342682177
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1398101999948267,
+        "max": 0.15185369999380782,
+        "mean": 0.14476459999665772,
+        "stddev": 0.006299141299326123,
+        "rounds": 3,
+        "median": 0.14262990000133868,
+        "iqr": 0.00903262499923585,
+        "q1": 0.1405151249964547,
+        "q3": 0.14954774999569054,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1398101999948267,
+        "hd15iqr": 0.15185369999380782,
+        "ops": 6.907766125303338,
+        "total": 0.4342937999899732,
+        "data": [0.1398101999948267, 0.15185369999380782, 0.14262990000133868],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {
+        "compression_ratio": 1.7101929820689215
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1281923999922583,
+        "max": 0.14117080000869464,
+        "mean": 0.13492536666550828,
+        "stddev": 0.006502921136504809,
+        "rounds": 3,
+        "median": 0.13541289999557193,
+        "iqr": 0.009733800012327265,
+        "q1": 0.1299975249930867,
+        "q3": 0.13973132500541396,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1281923999922583,
+        "hd15iqr": 0.14117080000869464,
+        "ops": 7.4115047801136384,
+        "total": 0.40477609999652486,
+        "data": [0.1281923999922583, 0.13541289999557193, 0.14117080000869464],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {
+        "compression_ratio": 1.723309640355184
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1374111999903107,
+        "max": 0.1419634999911068,
+        "mean": 0.13902299999123593,
+        "stddev": 0.0025504786981487603,
+        "rounds": 3,
+        "median": 0.13769429999229033,
+        "iqr": 0.003414225000597071,
+        "q1": 0.1374819749908056,
+        "q3": 0.14089619999140268,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1374111999903107,
+        "hd15iqr": 0.1419634999911068,
+        "ops": 7.19305438713767,
+        "total": 0.41706899997370783,
+        "data": [0.1374111999903107, 0.1419634999911068, 0.13769429999229033],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {
+        "compression_ratio": 1.7376289086252106
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.1394338000100106,
+        "max": 0.15468649999820627,
+        "mean": 0.1459006333364717,
+        "stddev": 0.007886358534840921,
+        "rounds": 3,
+        "median": 0.14358160000119824,
+        "iqr": 0.011439524991146754,
+        "q1": 0.1404707500078075,
+        "q3": 0.15191027499895426,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.1394338000100106,
+        "hd15iqr": 0.15468649999820627,
+        "ops": 6.853979843211714,
+        "total": 0.4377019000094151,
+        "data": [0.1394338000100106, 0.15468649999820627, 0.14358160000119824],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "read",
+      "name": "test_read_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_read_tensorstore_benchmark.py::test_read_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {
+        "compression_ratio": 1.740952858432642
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.14097140000376385,
+        "max": 0.14552990000811405,
+        "mean": 0.14301806666965908,
+        "stddev": 0.0023145767641969566,
+        "rounds": 3,
+        "median": 0.1425528999970993,
+        "iqr": 0.003418875003262656,
+        "q1": 0.1413667750020977,
+        "q3": 0.14478565000536037,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.14097140000376385,
+        "hd15iqr": 0.14552990000811405,
+        "ops": 6.992123605682523,
+        "total": 0.4290542000089772,
+        "data": [0.14097140000376385, 0.14552990000811405, 0.1425528999970993],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[60-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[60-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 60,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "60-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4185941999894567,
+        "max": 1.7952645999903325,
+        "mean": 1.6164672333252383,
+        "stddev": 0.18905834642618488,
+        "rounds": 3,
+        "median": 1.6355428999959258,
+        "iqr": 0.28250280000065686,
+        "q1": 1.472831374991074,
+        "q3": 1.7553341749917308,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4185941999894567,
+        "hd15iqr": 1.7952645999903325,
+        "ops": 0.618633016113106,
+        "total": 4.849401699975715,
+        "data": [1.7952645999903325, 1.6355428999959258, 1.4185941999894567],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[61-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[61-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 61,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "61-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4666966000077082,
+        "max": 1.8318882000021404,
+        "mean": 1.6548412666694883,
+        "stddev": 0.18284856012669792,
+        "rounds": 3,
+        "median": 1.665938999998616,
+        "iqr": 0.27389369999582414,
+        "q1": 1.5165072000054352,
+        "q3": 1.7904009000012593,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4666966000077082,
+        "hd15iqr": 1.8318882000021404,
+        "ops": 0.6042875653038233,
+        "total": 4.964523800008465,
+        "data": [1.665938999998616, 1.4666966000077082, 1.8318882000021404],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[62-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[62-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 62,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "62-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2775550999940606,
+        "max": 1.651885700004641,
+        "mean": 1.472075833332686,
+        "stddev": 0.18759839211633372,
+        "rounds": 3,
+        "median": 1.4867866999993566,
+        "iqr": 0.2807479500079353,
+        "q1": 1.3298629999953846,
+        "q3": 1.6106109500033199,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2775550999940606,
+        "hd15iqr": 1.651885700004641,
+        "ops": 0.679312829785449,
+        "total": 4.416227499998058,
+        "data": [1.651885700004641, 1.4867866999993566, 1.2775550999940606],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[63-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[63-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 63,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "63-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.276759200001834,
+        "max": 1.4033206000021892,
+        "mean": 1.3486783999978798,
+        "stddev": 0.06502551836816314,
+        "rounds": 3,
+        "median": 1.3659553999896161,
+        "iqr": 0.0949210500002664,
+        "q1": 1.2990582499987795,
+        "q3": 1.393979299999046,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.276759200001834,
+        "hd15iqr": 1.4033206000021892,
+        "ops": 0.7414666090904786,
+        "total": 4.046035199993639,
+        "data": [1.4033206000021892, 1.3659553999896161, 1.276759200001834],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2262505000107922,
+        "max": 1.4494783999980427,
+        "mean": 1.3519768000066203,
+        "stddev": 0.11425913136784083,
+        "rounds": 3,
+        "median": 1.380201500011026,
+        "iqr": 0.16742092499043792,
+        "q1": 1.2647382500108506,
+        "q3": 1.4321591750012885,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2262505000107922,
+        "hd15iqr": 1.4494783999980427,
+        "ops": 0.7396576627610054,
+        "total": 4.055930400019861,
+        "data": [1.2262505000107922, 1.4494783999980427, 1.380201500011026],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.480467100001988,
+        "max": 1.7500555000005988,
+        "mean": 1.6005577999991754,
+        "stddev": 0.13717891634791993,
+        "rounds": 3,
+        "median": 1.571150799994939,
+        "iqr": 0.20219129999895813,
+        "q1": 1.5031380250002258,
+        "q3": 1.7053293249991839,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.480467100001988,
+        "hd15iqr": 1.7500555000005988,
+        "ops": 0.624782185310968,
+        "total": 4.801673399997526,
+        "data": [1.7500555000005988, 1.571150799994939, 1.480467100001988],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4724974999990081,
+        "max": 1.7766129999945406,
+        "mean": 1.6332064333303908,
+        "stddev": 0.15279426773802318,
+        "rounds": 3,
+        "median": 1.650508799997624,
+        "iqr": 0.22808662499664933,
+        "q1": 1.517000324998662,
+        "q3": 1.7450869499953114,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4724974999990081,
+        "hd15iqr": 1.7766129999945406,
+        "ops": 0.6122924693364248,
+        "total": 4.899619299991173,
+        "data": [1.650508799997624, 1.4724974999990081, 1.7766129999945406],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7384044000064023,
+        "max": 1.8394948999921326,
+        "mean": 1.7864428000029875,
+        "stddev": 0.050731402381097045,
+        "rounds": 3,
+        "median": 1.7814291000104276,
+        "iqr": 0.0758178749892977,
+        "q1": 1.7491605750074086,
+        "q3": 1.8249784499967063,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7384044000064023,
+        "hd15iqr": 1.8394948999921326,
+        "ops": 0.5597716310862725,
+        "total": 5.3593284000089625,
+        "data": [1.7384044000064023, 1.7814291000104276, 1.8394948999921326],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4356090999935986,
+        "max": 1.7136899000033736,
+        "mean": 1.5721150999985791,
+        "stddev": 0.13910967753394335,
+        "rounds": 3,
+        "median": 1.5670462999987649,
+        "iqr": 0.20856060000733123,
+        "q1": 1.4684683999948902,
+        "q3": 1.6770290000022214,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4356090999935986,
+        "hd15iqr": 1.7136899000033736,
+        "ops": 0.6360857420686971,
+        "total": 4.716345299995737,
+        "data": [1.4356090999935986, 1.7136899000033736, 1.5670462999987649],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5555025000066962,
+        "max": 1.7428803999937372,
+        "mean": 1.6474213666660944,
+        "stddev": 0.09373910035794882,
+        "rounds": 3,
+        "median": 1.6438811999978498,
+        "iqr": 0.14053342499028076,
+        "q1": 1.5775971750044846,
+        "q3": 1.7181305999947654,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5555025000066962,
+        "hd15iqr": 1.7428803999937372,
+        "ops": 0.6070092450140497,
+        "total": 4.942264099998283,
+        "data": [1.6438811999978498, 1.7428803999937372, 1.5555025000066962],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5083379999996396,
+        "max": 1.5393463999935193,
+        "mean": 1.523782300001282,
+        "stddev": 0.01550454712571186,
+        "rounds": 3,
+        "median": 1.523662500010687,
+        "iqr": 0.02325629999540979,
+        "q1": 1.5121691250024014,
+        "q3": 1.5354254249978112,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5083379999996396,
+        "hd15iqr": 1.5393463999935193,
+        "ops": 0.6562617245253202,
+        "total": 4.571346900003846,
+        "data": [1.5083379999996396, 1.523662500010687, 1.5393463999935193],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.565333799997461,
+        "max": 1.6031283999909647,
+        "mean": 1.5803695333306678,
+        "stddev": 0.020046023008523282,
+        "rounds": 3,
+        "median": 1.5726464000035776,
+        "iqr": 0.02834594999512774,
+        "q1": 1.5671619499989902,
+        "q3": 1.595507899994118,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.565333799997461,
+        "hd15iqr": 1.6031283999909647,
+        "ops": 0.6327634005272649,
+        "total": 4.741108599992003,
+        "data": [1.6031283999909647, 1.5726464000035776, 1.565333799997461],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7318438999936916,
+        "max": 1.8559296000021277,
+        "mean": 1.7990045333329665,
+        "stddev": 0.06267288373323554,
+        "rounds": 3,
+        "median": 1.8092401000030804,
+        "iqr": 0.09306427500632708,
+        "q1": 1.7511929499960388,
+        "q3": 1.8442572250023659,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7318438999936916,
+        "hd15iqr": 1.8559296000021277,
+        "ops": 0.5558629683646918,
+        "total": 5.3970135999989,
+        "data": [1.7318438999936916, 1.8559296000021277, 1.8092401000030804],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5032416000030935,
+        "max": 1.712622699997155,
+        "mean": 1.6163337999993626,
+        "stddev": 0.10569708807157317,
+        "rounds": 3,
+        "median": 1.633137099997839,
+        "iqr": 0.15703582499554614,
+        "q1": 1.5357154750017799,
+        "q3": 1.692751299997326,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5032416000030935,
+        "hd15iqr": 1.712622699997155,
+        "ops": 0.6186840861710585,
+        "total": 4.849001399998087,
+        "data": [1.712622699997155, 1.5032416000030935, 1.633137099997839],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5375868999981321,
+        "max": 1.7151943999924697,
+        "mean": 1.636094199993143,
+        "stddev": 0.09038021166849261,
+        "rounds": 3,
+        "median": 1.6555012999888277,
+        "iqr": 0.13320562499575317,
+        "q1": 1.567065499995806,
+        "q3": 1.7002711249915592,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5375868999981321,
+        "hd15iqr": 1.7151943999924697,
+        "ops": 0.6112117505240169,
+        "total": 4.9082825999794295,
+        "data": [1.5375868999981321, 1.6555012999888277, 1.7151943999924697],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.518621000010171,
+        "max": 1.6938474000053247,
+        "mean": 1.5845870000048308,
+        "stddev": 0.09529888046411819,
+        "rounds": 3,
+        "median": 1.5412925999989966,
+        "iqr": 0.13141979999636533,
+        "q1": 1.5242889000073774,
+        "q3": 1.6557087000037427,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.518621000010171,
+        "hd15iqr": 1.6938474000053247,
+        "ops": 0.6310792654470543,
+        "total": 4.753761000014492,
+        "data": [1.6938474000053247, 1.518621000010171, 1.5412925999989966],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.625949599998421,
+        "max": 1.8310627000028035,
+        "mean": 1.736193033333014,
+        "stddev": 0.1034171672134265,
+        "rounds": 3,
+        "median": 1.7515667999978177,
+        "iqr": 0.15383482500328682,
+        "q1": 1.6573538999982702,
+        "q3": 1.811188725001557,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.625949599998421,
+        "hd15iqr": 1.8310627000028035,
+        "ops": 0.5759728214553853,
+        "total": 5.208579099999042,
+        "data": [1.8310627000028035, 1.625949599998421, 1.7515667999978177],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5762585999909788,
+        "max": 1.7140056000062032,
+        "mean": 1.6255418999984006,
+        "stddev": 0.07677816624171825,
+        "rounds": 3,
+        "median": 1.58636149999802,
+        "iqr": 0.10331025001141825,
+        "q1": 1.5787843249927391,
+        "q3": 1.6820945750041574,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5762585999909788,
+        "hd15iqr": 1.7140056000062032,
+        "ops": 0.6151794672293491,
+        "total": 4.876625699995202,
+        "data": [1.5762585999909788, 1.58636149999802, 1.7140056000062032],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5436925000103656,
+        "max": 1.7025348000024678,
+        "mean": 1.6257976000051713,
+        "stddev": 0.07955708535060024,
+        "rounds": 3,
+        "median": 1.6311655000026803,
+        "iqr": 0.11913172499407665,
+        "q1": 1.5655607500084443,
+        "q3": 1.684692475002521,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5436925000103656,
+        "hd15iqr": 1.7025348000024678,
+        "ops": 0.615082713861073,
+        "total": 4.877392800015514,
+        "data": [1.5436925000103656, 1.6311655000026803, 1.7025348000024678],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.424610699992627,
+        "max": 1.5833272000018042,
+        "mean": 1.5044061333319405,
+        "stddev": 0.07936186257639921,
+        "rounds": 3,
+        "median": 1.5052805000013905,
+        "iqr": 0.11903737500688294,
+        "q1": 1.4447781499948178,
+        "q3": 1.5638155250017007,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.424610699992627,
+        "hd15iqr": 1.5833272000018042,
+        "ops": 0.6647141206378973,
+        "total": 4.5132183999958215,
+        "data": [1.5052805000013905, 1.5833272000018042, 1.424610699992627],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4321654999948805,
+        "max": 1.6823013999965042,
+        "mean": 1.5331181333312998,
+        "stddev": 0.13185839984952555,
+        "rounds": 3,
+        "median": 1.4848875000025146,
+        "iqr": 0.18760192500121775,
+        "q1": 1.445345999996789,
+        "q3": 1.6329479249980068,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4321654999948805,
+        "hd15iqr": 1.6823013999965042,
+        "ops": 0.6522654570832765,
+        "total": 4.599354399993899,
+        "data": [1.6823013999965042, 1.4848875000025146, 1.4321654999948805],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.688942799999495,
+        "max": 1.7695836999919266,
+        "mean": 1.7176906999957282,
+        "stddev": 0.04502788500922096,
+        "rounds": 3,
+        "median": 1.694545599995763,
+        "iqr": 0.060480674994323635,
+        "q1": 1.690343499998562,
+        "q3": 1.7508241749928857,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.688942799999495,
+        "hd15iqr": 1.7695836999919266,
+        "ops": 0.5821769891415765,
+        "total": 5.153072099987185,
+        "data": [1.7695836999919266, 1.694545599995763, 1.688942799999495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5877043999935267,
+        "max": 1.6643075000029057,
+        "mean": 1.6356486666675967,
+        "stddev": 0.041784622614779894,
+        "rounds": 3,
+        "median": 1.6549341000063578,
+        "iqr": 0.05745232500703423,
+        "q1": 1.6045118249967345,
+        "q3": 1.6619641500037687,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5877043999935267,
+        "hd15iqr": 1.6643075000029057,
+        "ops": 0.6113782381135423,
+        "total": 4.90694600000279,
+        "data": [1.5877043999935267, 1.6549341000063578, 1.6643075000029057],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7109366000076989,
+        "max": 1.8910419000021648,
+        "mean": 1.8279685000064394,
+        "stddev": 0.10145501251025349,
+        "rounds": 3,
+        "median": 1.8819270000094548,
+        "iqr": 0.13507897499584942,
+        "q1": 1.7536842000081379,
+        "q3": 1.8887631750039873,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7109366000076989,
+        "hd15iqr": 1.8910419000021648,
+        "ops": 0.5470553786875852,
+        "total": 5.483905500019318,
+        "data": [1.7109366000076989, 1.8819270000094548, 1.8910419000021648],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5003562000056263,
+        "max": 2.2957448000088334,
+        "mean": 1.7972848666734837,
+        "stddev": 0.4343062224251666,
+        "rounds": 3,
+        "median": 1.5957536000059918,
+        "iqr": 0.5965414500024053,
+        "q1": 1.5242055500057177,
+        "q3": 2.120747000008123,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5003562000056263,
+        "hd15iqr": 2.2957448000088334,
+        "ops": 0.5563948256298715,
+        "total": 5.3918546000204515,
+        "data": [2.2957448000088334, 1.5957536000059918, 1.5003562000056263],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4378857000119751,
+        "max": 1.6915544999937993,
+        "mean": 1.5495639333336537,
+        "stddev": 0.12952255859645234,
+        "rounds": 3,
+        "median": 1.5192515999951866,
+        "iqr": 0.1902515999863681,
+        "q1": 1.458227175007778,
+        "q3": 1.648478774994146,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4378857000119751,
+        "hd15iqr": 1.6915544999937993,
+        "ops": 0.6453428467766738,
+        "total": 4.648691800000961,
+        "data": [1.4378857000119751, 1.5192515999951866, 1.6915544999937993],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.611268699998618,
+        "max": 1.7147476999962237,
+        "mean": 1.6663109333312605,
+        "stddev": 0.0520547788637074,
+        "rounds": 3,
+        "median": 1.6729163999989396,
+        "iqr": 0.07760924999820418,
+        "q1": 1.6266806249986985,
+        "q3": 1.7042898749969027,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.611268699998618,
+        "hd15iqr": 1.7147476999962237,
+        "ops": 0.6001280913405621,
+        "total": 4.998932799993781,
+        "data": [1.7147476999962237, 1.6729163999989396, 1.611268699998618],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6175752999988617,
+        "max": 1.6742039999953704,
+        "mean": 1.6524743333332783,
+        "stddev": 0.030525015638591342,
+        "rounds": 3,
+        "median": 1.665643700005603,
+        "iqr": 0.04247152499738149,
+        "q1": 1.629592400000547,
+        "q3": 1.6720639249979286,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6175752999988617,
+        "hd15iqr": 1.6742039999953704,
+        "ops": 0.6051531208856092,
+        "total": 4.957422999999835,
+        "data": [1.665643700005603, 1.6175752999988617, 1.6742039999953704],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7180860999942524,
+        "max": 1.9032066000072518,
+        "mean": 1.8104984666667103,
+        "stddev": 0.09256060441520025,
+        "rounds": 3,
+        "median": 1.8102026999986265,
+        "iqr": 0.13884037500974955,
+        "q1": 1.741115249995346,
+        "q3": 1.8799556250050955,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7180860999942524,
+        "hd15iqr": 1.9032066000072518,
+        "ops": 0.5523340772782258,
+        "total": 5.431495400000131,
+        "data": [1.8102026999986265, 1.7180860999942524, 1.9032066000072518],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5621510999917518,
+        "max": 1.6707582999952137,
+        "mean": 1.5998154666594928,
+        "stddev": 0.061477420497097014,
+        "rounds": 3,
+        "median": 1.5665369999915129,
+        "iqr": 0.08145540000259643,
+        "q1": 1.563247574991692,
+        "q3": 1.6447029749942885,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5621510999917518,
+        "hd15iqr": 1.6707582999952137,
+        "ops": 0.6250720916507063,
+        "total": 4.799446399978478,
+        "data": [1.5621510999917518, 1.6707582999952137, 1.5665369999915129],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.439201300003333,
+        "max": 1.5196682999958284,
+        "mean": 1.4886731666677708,
+        "stddev": 0.04329869256728021,
+        "rounds": 3,
+        "median": 1.5071499000041513,
+        "iqr": 0.06035024999437155,
+        "q1": 1.4561884500035376,
+        "q3": 1.5165386999979091,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.439201300003333,
+        "hd15iqr": 1.5196682999958284,
+        "ops": 0.6717391180217137,
+        "total": 4.466019500003313,
+        "data": [1.5071499000041513, 1.5196682999958284, 1.439201300003333],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.474453500006348,
+        "max": 1.77106339999591,
+        "mean": 1.592305833333133,
+        "stddev": 0.15740534863446734,
+        "rounds": 3,
+        "median": 1.5314005999971414,
+        "iqr": 0.22245742499217158,
+        "q1": 1.4886902750040463,
+        "q3": 1.7111476999962179,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.474453500006348,
+        "hd15iqr": 1.77106339999591,
+        "ops": 0.6280200568672951,
+        "total": 4.776917499999399,
+        "data": [1.77106339999591, 1.5314005999971414, 1.474453500006348],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4785911999933887,
+        "max": 1.6968175999936648,
+        "mean": 1.6064454333294027,
+        "stddev": 0.11383922612948215,
+        "rounds": 3,
+        "median": 1.6439275000011548,
+        "iqr": 0.16366980000020703,
+        "q1": 1.5199252749953303,
+        "q3": 1.6835950749955373,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4785911999933887,
+        "hd15iqr": 1.6968175999936648,
+        "ops": 0.6224923543948033,
+        "total": 4.819336299988208,
+        "data": [1.4785911999933887, 1.6968175999936648, 1.6439275000011548],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4564948000042932,
+        "max": 2.0531314999971073,
+        "mean": 1.7568745666649193,
+        "stddev": 0.29833971619710536,
+        "rounds": 3,
+        "median": 1.7609973999933572,
+        "iqr": 0.4474775249946106,
+        "q1": 1.5326204500015592,
+        "q3": 1.9800979749961698,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4564948000042932,
+        "hd15iqr": 2.0531314999971073,
+        "ops": 0.5691925985918865,
+        "total": 5.270623699994758,
+        "data": [1.7609973999933572, 2.0531314999971073, 1.4564948000042932],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.041953599997214,
+        "max": 1.222596000006888,
+        "mean": 1.1272629666685436,
+        "stddev": 0.09073739356187357,
+        "rounds": 3,
+        "median": 1.117239300001529,
+        "iqr": 0.13548180000725552,
+        "q1": 1.0607750249982928,
+        "q3": 1.1962568250055483,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.041953599997214,
+        "hd15iqr": 1.222596000006888,
+        "ops": 0.8871044552766154,
+        "total": 3.381788900005631,
+        "data": [1.041953599997214, 1.222596000006888, 1.117239300001529],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.030289400005131,
+        "max": 1.2266107999894302,
+        "mean": 1.1034888333330553,
+        "stddev": 0.1072600462585977,
+        "rounds": 3,
+        "median": 1.0535663000046043,
+        "iqr": 0.1472410499882244,
+        "q1": 1.0361086250049993,
+        "q3": 1.1833496749932237,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.030289400005131,
+        "hd15iqr": 1.2266107999894302,
+        "ops": 0.9062166918169255,
+        "total": 3.3104664999991655,
+        "data": [1.030289400005131, 1.2266107999894302, 1.0535663000046043],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1743368999887025,
+        "max": 1.242361600001459,
+        "mean": 1.2162180666637141,
+        "stddev": 0.03664143529189415,
+        "rounds": 3,
+        "median": 1.2319557000009809,
+        "iqr": 0.051018525009567384,
+        "q1": 1.188741599991772,
+        "q3": 1.2397601250013395,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1743368999887025,
+        "hd15iqr": 1.242361600001459,
+        "ops": 0.8222209712302369,
+        "total": 3.6486541999911424,
+        "data": [1.242361600001459, 1.2319557000009809, 1.1743368999887025],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3854401000135113,
+        "max": 1.4983716999995522,
+        "mean": 1.447361766671141,
+        "stddev": 0.05725107869759115,
+        "rounds": 3,
+        "median": 1.4582735000003595,
+        "iqr": 0.08469869998953072,
+        "q1": 1.4036484500102233,
+        "q3": 1.488347149999754,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3854401000135113,
+        "hd15iqr": 1.4983716999995522,
+        "ops": 0.6909122674284464,
+        "total": 4.342085300013423,
+        "data": [1.4983716999995522, 1.4582735000003595, 1.3854401000135113],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6723004999948898,
+        "max": 1.726013100007549,
+        "mean": 1.7017610000038985,
+        "stddev": 0.02723245165224458,
+        "rounds": 3,
+        "median": 1.7069694000092568,
+        "iqr": 0.04028445000949432,
+        "q1": 1.6809677249984816,
+        "q3": 1.721252175007976,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6723004999948898,
+        "hd15iqr": 1.726013100007549,
+        "ops": 0.5876265821097728,
+        "total": 5.1052830000116955,
+        "data": [1.726013100007549, 1.7069694000092568, 1.6723004999948898],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5973210999945877,
+        "max": 1.752722500008531,
+        "mean": 1.6627557333364773,
+        "stddev": 0.08055288918387789,
+        "rounds": 3,
+        "median": 1.638223600006313,
+        "iqr": 0.1165510500104574,
+        "q1": 1.607546724997519,
+        "q3": 1.7240977750079765,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5973210999945877,
+        "hd15iqr": 1.752722500008531,
+        "ops": 0.6014112475759774,
+        "total": 4.988267200009432,
+        "data": [1.638223600006313, 1.752722500008531, 1.5973210999945877],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4622732999996515,
+        "max": 1.638760200003162,
+        "mean": 1.5306693333356332,
+        "stddev": 0.09470304278705502,
+        "rounds": 3,
+        "median": 1.4909745000040857,
+        "iqr": 0.1323651750026329,
+        "q1": 1.46944860000076,
+        "q3": 1.601813775003393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4622732999996515,
+        "hd15iqr": 1.638760200003162,
+        "ops": 0.6533089663597043,
+        "total": 4.592008000006899,
+        "data": [1.4622732999996515, 1.4909745000040857, 1.638760200003162],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7126731999887852,
+        "max": 1.7325832999922568,
+        "mean": 1.7194660333237455,
+        "stddev": 0.011362300087568413,
+        "rounds": 3,
+        "median": 1.7131415999901947,
+        "iqr": 0.014932575002603699,
+        "q1": 1.7127902999891376,
+        "q3": 1.7277228749917413,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7126731999887852,
+        "hd15iqr": 1.7325832999922568,
+        "ops": 0.5815758965979628,
+        "total": 5.158398099971237,
+        "data": [1.7126731999887852, 1.7325832999922568, 1.7131415999901947],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.5337706999998773,
+        "max": 3.558924600001774,
+        "mean": 3.5474069666670403,
+        "stddev": 0.012710079729266596,
+        "rounds": 3,
+        "median": 3.5495255999994697,
+        "iqr": 0.01886542500142241,
+        "q1": 3.5377094249997754,
+        "q3": 3.5565748500011978,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.5337706999998773,
+        "hd15iqr": 3.558924600001774,
+        "ops": 0.2818960467170611,
+        "total": 10.64222090000112,
+        "data": [3.5495255999994697, 3.558924600001774, 3.5337706999998773],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3004180999996606,
+        "max": 2.3804972999932943,
+        "mean": 2.34304393332665,
+        "stddev": 0.04028939533449692,
+        "rounds": 3,
+        "median": 2.3482163999869954,
+        "iqr": 0.06005939999522525,
+        "q1": 2.3123676749964943,
+        "q3": 2.3724270749917196,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3004180999996606,
+        "hd15iqr": 2.3804972999932943,
+        "ops": 0.4267952409156074,
+        "total": 7.02913179997995,
+        "data": [2.3482163999869954, 2.3004180999996606, 2.3804972999932943],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "64-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.4359854999929667,
+        "max": 1.4824988000036683,
+        "mean": 1.4654813999998926,
+        "stddev": 0.02564481411938585,
+        "rounds": 3,
+        "median": 1.477959900003043,
+        "iqr": 0.03488497500802623,
+        "q1": 1.4464790999954857,
+        "q3": 1.481364075003512,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.4359854999929667,
+        "hd15iqr": 1.4824988000036683,
+        "ops": 0.6823696295292955,
+        "total": 4.396444199999678,
+        "data": [1.4359854999929667, 1.4824988000036683, 1.477959900003043],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "64-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.475029799999902,
+        "max": 1.5499225000094157,
+        "mean": 1.5064540333405603,
+        "stddev": 0.03887192812334876,
+        "rounds": 3,
+        "median": 1.4944098000123631,
+        "iqr": 0.056169525007135235,
+        "q1": 1.4798748000030173,
+        "q3": 1.5360443250101525,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.475029799999902,
+        "hd15iqr": 1.5499225000094157,
+        "ops": 0.6638104966153537,
+        "total": 4.519362100021681,
+        "data": [1.475029799999902, 1.4944098000123631, 1.5499225000094157],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "64-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.017417700000806,
+        "max": 3.0618317000044044,
+        "mean": 3.0338156333358106,
+        "stddev": 0.024380045440845845,
+        "rounds": 3,
+        "median": 3.022197500002221,
+        "iqr": 0.03331050000269897,
+        "q1": 3.0186126500011596,
+        "q3": 3.0519231500038586,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.017417700000806,
+        "hd15iqr": 3.0618317000044044,
+        "ops": 0.3296179204207136,
+        "total": 9.101446900007431,
+        "data": [3.0618317000044044, 3.022197500002221, 3.017417700000806],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "64-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.331817099999171,
+        "max": 6.397730099997716,
+        "mean": 6.3634721666652085,
+        "stddev": 0.0330334993357443,
+        "rounds": 3,
+        "median": 6.36086929999874,
+        "iqr": 0.049434749998908956,
+        "q1": 6.339080149999063,
+        "q3": 6.388514899997972,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.331817099999171,
+        "hd15iqr": 6.397730099997716,
+        "ops": 0.15714691190737967,
+        "total": 19.090416499995627,
+        "data": [6.36086929999874, 6.331817099999171, 6.397730099997716],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[64-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[64-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 64,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "64-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.840177099991706,
+        "max": 6.864623499990557,
+        "mean": 6.856317799994334,
+        "stddev": 0.013980237374637982,
+        "rounds": 3,
+        "median": 6.864152800000738,
+        "iqr": 0.01833479999913834,
+        "q1": 6.846171024993964,
+        "q3": 6.864505824993103,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.840177099991706,
+        "hd15iqr": 6.864623499990557,
+        "ops": 0.14585088223314654,
+        "total": 20.568953399983002,
+        "data": [6.864623499990557, 6.840177099991706, 6.864152800000738],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[65-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[65-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 65,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "65-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6283082000009017,
+        "max": 1.7337547999923117,
+        "mean": 1.676311633331352,
+        "stddev": 0.053353329666014845,
+        "rounds": 3,
+        "median": 1.6668719000008423,
+        "iqr": 0.07908494999355753,
+        "q1": 1.6379491250008869,
+        "q3": 1.7170340749944444,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6283082000009017,
+        "hd15iqr": 1.7337547999923117,
+        "ops": 0.5965477898716776,
+        "total": 5.028934899994056,
+        "data": [1.6668719000008423, 1.6283082000009017, 1.7337547999923117],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[66-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[66-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 66,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "66-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7356470999948215,
+        "max": 1.9838179999933345,
+        "mean": 1.8227377333290253,
+        "stddev": 0.1396533146107193,
+        "rounds": 3,
+        "median": 1.7487480999989202,
+        "iqr": 0.1861281749988848,
+        "q1": 1.7389223499958462,
+        "q3": 1.925050524994731,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7356470999948215,
+        "hd15iqr": 1.9838179999933345,
+        "ops": 0.5486252803762461,
+        "total": 5.468213199987076,
+        "data": [1.9838179999933345, 1.7487480999989202, 1.7356470999948215],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[67-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[67-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 67,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "67-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6115900999866426,
+        "max": 1.8112349000002723,
+        "mean": 1.70298743332872,
+        "stddev": 0.1008833821203292,
+        "rounds": 3,
+        "median": 1.6861372999992454,
+        "iqr": 0.1497336000102223,
+        "q1": 1.6302268999897933,
+        "q3": 1.7799605000000156,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6115900999866426,
+        "hd15iqr": 1.8112349000002723,
+        "ops": 0.587203393536125,
+        "total": 5.10896229998616,
+        "data": [1.6861372999992454, 1.8112349000002723, 1.6115900999866426],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[68-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[68-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 68,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "68-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5787962000031257,
+        "max": 1.6193884999956936,
+        "mean": 1.5971899333332356,
+        "stddev": 0.020561888828287824,
+        "rounds": 3,
+        "median": 1.5933851000008872,
+        "iqr": 0.030444224994425895,
+        "q1": 1.582443425002566,
+        "q3": 1.612887649996992,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5787962000031257,
+        "hd15iqr": 1.6193884999956936,
+        "ops": 0.626099613533791,
+        "total": 4.7915697999997064,
+        "data": [1.5933851000008872, 1.5787962000031257, 1.6193884999956936],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[69-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[69-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 69,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "69-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6476736000040546,
+        "max": 1.7511524000001373,
+        "mean": 1.7006290666662,
+        "stddev": 0.05178225532508174,
+        "rounds": 3,
+        "median": 1.7030611999944085,
+        "iqr": 0.077609099997062,
+        "q1": 1.661520500001643,
+        "q3": 1.739129599998705,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6476736000040546,
+        "hd15iqr": 1.7511524000001373,
+        "ops": 0.5880177045076228,
+        "total": 5.1018871999986,
+        "data": [1.6476736000040546, 1.7030611999944085, 1.7511524000001373],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[70-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[70-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 70,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "70-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.300108800001908,
+        "max": 1.5670380000083242,
+        "mean": 1.458029000001261,
+        "stddev": 0.14002509977689945,
+        "rounds": 3,
+        "median": 1.5069401999935508,
+        "iqr": 0.20019690000481205,
+        "q1": 1.3518166499998188,
+        "q3": 1.5520135500046308,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.300108800001908,
+        "hd15iqr": 1.5670380000083242,
+        "ops": 0.6858574143581061,
+        "total": 4.374087000003783,
+        "data": [1.300108800001908, 1.5670380000083242, 1.5069401999935508],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[71-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[71-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 71,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "71-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2747868000005838,
+        "max": 1.3567959999927552,
+        "mean": 1.325692033332113,
+        "stddev": 0.04444597667019674,
+        "rounds": 3,
+        "median": 1.3454933000029996,
+        "iqr": 0.061506899994128617,
+        "q1": 1.2924634250011877,
+        "q3": 1.3539703249953163,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2747868000005838,
+        "hd15iqr": 1.3567959999927552,
+        "ops": 0.7543230062916729,
+        "total": 3.9770760999963386,
+        "data": [1.3567959999927552, 1.3454933000029996, 1.2747868000005838],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[72-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[72-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 72,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "72-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3062280000012834,
+        "max": 1.3659790999954566,
+        "mean": 1.3425378999963868,
+        "stddev": 0.031886534263217775,
+        "rounds": 3,
+        "median": 1.3554065999924205,
+        "iqr": 0.044813324995629955,
+        "q1": 1.3185226499990677,
+        "q3": 1.3633359749946976,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3062280000012834,
+        "hd15iqr": 1.3659790999954566,
+        "ops": 0.7448579291524592,
+        "total": 4.0276136999891605,
+        "data": [1.3659790999954566, 1.3062280000012834, 1.3554065999924205],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[73-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[73-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 73,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "73-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.3216102999867871,
+        "max": 1.5278449000034016,
+        "mean": 1.4056611999985762,
+        "stddev": 0.10827631498848175,
+        "rounds": 3,
+        "median": 1.3675284000055399,
+        "iqr": 0.15467595001246082,
+        "q1": 1.3330898249914753,
+        "q3": 1.4877657750039361,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.3216102999867871,
+        "hd15iqr": 1.5278449000034016,
+        "ops": 0.7114089796325124,
+        "total": 4.216983599995729,
+        "data": [1.5278449000034016, 1.3675284000055399, 1.3216102999867871],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[74-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[74-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 74,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "74-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2840874999965308,
+        "max": 1.3263772999926005,
+        "mean": 1.3088093666641119,
+        "stddev": 0.02203385730170793,
+        "rounds": 3,
+        "median": 1.3159633000032045,
+        "iqr": 0.031717349997052224,
+        "q1": 1.2920564499981992,
+        "q3": 1.3237737999952515,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2840874999965308,
+        "hd15iqr": 1.3263772999926005,
+        "ops": 0.7640532116214876,
+        "total": 3.9264280999923358,
+        "data": [1.2840874999965308, 1.3263772999926005, 1.3159633000032045],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[75-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[75-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 75,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "75-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.201382700004615,
+        "max": 1.3437313999893377,
+        "mean": 1.270921899995301,
+        "stddev": 0.07123067628079274,
+        "rounds": 3,
+        "median": 1.2676515999919502,
+        "iqr": 0.10676152498854208,
+        "q1": 1.2179499250014487,
+        "q3": 1.3247114499899908,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.201382700004615,
+        "hd15iqr": 1.3437313999893377,
+        "ops": 0.7868304102743823,
+        "total": 3.8127656999859028,
+        "data": [1.201382700004615, 1.3437313999893377, 1.2676515999919502],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[76-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[76-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 76,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "76-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.228510599990841,
+        "max": 1.4393503000028431,
+        "mean": 1.3293491333315615,
+        "stddev": 0.10571806923345932,
+        "rounds": 3,
+        "median": 1.3201865000010002,
+        "iqr": 0.1581297750090016,
+        "q1": 1.2514295749933808,
+        "q3": 1.4095593500023824,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.228510599990841,
+        "hd15iqr": 1.4393503000028431,
+        "ops": 0.7522478293522786,
+        "total": 3.9880473999946844,
+        "data": [1.3201865000010002, 1.228510599990841, 1.4393503000028431],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[77-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[77-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 77,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "77-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2387623999966308,
+        "max": 1.3897196000034455,
+        "mean": 1.3165034333311876,
+        "stddev": 0.07558025451272342,
+        "rounds": 3,
+        "median": 1.3210282999934861,
+        "iqr": 0.113217900005111,
+        "q1": 1.2593288749958447,
+        "q3": 1.3725467750009557,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2387623999966308,
+        "hd15iqr": 1.3897196000034455,
+        "ops": 0.7595878405494702,
+        "total": 3.9495102999935625,
+        "data": [1.3210282999934861, 1.3897196000034455, 1.2387623999966308],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[78-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[78-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 78,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "78-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2405299999954877,
+        "max": 1.3100156000000425,
+        "mean": 1.2855326333325745,
+        "stddev": 0.039023770860495244,
+        "rounds": 3,
+        "median": 1.306052300002193,
+        "iqr": 0.052114200003416045,
+        "q1": 1.256910574997164,
+        "q3": 1.3090247750005801,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2405299999954877,
+        "hd15iqr": 1.3100156000000425,
+        "ops": 0.777887681783411,
+        "total": 3.8565978999977233,
+        "data": [1.3100156000000425, 1.306052300002193, 1.2405299999954877],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[79-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[79-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 79,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "79-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0555747000034899,
+        "max": 1.217344199991203,
+        "mean": 1.1130640999957297,
+        "stddev": 0.09046750790567348,
+        "rounds": 3,
+        "median": 1.0662733999924967,
+        "iqr": 0.1213271249907848,
+        "q1": 1.0582493750007416,
+        "q3": 1.1795764999915264,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0555747000034899,
+        "hd15iqr": 1.217344199991203,
+        "ops": 0.8984208546514405,
+        "total": 3.3391922999871895,
+        "data": [1.217344199991203, 1.0662733999924967, 1.0555747000034899],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[80-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[80-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 80,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "80-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.129124300001422,
+        "max": 1.1705324999929871,
+        "mean": 1.1490801333323664,
+        "stddev": 0.020744624981919747,
+        "rounds": 3,
+        "median": 1.1475836000026902,
+        "iqr": 0.0310561499936739,
+        "q1": 1.133739125001739,
+        "q3": 1.164795274995413,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.129124300001422,
+        "hd15iqr": 1.1705324999929871,
+        "ops": 0.8702613255526143,
+        "total": 3.4472403999970993,
+        "data": [1.1705324999929871, 1.129124300001422, 1.1475836000026902],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[81-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[81-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 81,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "81-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9818890999886207,
+        "max": 1.049618899996858,
+        "mean": 1.0200737333264744,
+        "stddev": 0.03468157638448264,
+        "rounds": 3,
+        "median": 1.0287131999939447,
+        "iqr": 0.05079735000617802,
+        "q1": 0.9935951249899517,
+        "q3": 1.0443924749961297,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9818890999886207,
+        "hd15iqr": 1.049618899996858,
+        "ops": 0.9803212918138635,
+        "total": 3.0602211999794235,
+        "data": [1.0287131999939447, 1.049618899996858, 0.9818890999886207],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[82-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[82-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 82,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "82-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9342732000077376,
+        "max": 0.9731258999963757,
+        "mean": 0.9535890000018602,
+        "stddev": 0.019427293635743737,
+        "rounds": 3,
+        "median": 0.9533679000014672,
+        "iqr": 0.029139524991478538,
+        "q1": 0.93904687500617,
+        "q3": 0.9681863999976486,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9342732000077376,
+        "hd15iqr": 0.9731258999963757,
+        "ops": 1.048669814771405,
+        "total": 2.8607670000055805,
+        "data": [0.9533679000014672, 0.9342732000077376, 0.9731258999963757],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[83-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[83-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 83,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "83-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9842574999929639,
+        "max": 1.0129295000078855,
+        "mean": 0.9939186666694392,
+        "stddev": 0.016464601307999985,
+        "rounds": 3,
+        "median": 0.9845690000074683,
+        "iqr": 0.021504000011191238,
+        "q1": 0.98433537499659,
+        "q3": 1.0058393750077812,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9842574999929639,
+        "hd15iqr": 1.0129295000078855,
+        "ops": 1.00611854222533,
+        "total": 2.9817560000083176,
+        "data": [1.0129295000078855, 0.9845690000074683, 0.9842574999929639],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[84-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[84-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 84,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "84-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9073452000011457,
+        "max": 0.9685133000020869,
+        "mean": 0.9471773000016886,
+        "stddev": 0.03452482296613261,
+        "rounds": 3,
+        "median": 0.9656734000018332,
+        "iqr": 0.045876075000705896,
+        "q1": 0.9219272500013176,
+        "q3": 0.9678033250020235,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9073452000011457,
+        "hd15iqr": 0.9685133000020869,
+        "ops": 1.0557685451268914,
+        "total": 2.841531900005066,
+        "data": [0.9073452000011457, 0.9685133000020869, 0.9656734000018332],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[85-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[85-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 85,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "85-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9259314000082668,
+        "max": 1.0180526000040118,
+        "mean": 0.9596737333389077,
+        "stddev": 0.050762170493578174,
+        "rounds": 3,
+        "median": 0.9350372000044445,
+        "iqr": 0.06909089999680873,
+        "q1": 0.9282078500073112,
+        "q3": 0.9972987500041199,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9259314000082668,
+        "hd15iqr": 1.0180526000040118,
+        "ops": 1.0420208090105674,
+        "total": 2.879021200016723,
+        "data": [1.0180526000040118, 0.9350372000044445, 0.9259314000082668],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[86-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[86-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 86,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "86-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9384353000059491,
+        "max": 0.9591745000070659,
+        "mean": 0.9479225000056127,
+        "stddev": 0.010481626469986344,
+        "rounds": 3,
+        "median": 0.9461577000038233,
+        "iqr": 0.015554400000837632,
+        "q1": 0.9403659000054176,
+        "q3": 0.9559203000062553,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9384353000059491,
+        "hd15iqr": 0.9591745000070659,
+        "ops": 1.0549385630091899,
+        "total": 2.8437675000168383,
+        "data": [0.9384353000059491, 0.9461577000038233, 0.9591745000070659],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[87-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[87-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 87,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "87-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9510290000034729,
+        "max": 1.020854899994447,
+        "mean": 0.9878983333328506,
+        "stddev": 0.03507700649477876,
+        "rounds": 3,
+        "median": 0.991811100000632,
+        "iqr": 0.052369424993230496,
+        "q1": 0.9612245250027627,
+        "q3": 1.0135939499959932,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9510290000034729,
+        "hd15iqr": 1.020854899994447,
+        "ops": 1.0122499110068566,
+        "total": 2.963694999998552,
+        "data": [0.9510290000034729, 0.991811100000632, 1.020854899994447],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[88-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[88-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 88,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "88-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9787489000009373,
+        "max": 1.0365853999974206,
+        "mean": 1.013205400003547,
+        "stddev": 0.030467717707328482,
+        "rounds": 3,
+        "median": 1.0242819000122836,
+        "iqr": 0.043377374997362494,
+        "q1": 0.9901321500037739,
+        "q3": 1.0335095250011364,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9787489000009373,
+        "hd15iqr": 1.0365853999974206,
+        "ops": 0.9869667098068161,
+        "total": 3.0396162000106415,
+        "data": [1.0365853999974206, 1.0242819000122836, 0.9787489000009373],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[89-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[89-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 89,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "89-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9431355999986408,
+        "max": 1.0252719999989495,
+        "mean": 0.9806854666676372,
+        "stddev": 0.04151786434223328,
+        "rounds": 3,
+        "median": 0.9736488000053214,
+        "iqr": 0.06160230000023148,
+        "q1": 0.950763900000311,
+        "q3": 1.0123662000005424,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9431355999986408,
+        "hd15iqr": 1.0252719999989495,
+        "ops": 1.01969493174809,
+        "total": 2.9420564000029117,
+        "data": [0.9431355999986408, 1.0252719999989495, 0.9736488000053214],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[90-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[90-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 90,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "90-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7801568999857409,
+        "max": 0.8478862000047229,
+        "mean": 0.8079300333338324,
+        "stddev": 0.035470188129944326,
+        "rounds": 3,
+        "median": 0.7957470000110334,
+        "iqr": 0.05079697501423652,
+        "q1": 0.784054424992064,
+        "q3": 0.8348514000063005,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7801568999857409,
+        "hd15iqr": 0.8478862000047229,
+        "ops": 1.2377309404796013,
+        "total": 2.423790100001497,
+        "data": [0.8478862000047229, 0.7801568999857409, 0.7957470000110334],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[91-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[91-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 91,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "91-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7963624999974854,
+        "max": 0.8192790000030072,
+        "mean": 0.8050219666668758,
+        "stddev": 0.012441505438138495,
+        "rounds": 3,
+        "median": 0.7994244000001345,
+        "iqr": 0.01718737500414136,
+        "q1": 0.7971279749981477,
+        "q3": 0.814315350002289,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7963624999974854,
+        "hd15iqr": 0.8192790000030072,
+        "ops": 1.2422021279002038,
+        "total": 2.415065900000627,
+        "data": [0.7963624999974854, 0.8192790000030072, 0.7994244000001345],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[92-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[92-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 92,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "92-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7157474999985425,
+        "max": 0.7485568999982206,
+        "mean": 0.7331827999975454,
+        "stddev": 0.016501532994226624,
+        "rounds": 3,
+        "median": 0.7352439999958733,
+        "iqr": 0.0246070499997586,
+        "q1": 0.7206216249978752,
+        "q3": 0.7452286749976338,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7157474999985425,
+        "hd15iqr": 0.7485568999982206,
+        "ops": 1.363916338467498,
+        "total": 2.1995483999926364,
+        "data": [0.7157474999985425, 0.7352439999958733, 0.7485568999982206],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[93-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[93-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 93,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "93-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7433477000013227,
+        "max": 0.7742797999962931,
+        "mean": 0.7554284999981368,
+        "stddev": 0.01654020723043837,
+        "rounds": 3,
+        "median": 0.7486579999967944,
+        "iqr": 0.023199074996227864,
+        "q1": 0.7446752750001906,
+        "q3": 0.7678743499964185,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7433477000013227,
+        "hd15iqr": 0.7742797999962931,
+        "ops": 1.3237520162430547,
+        "total": 2.26628549999441,
+        "data": [0.7486579999967944, 0.7433477000013227, 0.7742797999962931],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[94-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[94-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 94,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "94-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7608979999931762,
+        "max": 0.8380734999955166,
+        "mean": 0.8089023666640666,
+        "stddev": 0.04189310753174283,
+        "rounds": 3,
+        "median": 0.827735600003507,
+        "iqr": 0.05788162500175531,
+        "q1": 0.7776073999957589,
+        "q3": 0.8354890249975142,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7608979999931762,
+        "hd15iqr": 0.8380734999955166,
+        "ops": 1.236243137875866,
+        "total": 2.4267070999922,
+        "data": [0.8380734999955166, 0.827735600003507, 0.7608979999931762],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[95-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[95-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 95,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "95-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7185334999958286,
+        "max": 0.772077999994508,
+        "mean": 0.743149499995828,
+        "stddev": 0.02703149297035052,
+        "rounds": 3,
+        "median": 0.7388369999971474,
+        "iqr": 0.04015837499900954,
+        "q1": 0.7236093749961583,
+        "q3": 0.7637677499951678,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7185334999958286,
+        "hd15iqr": 0.772077999994508,
+        "ops": 1.3456242653808068,
+        "total": 2.229448499987484,
+        "data": [0.7185334999958286, 0.772077999994508, 0.7388369999971474],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[96-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[96-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 96,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "96-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.736799999998766,
+        "max": 0.7860447999992175,
+        "mean": 0.7604081000026781,
+        "stddev": 0.02468499534572941,
+        "rounds": 3,
+        "median": 0.7583795000100508,
+        "iqr": 0.03693360000033863,
+        "q1": 0.7421948750015872,
+        "q3": 0.7791284750019258,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.736799999998766,
+        "hd15iqr": 0.7860447999992175,
+        "ops": 1.3150833085503404,
+        "total": 2.2812243000080343,
+        "data": [0.7860447999992175, 0.7583795000100508, 0.736799999998766],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[97-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[97-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 97,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "97-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7553996999922674,
+        "max": 0.8002438999974402,
+        "mean": 0.7775117999990471,
+        "stddev": 0.02242852800605034,
+        "rounds": 3,
+        "median": 0.7768918000074336,
+        "iqr": 0.033633150003879564,
+        "q1": 0.760772724996059,
+        "q3": 0.7944058749999385,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7553996999922674,
+        "hd15iqr": 0.8002438999974402,
+        "ops": 1.2861541136754782,
+        "total": 2.332535399997141,
+        "data": [0.7553996999922674, 0.8002438999974402, 0.7768918000074336],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[98-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[98-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 98,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "98-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7846199000050547,
+        "max": 1.0140754000021843,
+        "mean": 0.8882813666665849,
+        "stddev": 0.11631785976547102,
+        "rounds": 3,
+        "median": 0.8661487999925157,
+        "iqr": 0.17209162499784725,
+        "q1": 0.8050021250019199,
+        "q3": 0.9770937499997672,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7846199000050547,
+        "hd15iqr": 1.0140754000021843,
+        "ops": 1.1257694211831288,
+        "total": 2.6648440999997547,
+        "data": [0.7846199000050547, 0.8661487999925157, 1.0140754000021843],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[99-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[99-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 99,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "99-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7435908999905223,
+        "max": 0.7877141000062693,
+        "mean": 0.7708819999970729,
+        "stddev": 0.02384863110570277,
+        "rounds": 3,
+        "median": 0.781340999994427,
+        "iqr": 0.03309240001181024,
+        "q1": 0.7530284249914985,
+        "q3": 0.7861208250033087,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7435908999905223,
+        "hd15iqr": 0.7877141000062693,
+        "ops": 1.2972153974328071,
+        "total": 2.3126459999912186,
+        "data": [0.781340999994427, 0.7877141000062693, 0.7435908999905223],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[100-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[100-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 100,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "100-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7796465999999782,
+        "max": 0.8949425999890082,
+        "mean": 0.83463913333253,
+        "stddev": 0.05783118892903717,
+        "rounds": 3,
+        "median": 0.8293282000086037,
+        "iqr": 0.08647199999177246,
+        "q1": 0.7920670000021346,
+        "q3": 0.878538999993907,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7796465999999782,
+        "hd15iqr": 0.8949425999890082,
+        "ops": 1.1981225898277983,
+        "total": 2.50391739999759,
+        "data": [0.7796465999999782, 0.8293282000086037, 0.8949425999890082],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[101-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[101-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 101,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "101-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7056589999992866,
+        "max": 0.7626022000040393,
+        "mean": 0.7428340333329592,
+        "stddev": 0.03221616460648705,
+        "rounds": 3,
+        "median": 0.7602408999955514,
+        "iqr": 0.042707400003564544,
+        "q1": 0.7193044749983528,
+        "q3": 0.7620118750019174,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7056589999992866,
+        "hd15iqr": 0.7626022000040393,
+        "ops": 1.3461957249228131,
+        "total": 2.2285020999988774,
+        "data": [0.7626022000040393, 0.7056589999992866, 0.7602408999955514],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[102-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[102-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 102,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "102-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7279226999962702,
+        "max": 0.7407371000008425,
+        "mean": 0.7348220666657047,
+        "stddev": 0.006463659640950386,
+        "rounds": 3,
+        "median": 0.7358064000000013,
+        "iqr": 0.009610800003429176,
+        "q1": 0.729893624997203,
+        "q3": 0.7395044250006322,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7279226999962702,
+        "hd15iqr": 0.7407371000008425,
+        "ops": 1.3608736663796104,
+        "total": 2.204466199997114,
+        "data": [0.7407371000008425, 0.7279226999962702, 0.7358064000000013],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[103-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[103-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 103,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "103-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7119387999991886,
+        "max": 0.7541439000051469,
+        "mean": 0.7389684999992218,
+        "stddev": 0.023467231150925427,
+        "rounds": 3,
+        "median": 0.7508227999933297,
+        "iqr": 0.03165382500446867,
+        "q1": 0.7216597999977239,
+        "q3": 0.7533136250021926,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7119387999991886,
+        "hd15iqr": 0.7541439000051469,
+        "ops": 1.3532376549217635,
+        "total": 2.216905499997665,
+        "data": [0.7508227999933297, 0.7541439000051469, 0.7119387999991886],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[104-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[104-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 104,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "104-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7106329000089318,
+        "max": 0.7510419999889564,
+        "mean": 0.7312890333317531,
+        "stddev": 0.02021968404348394,
+        "rounds": 3,
+        "median": 0.7321921999973711,
+        "iqr": 0.030306824985018466,
+        "q1": 0.7160227250060416,
+        "q3": 0.74632954999106,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7106329000089318,
+        "hd15iqr": 0.7510419999889564,
+        "ops": 1.3674483746105144,
+        "total": 2.193867099995259,
+        "data": [0.7510419999889564, 0.7321921999973711, 0.7106329000089318],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[105-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[105-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 105,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "105-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5892478000023402,
+        "max": 0.6627908999944339,
+        "mean": 0.6185582333321994,
+        "stddev": 0.03897629632008615,
+        "rounds": 3,
+        "median": 0.603635999999824,
+        "iqr": 0.05515732499407022,
+        "q1": 0.5928448500017112,
+        "q3": 0.6480021749957814,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5892478000023402,
+        "hd15iqr": 0.6627908999944339,
+        "ops": 1.6166626618369586,
+        "total": 1.855674699996598,
+        "data": [0.6627908999944339, 0.603635999999824, 0.5892478000023402],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[106-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[106-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 106,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "106-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5752172000065912,
+        "max": 0.6119267999893054,
+        "mean": 0.5892837999999756,
+        "stddev": 0.019800622727342773,
+        "rounds": 3,
+        "median": 0.5807074000040302,
+        "iqr": 0.02753219998703571,
+        "q1": 0.5765897500059509,
+        "q3": 0.6041219499929866,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5752172000065912,
+        "hd15iqr": 0.6119267999893054,
+        "ops": 1.6969752095680237,
+        "total": 1.7678513999999268,
+        "data": [0.5807074000040302, 0.6119267999893054, 0.5752172000065912],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[107-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[107-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 107,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "107-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6018478000041796,
+        "max": 0.634089999992284,
+        "mean": 0.6140447666645438,
+        "stddev": 0.017495323154486552,
+        "rounds": 3,
+        "median": 0.6061964999971678,
+        "iqr": 0.024181649991078302,
+        "q1": 0.6029349750024267,
+        "q3": 0.627116624993505,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6018478000041796,
+        "hd15iqr": 0.634089999992284,
+        "ops": 1.6285457580429241,
+        "total": 1.8421342999936314,
+        "data": [0.634089999992284, 0.6018478000041796, 0.6061964999971678],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[108-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[108-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 108,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "108-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.571023199998308,
+        "max": 0.5933491999894613,
+        "mean": 0.5812696333305212,
+        "stddev": 0.01127532049417722,
+        "rounds": 3,
+        "median": 0.5794365000037942,
+        "iqr": 0.016744499993365025,
+        "q1": 0.5731265249996795,
+        "q3": 0.5898710249930446,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.571023199998308,
+        "hd15iqr": 0.5933491999894613,
+        "ops": 1.720371997192189,
+        "total": 1.7438088999915635,
+        "data": [0.5794365000037942, 0.5933491999894613, 0.571023199998308],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[109-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[109-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 109,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "109-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5272513999952935,
+        "max": 0.5547717000008561,
+        "mean": 0.5371525666657059,
+        "stddev": 0.01529761370859992,
+        "rounds": 3,
+        "median": 0.5294346000009682,
+        "iqr": 0.020640225004171953,
+        "q1": 0.5277971999967122,
+        "q3": 0.5484374250008841,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5272513999952935,
+        "hd15iqr": 0.5547717000008561,
+        "ops": 1.8616684756946247,
+        "total": 1.6114576999971177,
+        "data": [0.5547717000008561, 0.5294346000009682, 0.5272513999952935],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[110-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[110-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 110,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "110-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5388864999986254,
+        "max": 0.6033167999994475,
+        "mean": 0.5651702333319312,
+        "stddev": 0.033813621524253074,
+        "rounds": 3,
+        "median": 0.5533073999977205,
+        "iqr": 0.04832272500061663,
+        "q1": 0.5424917249983991,
+        "q3": 0.5908144499990158,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5388864999986254,
+        "hd15iqr": 0.6033167999994475,
+        "ops": 1.7693783943725292,
+        "total": 1.6955106999957934,
+        "data": [0.5388864999986254, 0.5533073999977205, 0.6033167999994475],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[111-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[111-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 111,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "111-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5463464000058593,
+        "max": 0.6114251999970293,
+        "mean": 0.5723552666653026,
+        "stddev": 0.03444932726536256,
+        "rounds": 3,
+        "median": 0.559294199993019,
+        "iqr": 0.04880909999337746,
+        "q1": 0.5495833500026492,
+        "q3": 0.5983924499960267,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5463464000058593,
+        "hd15iqr": 0.6114251999970293,
+        "ops": 1.7471665908243879,
+        "total": 1.7170657999959076,
+        "data": [0.5463464000058593, 0.559294199993019, 0.6114251999970293],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[112-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[112-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 112,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "112-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6067981999949552,
+        "max": 0.6333976999885635,
+        "mean": 0.6194777999917278,
+        "stddev": 0.013343054674440554,
+        "rounds": 3,
+        "median": 0.6182374999916647,
+        "iqr": 0.01994962499520625,
+        "q1": 0.6096580249941326,
+        "q3": 0.6296076499893388,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6067981999949552,
+        "hd15iqr": 0.6333976999885635,
+        "ops": 1.6142628517331106,
+        "total": 1.8584333999751834,
+        "data": [0.6182374999916647, 0.6067981999949552, 0.6333976999885635],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[113-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[113-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 113,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "113-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6112971999973524,
+        "max": 0.6342215999902692,
+        "mean": 0.6236332666594535,
+        "stddev": 0.01156170219330937,
+        "rounds": 3,
+        "median": 0.6253809999907389,
+        "iqr": 0.01719329999468755,
+        "q1": 0.6148181499956991,
+        "q3": 0.6320114499903866,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6112971999973524,
+        "hd15iqr": 0.6342215999902692,
+        "ops": 1.603506505284088,
+        "total": 1.8708997999783605,
+        "data": [0.6112971999973524, 0.6253809999907389, 0.6342215999902692],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[114-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[114-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 114,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "114-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6467569999949774,
+        "max": 0.6690397000056691,
+        "mean": 0.6614638000028208,
+        "stddev": 0.012738405751998545,
+        "rounds": 3,
+        "median": 0.6685947000078158,
+        "iqr": 0.016712025008018827,
+        "q1": 0.652216424998187,
+        "q3": 0.6689284500062058,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6467569999949774,
+        "hd15iqr": 0.6690397000056691,
+        "ops": 1.5117985292554719,
+        "total": 1.9843914000084624,
+        "data": [0.6467569999949774, 0.6685947000078158, 0.6690397000056691],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[115-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[115-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 115,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "115-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5978648000018438,
+        "max": 0.6676440000010189,
+        "mean": 0.6387988000011925,
+        "stddev": 0.03642648078256471,
+        "rounds": 3,
+        "median": 0.6508876000007149,
+        "iqr": 0.052334399999381276,
+        "q1": 0.6111205000015616,
+        "q3": 0.6634549000009429,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5978648000018438,
+        "hd15iqr": 0.6676440000010189,
+        "ops": 1.5654381316904997,
+        "total": 1.9163964000035776,
+        "data": [0.5978648000018438, 0.6676440000010189, 0.6508876000007149],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[116-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[116-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 116,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "116-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5756609000090975,
+        "max": 0.620738400000846,
+        "mean": 0.597120933336555,
+        "stddev": 0.022616059345710107,
+        "rounds": 3,
+        "median": 0.5949634999997215,
+        "iqr": 0.03380812499381136,
+        "q1": 0.5804865500067535,
+        "q3": 0.6142946750005649,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5756609000090975,
+        "hd15iqr": 0.620738400000846,
+        "ops": 1.6747026342088904,
+        "total": 1.791362800009665,
+        "data": [0.5756609000090975, 0.5949634999997215, 0.620738400000846],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[117-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[117-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 117,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "117-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5761506999988342,
+        "max": 0.619176400010474,
+        "mean": 0.602242300005552,
+        "stddev": 0.02292809564889931,
+        "rounds": 3,
+        "median": 0.611399800007348,
+        "iqr": 0.03226927500872989,
+        "q1": 0.5849629750009626,
+        "q3": 0.6172322500096925,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5761506999988342,
+        "hd15iqr": 0.619176400010474,
+        "ops": 1.660461246230597,
+        "total": 1.8067269000166561,
+        "data": [0.611399800007348, 0.5761506999988342, 0.619176400010474],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[118-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[118-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 118,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "118-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5884096999943722,
+        "max": 0.611316499998793,
+        "mean": 0.6033649333354939,
+        "stddev": 0.01296028093102792,
+        "rounds": 3,
+        "median": 0.6103686000133166,
+        "iqr": 0.0171801000033156,
+        "q1": 0.5938994249991083,
+        "q3": 0.6110795250024239,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5884096999943722,
+        "hd15iqr": 0.611316499998793,
+        "ops": 1.6573717575395814,
+        "total": 1.8100948000064818,
+        "data": [0.611316499998793, 0.5884096999943722, 0.6103686000133166],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[119-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[119-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 119,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "119-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5990293999930145,
+        "max": 0.6248791999969399,
+        "mean": 0.6114875999968111,
+        "stddev": 0.012950153154522897,
+        "rounds": 3,
+        "median": 0.6105542000004789,
+        "iqr": 0.019387350002944004,
+        "q1": 0.6019105999948806,
+        "q3": 0.6212979499978246,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5990293999930145,
+        "hd15iqr": 0.6248791999969399,
+        "ops": 1.6353561380561357,
+        "total": 1.8344627999904333,
+        "data": [0.5990293999930145, 0.6105542000004789, 0.6248791999969399],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[120-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[120-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 120,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "120-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5672131000028457,
+        "max": 0.586955399994622,
+        "mean": 0.5753444333289129,
+        "stddev": 0.010320876337554031,
+        "rounds": 3,
+        "median": 0.571864799989271,
+        "iqr": 0.014806724993832177,
+        "q1": 0.5683760249994521,
+        "q3": 0.5831827499932842,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5672131000028457,
+        "hd15iqr": 0.586955399994622,
+        "ops": 1.7380892941190933,
+        "total": 1.7260332999867387,
+        "data": [0.5672131000028457, 0.571864799989271, 0.586955399994622],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[121-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[121-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 121,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "121-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5175686000002315,
+        "max": 0.599489000000176,
+        "mean": 0.5608473000029335,
+        "stddev": 0.041156582837083296,
+        "rounds": 3,
+        "median": 0.5654843000083929,
+        "iqr": 0.06144029999995837,
+        "q1": 0.5295475250022719,
+        "q3": 0.5909878250022302,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5175686000002315,
+        "hd15iqr": 0.599489000000176,
+        "ops": 1.7830165180339987,
+        "total": 1.6825419000088004,
+        "data": [0.5175686000002315, 0.599489000000176, 0.5654843000083929],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[122-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[122-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 122,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "122-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.640937699994538,
+        "max": 0.6948763999971561,
+        "mean": 0.6731778000006065,
+        "stddev": 0.028472587805310604,
+        "rounds": 3,
+        "median": 0.6837193000101252,
+        "iqr": 0.0404540250019636,
+        "q1": 0.6516330999984348,
+        "q3": 0.6920871250003984,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.640937699994538,
+        "hd15iqr": 0.6948763999971561,
+        "ops": 1.485491648713162,
+        "total": 2.0195334000018192,
+        "data": [0.640937699994538, 0.6948763999971561, 0.6837193000101252],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[123-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[123-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 123,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "123-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5869899000099394,
+        "max": 0.6312482999928761,
+        "mean": 0.6136126333343176,
+        "stddev": 0.023457984092933388,
+        "rounds": 3,
+        "median": 0.6225997000001371,
+        "iqr": 0.03319379998720251,
+        "q1": 0.5958923500074889,
+        "q3": 0.6290861499946914,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5869899000099394,
+        "hd15iqr": 0.6312482999928761,
+        "ops": 1.6296926524574424,
+        "total": 1.8408379000029527,
+        "data": [0.5869899000099394, 0.6312482999928761, 0.6225997000001371],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[124-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[124-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 124,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "124-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6136828000016976,
+        "max": 0.6454569000052288,
+        "mean": 0.6335633666700838,
+        "stddev": 0.01732751811017179,
+        "rounds": 3,
+        "median": 0.6415504000033252,
+        "iqr": 0.023830575002648402,
+        "q1": 0.6206497000021045,
+        "q3": 0.6444802750047529,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6136828000016976,
+        "hd15iqr": 0.6454569000052288,
+        "ops": 1.5783740863299174,
+        "total": 1.9006901000102516,
+        "data": [0.6415504000033252, 0.6454569000052288, 0.6136828000016976],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[125-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[125-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 125,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "125-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5892534000013256,
+        "max": 0.7190180000034161,
+        "mean": 0.6341939000024771,
+        "stddev": 0.07350332655827847,
+        "rounds": 3,
+        "median": 0.5943103000026895,
+        "iqr": 0.09732345000156783,
+        "q1": 0.5905176250016666,
+        "q3": 0.6878410750032344,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5892534000013256,
+        "hd15iqr": 0.7190180000034161,
+        "ops": 1.5768048226198552,
+        "total": 1.9025817000074312,
+        "data": [0.7190180000034161, 0.5943103000026895, 0.5892534000013256],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[126-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[126-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 126,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "126-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4833952000044519,
+        "max": 0.5447754000051646,
+        "mean": 0.5175980000009682,
+        "stddev": 0.031287368406769836,
+        "rounds": 3,
+        "median": 0.5246233999932883,
+        "iqr": 0.046035150000534486,
+        "q1": 0.493702250001661,
+        "q3": 0.5397374000021955,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4833952000044519,
+        "hd15iqr": 0.5447754000051646,
+        "ops": 1.9320012828452375,
+        "total": 1.5527940000029048,
+        "data": [0.5246233999932883, 0.5447754000051646, 0.4833952000044519],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[127-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[127-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 127,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "127-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4951446000050055,
+        "max": 0.5481580999912694,
+        "mean": 0.520051233334622,
+        "stddev": 0.026651246034828848,
+        "rounds": 3,
+        "median": 0.5168510000075912,
+        "iqr": 0.03976012498969794,
+        "q1": 0.5005712000056519,
+        "q3": 0.5403313249953499,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4951446000050055,
+        "hd15iqr": 0.5481580999912694,
+        "ops": 1.9228874693516196,
+        "total": 1.560153700003866,
+        "data": [0.4951446000050055, 0.5481580999912694, 0.5168510000075912],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-1-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-1-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5034226999996463,
+        "max": 0.5261775000108173,
+        "mean": 0.5156620000052499,
+        "stddev": 0.011474922471075379,
+        "rounds": 3,
+        "median": 0.517385800005286,
+        "iqr": 0.01706610000837827,
+        "q1": 0.5069134750010562,
+        "q3": 0.5239795750094345,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5034226999996463,
+        "hd15iqr": 0.5261775000108173,
+        "ops": 1.9392547831521796,
+        "total": 1.5469860000157496,
+        "data": [0.517385800005286, 0.5261775000108173, 0.5034226999996463],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-1-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-1-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49971479999658186,
+        "max": 0.5192243000055896,
+        "mean": 0.5074817333370447,
+        "stddev": 0.010344534446744613,
+        "rounds": 3,
+        "median": 0.5035061000089627,
+        "iqr": 0.014632125006755814,
+        "q1": 0.5006626249996771,
+        "q3": 0.5152947500064329,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49971479999658186,
+        "hd15iqr": 0.5192243000055896,
+        "ops": 1.9705142753105727,
+        "total": 1.5224452000111341,
+        "data": [0.5035061000089627, 0.49971479999658186, 0.5192243000055896],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-1-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-1-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49379579999367706,
+        "max": 0.5339642000035383,
+        "mean": 0.5106506666634232,
+        "stddev": 0.020848522038918155,
+        "rounds": 3,
+        "median": 0.5041919999930542,
+        "iqr": 0.030126300007395912,
+        "q1": 0.49639484999352135,
+        "q3": 0.5265211500009173,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49379579999367706,
+        "hd15iqr": 0.5339642000035383,
+        "ops": 1.9582858993095442,
+        "total": 1.5319519999902695,
+        "data": [0.49379579999367706, 0.5339642000035383, 0.5041919999930542],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-1-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-1-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2200788000045577,
+        "max": 1.2221437999978662,
+        "mean": 1.220814466670466,
+        "stddev": 0.001153423739055253,
+        "rounds": 3,
+        "median": 1.220220800008974,
+        "iqr": 0.0015487499949813355,
+        "q1": 1.2201143000056618,
+        "q3": 1.2216630500006431,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2200788000045577,
+        "hd15iqr": 1.2221437999978662,
+        "ops": 0.819125286684475,
+        "total": 3.662443400011398,
+        "data": [1.2221437999978662, 1.220220800008974, 1.2200788000045577],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-1-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-1-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 1,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-1-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4862353000062285,
+        "max": 0.5407384999998612,
+        "mean": 0.5197336666654641,
+        "stddev": 0.029320913757770507,
+        "rounds": 3,
+        "median": 0.5322271999903023,
+        "iqr": 0.04087739999522455,
+        "q1": 0.49773327500224696,
+        "q3": 0.5386106749974715,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4862353000062285,
+        "hd15iqr": 0.5407384999998612,
+        "ops": 1.924062388368749,
+        "total": 1.559200999996392,
+        "data": [0.5322271999903023, 0.4862353000062285, 0.5407384999998612],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-2-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-2-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.544831899998826,
+        "max": 0.6209711999981664,
+        "mean": 0.5784251333340459,
+        "stddev": 0.03885116690086277,
+        "rounds": 3,
+        "median": 0.5694723000051454,
+        "iqr": 0.05710447499950533,
+        "q1": 0.5509920000004058,
+        "q3": 0.6080964749999112,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.544831899998826,
+        "hd15iqr": 0.6209711999981664,
+        "ops": 1.7288322072659499,
+        "total": 1.7352754000021378,
+        "data": [0.544831899998826, 0.5694723000051454, 0.6209711999981664],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-2-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-2-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5060822000086773,
+        "max": 0.5382725999952527,
+        "mean": 0.5207385000006374,
+        "stddev": 0.016287012079119666,
+        "rounds": 3,
+        "median": 0.517860699997982,
+        "iqr": 0.024142799989931518,
+        "q1": 0.5090268250060035,
+        "q3": 0.533169624995935,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5060822000086773,
+        "hd15iqr": 0.5382725999952527,
+        "ops": 1.9203496572632446,
+        "total": 1.562215500001912,
+        "data": [0.517860699997982, 0.5060822000086773, 0.5382725999952527],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-2-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-2-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4840958999993745,
+        "max": 0.5162972000107402,
+        "mean": 0.4960295000006833,
+        "stddev": 0.01764437156212589,
+        "rounds": 3,
+        "median": 0.4876953999919351,
+        "iqr": 0.024150975008524256,
+        "q1": 0.4849957749975147,
+        "q3": 0.5091467500060389,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4840958999993745,
+        "hd15iqr": 0.5162972000107402,
+        "ops": 2.016009128486557,
+        "total": 1.4880885000020498,
+        "data": [0.5162972000107402, 0.4840958999993745, 0.4876953999919351],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-2-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-2-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6360501000017393,
+        "max": 0.852026599997771,
+        "mean": 0.717459699997562,
+        "stddev": 0.11739137977488472,
+        "rounds": 3,
+        "median": 0.6643023999931756,
+        "iqr": 0.16198237499702373,
+        "q1": 0.6431131749995984,
+        "q3": 0.8050955499966221,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6360501000017393,
+        "hd15iqr": 0.852026599997771,
+        "ops": 1.3938065092762675,
+        "total": 2.152379099992686,
+        "data": [0.852026599997771, 0.6643023999931756, 0.6360501000017393],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-2-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-2-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 2,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-2-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0999863000033656,
+        "max": 1.1231294999888632,
+        "mean": 1.1117099666638144,
+        "stddev": 0.011574597150936207,
+        "rounds": 3,
+        "median": 1.1120140999992145,
+        "iqr": 0.017357399989123223,
+        "q1": 1.1029932500023278,
+        "q3": 1.120350649991451,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0999863000033656,
+        "hd15iqr": 1.1231294999888632,
+        "ops": 0.8995151883012703,
+        "total": 3.3351298999914434,
+        "data": [1.1120140999992145, 1.1231294999888632, 1.0999863000033656],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-bitshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-bitshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "bitshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-bitshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.515160900002229,
+        "max": 0.520117099993513,
+        "mean": 0.5169182000002669,
+        "stddev": 0.002774822066014165,
+        "rounds": 3,
+        "median": 0.5154766000050586,
+        "iqr": 0.0037171499934629537,
+        "q1": 0.5152398250029364,
+        "q3": 0.5189569749963994,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.515160900002229,
+        "hd15iqr": 0.520117099993513,
+        "ops": 1.9345420610059458,
+        "total": 1.5507546000008006,
+        "data": [0.5154766000050586, 0.520117099993513, 0.515160900002229],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-noshuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-noshuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "noshuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-noshuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5758234000095399,
+        "max": 0.5919412999937776,
+        "mean": 0.5855490333342459,
+        "stddev": 0.008560384043303426,
+        "rounds": 3,
+        "median": 0.5888823999994202,
+        "iqr": 0.012088424988178303,
+        "q1": 0.57908815000701,
+        "q3": 0.5911765749951883,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5758234000095399,
+        "hd15iqr": 0.5919412999937776,
+        "ops": 1.7077989084975147,
+        "total": 1.7566471000027377,
+        "data": [0.5888823999994202, 0.5758234000095399, 0.5919412999937776],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-3-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4411489000049187,
+        "max": 0.4722799000010127,
+        "mean": 0.45248870000068564,
+        "stddev": 0.017200418940159883,
+        "rounds": 3,
+        "median": 0.4440372999961255,
+        "iqr": 0.023348249997070525,
+        "q1": 0.4418710000027204,
+        "q3": 0.4652192499997909,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4411489000049187,
+        "hd15iqr": 0.4722799000010127,
+        "ops": 2.209999940326653,
+        "total": 1.357466100002057,
+        "data": [0.4411489000049187, 0.4440372999961255, 0.4722799000010127],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-3-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4199869000003673,
+        "max": 0.4382320000004256,
+        "mean": 0.4302250333372892,
+        "stddev": 0.009324939519787233,
+        "rounds": 3,
+        "median": 0.43245620001107454,
+        "iqr": 0.013683825000043726,
+        "q1": 0.4231042250030441,
+        "q3": 0.43678805000308785,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4199869000003673,
+        "hd15iqr": 0.4382320000004256,
+        "ops": 2.324364977655814,
+        "total": 1.2906751000118675,
+        "data": [0.4382320000004256, 0.43245620001107454, 0.4199869000003673],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-3-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4863697999971919,
+        "max": 0.5018729000003077,
+        "mean": 0.4926150000004175,
+        "stddev": 0.008178862902572658,
+        "rounds": 3,
+        "median": 0.48960230000375304,
+        "iqr": 0.011627325002336875,
+        "q1": 0.48717792499883217,
+        "q3": 0.49880525000116904,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4863697999971919,
+        "hd15iqr": 0.5018729000003077,
+        "ops": 2.0299828466432253,
+        "total": 1.4778450000012526,
+        "data": [0.48960230000375304, 0.4863697999971919, 0.5018729000003077],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-3-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5467410999990534,
+        "max": 0.5672277999983635,
+        "mean": 0.5544451999982508,
+        "stddev": 0.011147627142576328,
+        "rounds": 3,
+        "median": 0.5493666999973357,
+        "iqr": 0.015365024999482557,
+        "q1": 0.547397499998624,
+        "q3": 0.5627625249981065,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5467410999990534,
+        "hd15iqr": 0.5672277999983635,
+        "ops": 1.8036047566164424,
+        "total": 1.6633355999947526,
+        "data": [0.5493666999973357, 0.5467410999990534, 0.5672277999983635],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5106481999973767,
+        "max": 0.5672109000006458,
+        "mean": 0.5444736000014624,
+        "stddev": 0.02986710948859955,
+        "rounds": 3,
+        "median": 0.5555617000063648,
+        "iqr": 0.042422025002451846,
+        "q1": 0.5218765749996237,
+        "q3": 0.5642986000020755,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5106481999973767,
+        "hd15iqr": 0.5672109000006458,
+        "ops": 1.8366363401224854,
+        "total": 1.6334208000043873,
+        "data": [0.5672109000006458, 0.5555617000063648, 0.5106481999973767],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-4-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-4-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4823790999944322,
+        "max": 0.5163961999933235,
+        "mean": 0.5009690333293596,
+        "stddev": 0.017227683908316326,
+        "rounds": 3,
+        "median": 0.504131800000323,
+        "iqr": 0.025512824999168515,
+        "q1": 0.4878172749959049,
+        "q3": 0.5133300999950734,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4823790999944322,
+        "hd15iqr": 0.5163961999933235,
+        "ops": 1.9961313643563174,
+        "total": 1.5029070999880787,
+        "data": [0.5163961999933235, 0.504131800000323, 0.4823790999944322],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-4-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-4-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.459157299992512,
+        "max": 0.5169713000068441,
+        "mean": 0.4916234000023299,
+        "stddev": 0.02955699964307826,
+        "rounds": 3,
+        "median": 0.4987416000076337,
+        "iqr": 0.04336050001074909,
+        "q1": 0.4690533749962924,
+        "q3": 0.5124138750070415,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.459157299992512,
+        "hd15iqr": 0.5169713000068441,
+        "ops": 2.0340773038778477,
+        "total": 1.4748702000069898,
+        "data": [0.4987416000076337, 0.5169713000068441, 0.459157299992512],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-4-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-4-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.56517069999245,
+        "max": 0.5820034999924246,
+        "mean": 0.5733994666613095,
+        "stddev": 0.008422672245827753,
+        "rounds": 3,
+        "median": 0.573024199999054,
+        "iqr": 0.012624599999981001,
+        "q1": 0.567134074994101,
+        "q3": 0.579758674994082,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.56517069999245,
+        "hd15iqr": 0.5820034999924246,
+        "ops": 1.7439848798999165,
+        "total": 1.7201983999839285,
+        "data": [0.5820034999924246, 0.573024199999054, 0.56517069999245],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-4-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-4-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5331169999990379,
+        "max": 0.5523403999977745,
+        "mean": 0.54193053333438,
+        "stddev": 0.009710612078985777,
+        "rounds": 3,
+        "median": 0.5403342000063276,
+        "iqr": 0.014417549999052426,
+        "q1": 0.5349213000008604,
+        "q3": 0.5493388499999128,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5331169999990379,
+        "hd15iqr": 0.5523403999977745,
+        "ops": 1.8452549514920644,
+        "total": 1.62579160000314,
+        "data": [0.5523403999977745, 0.5403342000063276, 0.5331169999990379],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-4-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-4-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 4,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-4-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6612953000003472,
+        "max": 0.6835320999962278,
+        "mean": 0.6730839666658236,
+        "stddev": 0.011178845679721525,
+        "rounds": 3,
+        "median": 0.6744245000008959,
+        "iqr": 0.01667759999691043,
+        "q1": 0.6645776000004844,
+        "q3": 0.6812551999973948,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6612953000003472,
+        "hd15iqr": 0.6835320999962278,
+        "ops": 1.4856987382325888,
+        "total": 2.019251899997471,
+        "data": [0.6744245000008959, 0.6835320999962278, 0.6612953000003472],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-5-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-5-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4235132000030717,
+        "max": 0.4326452999957837,
+        "mean": 0.4292255999995784,
+        "stddev": 0.00497907295967422,
+        "rounds": 3,
+        "median": 0.4315182999998797,
+        "iqr": 0.006849074994534021,
+        "q1": 0.4255144750022737,
+        "q3": 0.4323635499968077,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4235132000030717,
+        "hd15iqr": 0.4326452999957837,
+        "ops": 2.329777161476348,
+        "total": 1.287676799998735,
+        "data": [0.4326452999957837, 0.4315182999998797, 0.4235132000030717],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-5-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-5-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3902788999985205,
+        "max": 0.4470010000077309,
+        "mean": 0.41817140000057407,
+        "stddev": 0.028372658928595154,
+        "rounds": 3,
+        "median": 0.4172342999954708,
+        "iqr": 0.042541575006907806,
+        "q1": 0.3970177499977581,
+        "q3": 0.4395593250046659,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3902788999985205,
+        "hd15iqr": 0.4470010000077309,
+        "ops": 2.3913639239762143,
+        "total": 1.2545142000017222,
+        "data": [0.4470010000077309, 0.4172342999954708, 0.3902788999985205],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-5-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-5-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6259201000066241,
+        "max": 0.6358671999914804,
+        "mean": 0.6309717999974964,
+        "stddev": 0.004975391622169316,
+        "rounds": 3,
+        "median": 0.6311280999943847,
+        "iqr": 0.007460324988642242,
+        "q1": 0.6272221000035643,
+        "q3": 0.6346824249922065,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6259201000066241,
+        "hd15iqr": 0.6358671999914804,
+        "ops": 1.5848568826752127,
+        "total": 1.8929153999924893,
+        "data": [0.6358671999914804, 0.6259201000066241, 0.6311280999943847],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-5-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-5-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6479375000053551,
+        "max": 0.6504409000044689,
+        "mean": 0.6492525333354328,
+        "stddev": 0.0012564976009349293,
+        "rounds": 3,
+        "median": 0.6493791999964742,
+        "iqr": 0.001877549999335315,
+        "q1": 0.6482979250031349,
+        "q3": 0.6501754750024702,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6479375000053551,
+        "hd15iqr": 0.6504409000044689,
+        "ops": 1.5402327271064424,
+        "total": 1.9477576000062982,
+        "data": [0.6493791999964742, 0.6479375000053551, 0.6504409000044689],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-5-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-5-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 5,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-5-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8040846999938367,
+        "max": 0.8283184000028996,
+        "mean": 0.8151685666671256,
+        "stddev": 0.012248233248929768,
+        "rounds": 3,
+        "median": 0.8131026000046404,
+        "iqr": 0.018175275006797165,
+        "q1": 0.8063391749965376,
+        "q3": 0.8245144500033348,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8040846999938367,
+        "hd15iqr": 0.8283184000028996,
+        "ops": 1.2267401380411058,
+        "total": 2.4455057000013767,
+        "data": [0.8040846999938367, 0.8283184000028996, 0.8131026000046404],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-6-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-6-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5040698999946471,
+        "max": 0.5643190999981016,
+        "mean": 0.5265645666659111,
+        "stddev": 0.03289588383287499,
+        "rounds": 3,
+        "median": 0.5113047000049846,
+        "iqr": 0.045186900002590846,
+        "q1": 0.5058785999972315,
+        "q3": 0.5510654999998224,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5040698999946471,
+        "hd15iqr": 0.5643190999981016,
+        "ops": 1.8991023386396393,
+        "total": 1.5796936999977333,
+        "data": [0.5040698999946471, 0.5113047000049846, 0.5643190999981016],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-6-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-6-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48127049999311566,
+        "max": 0.5087158999958774,
+        "mean": 0.49511776666137547,
+        "stddev": 0.013724396011897592,
+        "rounds": 3,
+        "median": 0.4953668999951333,
+        "iqr": 0.020584050002071308,
+        "q1": 0.48479459999362007,
+        "q3": 0.5053786499956914,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48127049999311566,
+        "hd15iqr": 0.5087158999958774,
+        "ops": 2.019721503316457,
+        "total": 1.4853532999841264,
+        "data": [0.5087158999958774, 0.4953668999951333, 0.48127049999311566],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-6-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-6-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7720601999899372,
+        "max": 0.78931440001179,
+        "mean": 0.7804508666692224,
+        "stddev": 0.008636814039879443,
+        "rounds": 3,
+        "median": 0.77997800000594,
+        "iqr": 0.012940650016389554,
+        "q1": 0.7740396499939379,
+        "q3": 0.7869803000103275,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7720601999899372,
+        "hd15iqr": 0.78931440001179,
+        "ops": 1.2813106406912722,
+        "total": 2.341352600007667,
+        "data": [0.7720601999899372, 0.78931440001179, 0.77997800000594],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-6-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-6-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.9016513999958988,
+        "max": 0.9080894000071567,
+        "mean": 0.9048174000005625,
+        "stddev": 0.003220308686530822,
+        "rounds": 3,
+        "median": 0.9047113999986323,
+        "iqr": 0.0048285000084433705,
+        "q1": 0.9024163999965822,
+        "q3": 0.9072449000050256,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.9016513999958988,
+        "hd15iqr": 0.9080894000071567,
+        "ops": 1.1051953687002243,
+        "total": 2.7144522000016877,
+        "data": [0.9016513999958988, 0.9047113999986323, 0.9080894000071567],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-6-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-6-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 6,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-6-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0260801999975229,
+        "max": 1.0398237999906996,
+        "mean": 1.035158399992118,
+        "stddev": 0.007862966237160391,
+        "rounds": 3,
+        "median": 1.0395711999881314,
+        "iqr": 0.010307699994882569,
+        "q1": 1.029452949995175,
+        "q3": 1.0397606499900576,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0260801999975229,
+        "hd15iqr": 1.0398237999906996,
+        "ops": 0.9660357294184294,
+        "total": 3.105475199976354,
+        "data": [1.0398237999906996, 1.0395711999881314, 1.0260801999975229],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-7-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-7-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.47865869999805,
+        "max": 0.5316272999916691,
+        "mean": 0.5012197999991864,
+        "stddev": 0.02734214038694037,
+        "rounds": 3,
+        "median": 0.49337340000784025,
+        "iqr": 0.03972644999521435,
+        "q1": 0.48233737500049756,
+        "q3": 0.5220638249957119,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.47865869999805,
+        "hd15iqr": 0.5316272999916691,
+        "ops": 1.9951326743309485,
+        "total": 1.5036593999975594,
+        "data": [0.47865869999805, 0.49337340000784025, 0.5316272999916691],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-7-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-7-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.5719222000043374,
+        "max": 0.6712092999950983,
+        "mean": 0.6308102999998179,
+        "stddev": 0.05216193219443553,
+        "rounds": 3,
+        "median": 0.6492994000000181,
+        "iqr": 0.07446532499307068,
+        "q1": 0.5912665000032575,
+        "q3": 0.6657318249963282,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.5719222000043374,
+        "hd15iqr": 0.6712092999950983,
+        "ops": 1.5852626375953098,
+        "total": 1.8924308999994537,
+        "data": [0.5719222000043374, 0.6712092999950983, 0.6492994000000181],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-7-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-7-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0130009000131395,
+        "max": 1.0367247999965912,
+        "mean": 1.024921066670989,
+        "stddev": 0.011862378561943157,
+        "rounds": 3,
+        "median": 1.0250375000032363,
+        "iqr": 0.017792924987588776,
+        "q1": 1.0160100500106637,
+        "q3": 1.0338029749982525,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0130009000131395,
+        "hd15iqr": 1.0367247999965912,
+        "ops": 0.9756848917625098,
+        "total": 3.074763200012967,
+        "data": [1.0130009000131395, 1.0367247999965912, 1.0250375000032363],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-7-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-7-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2254190999956336,
+        "max": 1.254147700004978,
+        "mean": 1.2374809666653164,
+        "stddev": 0.014907605857764007,
+        "rounds": 3,
+        "median": 1.2328760999953374,
+        "iqr": 0.02154645000700839,
+        "q1": 1.2272833499955595,
+        "q3": 1.248829800002568,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2254190999956336,
+        "hd15iqr": 1.254147700004978,
+        "ops": 0.8080932369365933,
+        "total": 3.712442899995949,
+        "data": [1.2328760999953374, 1.254147700004978, 1.2254190999956336],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-7-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-7-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 7,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-7-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7590076999913435,
+        "max": 1.7720169000094756,
+        "mean": 1.7642042000031022,
+        "stddev": 0.006887902299452978,
+        "rounds": 3,
+        "median": 1.7615880000084871,
+        "iqr": 0.009756900013599079,
+        "q1": 1.7596527749956294,
+        "q3": 1.7694096750092285,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7590076999913435,
+        "hd15iqr": 1.7720169000094756,
+        "ops": 0.5668278082538527,
+        "total": 5.292612600009306,
+        "data": [1.7590076999913435, 1.7720169000094756, 1.7615880000084871],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-8-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-8-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.49624570000742096,
+        "max": 0.5292630000039935,
+        "mean": 0.5116143666721958,
+        "stddev": 0.01662631079848951,
+        "rounds": 3,
+        "median": 0.5093344000051729,
+        "iqr": 0.02476297499742941,
+        "q1": 0.49951787500685896,
+        "q3": 0.5242808500042884,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.49624570000742096,
+        "hd15iqr": 0.5292630000039935,
+        "ops": 1.9545971832349367,
+        "total": 1.5348431000165874,
+        "data": [0.5292630000039935, 0.49624570000742096, 0.5093344000051729],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-8-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-8-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48392370001238305,
+        "max": 0.497141300002113,
+        "mean": 0.4905550000063765,
+        "stddev": 0.006608914897470652,
+        "rounds": 3,
+        "median": 0.49060000000463333,
+        "iqr": 0.00991319999229745,
+        "q1": 0.4855927750104456,
+        "q3": 0.49550597500274307,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48392370001238305,
+        "hd15iqr": 0.497141300002113,
+        "ops": 2.038507404851651,
+        "total": 1.4716650000191294,
+        "data": [0.49060000000463333, 0.497141300002113, 0.48392370001238305],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-8-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-8-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.378909199993359,
+        "max": 1.396192100000917,
+        "mean": 1.3854711333309144,
+        "stddev": 0.00936204181058362,
+        "rounds": 3,
+        "median": 1.3813120999984676,
+        "iqr": 0.012962175005668541,
+        "q1": 1.379509924994636,
+        "q3": 1.3924721000003046,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.378909199993359,
+        "hd15iqr": 1.396192100000917,
+        "ops": 0.7217761351662559,
+        "total": 4.1564133999927435,
+        "data": [1.378909199993359, 1.396192100000917, 1.3813120999984676],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-8-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-8-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.2875986999861198,
+        "max": 3.3174522000044817,
+        "mean": 3.304018799996508,
+        "stddev": 0.015149196299305827,
+        "rounds": 3,
+        "median": 3.3070054999989225,
+        "iqr": 0.022390125013771467,
+        "q1": 3.2924503999893204,
+        "q3": 3.314840525003092,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.2875986999861198,
+        "hd15iqr": 3.3174522000044817,
+        "ops": 0.30266171608982884,
+        "total": 9.912056399989524,
+        "data": [3.3174522000044817, 3.3070054999989225, 3.2875986999861198],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-8-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-8-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 8,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-8-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.3128359999973327,
+        "max": 2.331261999992421,
+        "mean": 2.321658499999709,
+        "stddev": 0.00923779409239162,
+        "rounds": 3,
+        "median": 2.3208775000093738,
+        "iqr": 0.013819499996316154,
+        "q1": 2.314846375000343,
+        "q3": 2.328665874996659,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.3128359999973327,
+        "hd15iqr": 2.331261999992421,
+        "ops": 0.43072656895927,
+        "total": 6.964975499999127,
+        "data": [2.3208775000093738, 2.3128359999973327, 2.331261999992421],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-blosclz]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-9-shuffle-blosclz]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "blosclz"
+      },
+      "param": "128-9-shuffle-blosclz",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4873329999973066,
+        "max": 0.5036611999967135,
+        "mean": 0.49439919999470777,
+        "stddev": 0.008382641710721285,
+        "rounds": 3,
+        "median": 0.4922033999901032,
+        "iqr": 0.0122461499995552,
+        "q1": 0.48855059999550576,
+        "q3": 0.500796749995061,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4873329999973066,
+        "hd15iqr": 0.5036611999967135,
+        "ops": 2.0226569946122575,
+        "total": 1.4831975999841234,
+        "data": [0.4873329999973066, 0.5036611999967135, 0.4922033999901032],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-9-shuffle-lz4]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4"
+      },
+      "param": "128-9-shuffle-lz4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48131880001164973,
+        "max": 0.5312168999953428,
+        "mean": 0.5045447000011336,
+        "stddev": 0.025126934418818102,
+        "rounds": 3,
+        "median": 0.5010983999964083,
+        "iqr": 0.037423574987769825,
+        "q1": 0.48626370000783936,
+        "q3": 0.5236872749956092,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48131880001164973,
+        "hd15iqr": 0.5312168999953428,
+        "ops": 1.9819849460270877,
+        "total": 1.5136341000034008,
+        "data": [0.5312168999953428, 0.48131880001164973, 0.5010983999964083],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-lz4hc]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-9-shuffle-lz4hc]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "lz4hc"
+      },
+      "param": "128-9-shuffle-lz4hc",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.971022300000186,
+        "max": 3.0272509999922477,
+        "mean": 2.9979652666661423,
+        "stddev": 0.02818746339096952,
+        "rounds": 3,
+        "median": 2.995622500005993,
+        "iqr": 0.042171524994046194,
+        "q1": 2.977172350001638,
+        "q3": 3.019343874995684,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.971022300000186,
+        "hd15iqr": 3.0272509999922477,
+        "ops": 0.33355956825745353,
+        "total": 8.993895799998427,
+        "data": [2.971022300000186, 3.0272509999922477, 2.995622500005993],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zlib]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-9-shuffle-zlib]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zlib"
+      },
+      "param": "128-9-shuffle-zlib",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.9927391999954125,
+        "max": 6.030745800002478,
+        "mean": 6.017622100000153,
+        "stddev": 0.021560020861466835,
+        "rounds": 3,
+        "median": 6.029381300002569,
+        "iqr": 0.02850495000529918,
+        "q1": 6.001899724997202,
+        "q3": 6.030404675002501,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.9927391999954125,
+        "hd15iqr": 6.030745800002478,
+        "ops": 0.16617859735658286,
+        "total": 18.05286630000046,
+        "data": [6.029381300002569, 5.9927391999954125, 6.030745800002478],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[128-9-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[128-9-shuffle-zstd]",
+      "params": {
+        "chunk_size": 128,
+        "blosc_clevel": 9,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "128-9-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.035088100004941,
+        "max": 7.150299100001575,
+        "mean": 7.100974200002383,
+        "stddev": 0.05936411912167689,
+        "rounds": 3,
+        "median": 7.117535400000634,
+        "iqr": 0.08640824999747565,
+        "q1": 7.055699925003864,
+        "q3": 7.14210817500134,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.035088100004941,
+        "hd15iqr": 7.150299100001575,
+        "ops": 0.14082574754315602,
+        "total": 21.30292260000715,
+        "data": [7.035088100004941, 7.150299100001575, 7.117535400000634],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[129-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[129-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 129,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "129-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4557063999964157,
+        "max": 0.47353850000945386,
+        "mean": 0.46306970000538666,
+        "stddev": 0.009312843034401792,
+        "rounds": 3,
+        "median": 0.45996420001029037,
+        "iqr": 0.013374075009778608,
+        "q1": 0.4567708499998844,
+        "q3": 0.470144925009663,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4557063999964157,
+        "hd15iqr": 0.47353850000945386,
+        "ops": 2.1595021224415407,
+        "total": 1.38920910001616,
+        "data": [0.47353850000945386, 0.4557063999964157, 0.45996420001029037],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_blosc[130-3-shuffle-zstd]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_blosc[130-3-shuffle-zstd]",
+      "params": {
+        "chunk_size": 130,
+        "blosc_clevel": 3,
+        "blosc_shuffle": "shuffle",
+        "blosc_cname": "zstd"
+      },
+      "param": "130-3-shuffle-zstd",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4713593999913428,
+        "max": 0.47881889999553096,
+        "mean": 0.4756440999917686,
+        "stddev": 0.003851615710330655,
+        "rounds": 3,
+        "median": 0.47675399998843204,
+        "iqr": 0.005594625003141118,
+        "q1": 0.4727080499906151,
+        "q3": 0.4783026749937562,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4713593999913428,
+        "hd15iqr": 0.47881889999553096,
+        "ops": 2.102412286870174,
+        "total": 1.4269322999753058,
+        "data": [0.47675399998843204, 0.47881889999553096, 0.4713593999913428],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-1]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6043953000043985,
+        "max": 1.8834168000030331,
+        "mean": 1.7607325000038447,
+        "stddev": 0.14252241095418133,
+        "rounds": 3,
+        "median": 1.7943854000041028,
+        "iqr": 0.209266124998976,
+        "q1": 1.6518928250043245,
+        "q3": 1.8611589500033006,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6043953000043985,
+        "hd15iqr": 1.8834168000030331,
+        "ops": 0.5679454431594898,
+        "total": 5.282197500011534,
+        "data": [1.8834168000030331, 1.7943854000041028, 1.6043953000043985],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-2]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2674878999969224,
+        "max": 1.7465280999895185,
+        "mean": 1.51203136666057,
+        "stddev": 0.2396780777214732,
+        "rounds": 3,
+        "median": 1.5220780999952694,
+        "iqr": 0.35928014999444713,
+        "q1": 1.3311354499965091,
+        "q3": 1.6904155999909563,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2674878999969224,
+        "hd15iqr": 1.7465280999895185,
+        "ops": 0.6613619413257092,
+        "total": 4.53609409998171,
+        "data": [1.5220780999952694, 1.2674878999969224, 1.7465280999895185],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-3]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1159600999963004,
+        "max": 1.8926957999938168,
+        "mean": 1.4756709999928717,
+        "stddev": 0.39152681806351586,
+        "rounds": 3,
+        "median": 1.4183570999884978,
+        "iqr": 0.5825517749981373,
+        "q1": 1.1915593499943498,
+        "q3": 1.774111124992487,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1159600999963004,
+        "hd15iqr": 1.8926957999938168,
+        "ops": 0.6776578248165279,
+        "total": 4.427012999978615,
+        "data": [1.1159600999963004, 1.4183570999884978, 1.8926957999938168],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.2180340999912005,
+        "max": 1.7009852000046521,
+        "mean": 1.528153399999913,
+        "stddev": 0.26915856756576884,
+        "rounds": 3,
+        "median": 1.6654409000038868,
+        "iqr": 0.36221332501008874,
+        "q1": 1.329885799994372,
+        "q3": 1.6920991250044608,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.2180340999912005,
+        "hd15iqr": 1.7009852000046521,
+        "ops": 0.6543845663662148,
+        "total": 4.584460199999739,
+        "data": [1.2180340999912005, 1.6654409000038868, 1.7009852000046521],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-5]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.681183399996371,
+        "max": 1.8662155999918468,
+        "mean": 1.7454888666591917,
+        "stddev": 0.1046267091055762,
+        "rounds": 3,
+        "median": 1.6890675999893574,
+        "iqr": 0.13877414999660687,
+        "q1": 1.6831544499946176,
+        "q3": 1.8219285999912245,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.681183399996371,
+        "hd15iqr": 1.8662155999918468,
+        "ops": 0.5729054015188118,
+        "total": 5.236466599977575,
+        "data": [1.6890675999893574, 1.681183399996371, 1.8662155999918468],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-6]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7548019999958342,
+        "max": 1.9049419999937527,
+        "mean": 1.8246933333284687,
+        "stddev": 0.07560397254884461,
+        "rounds": 3,
+        "median": 1.8143359999958193,
+        "iqr": 0.11260499999843887,
+        "q1": 1.7696854999958305,
+        "q3": 1.8822904999942693,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7548019999958342,
+        "hd15iqr": 1.9049419999937527,
+        "ops": 0.5480372957662288,
+        "total": 5.474079999985406,
+        "data": [1.7548019999958342, 1.9049419999937527, 1.8143359999958193],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-7]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6494459000095958,
+        "max": 1.8913835999992443,
+        "mean": 1.7613087000014882,
+        "stddev": 0.12199271744263256,
+        "rounds": 3,
+        "median": 1.7430965999956243,
+        "iqr": 0.1814532749922364,
+        "q1": 1.672858575006103,
+        "q3": 1.8543118499983393,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6494459000095958,
+        "hd15iqr": 1.8913835999992443,
+        "ops": 0.5677596437235307,
+        "total": 5.283926100004464,
+        "data": [1.8913835999992443, 1.6494459000095958, 1.7430965999956243],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-8]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.61366370000178,
+        "max": 1.893536799994763,
+        "mean": 1.766952399998748,
+        "stddev": 0.14183468459381243,
+        "rounds": 3,
+        "median": 1.7936566999997012,
+        "iqr": 0.20990482499473728,
+        "q1": 1.6586619500012603,
+        "q3": 1.8685667749959975,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.61366370000178,
+        "hd15iqr": 1.893536799994763,
+        "ops": 0.5659462020599472,
+        "total": 5.300857199996244,
+        "data": [1.893536799994763, 1.61366370000178, 1.7936566999997012],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[64-9]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "gzip_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.640702799995779,
+        "max": 1.864467399995192,
+        "mean": 1.7547349999949802,
+        "stddev": 0.11194425069313652,
+        "rounds": 3,
+        "median": 1.7590347999939695,
+        "iqr": 0.16782344999955967,
+        "q1": 1.6702857999953267,
+        "q3": 1.8381092499948863,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.640702799995779,
+        "hd15iqr": 1.864467399995192,
+        "ops": 0.5698866210583711,
+        "total": 5.2642049999849405,
+        "data": [1.864467399995192, 1.640702799995779, 1.7590347999939695],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-1]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6227467999997316,
+        "max": 0.6762011999962851,
+        "mean": 0.6494223333332533,
+        "stddev": 0.02672734981401311,
+        "rounds": 3,
+        "median": 0.649319000003743,
+        "iqr": 0.04009079999741516,
+        "q1": 0.6293898500007344,
+        "q3": 0.6694806499981496,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6227467999997316,
+        "hd15iqr": 0.6762011999962851,
+        "ops": 1.5398300130322846,
+        "total": 1.9482669999997597,
+        "data": [0.6762011999962851, 0.649319000003743, 0.6227467999997316],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-2]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6204111999977613,
+        "max": 0.656066000010469,
+        "mean": 0.6325687000062317,
+        "stddev": 0.020353365543431447,
+        "rounds": 3,
+        "median": 0.6212289000104647,
+        "iqr": 0.026741100009530783,
+        "q1": 0.6206156250009371,
+        "q3": 0.6473567250104679,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6204111999977613,
+        "hd15iqr": 0.656066000010469,
+        "ops": 1.5808559607678163,
+        "total": 1.897706100018695,
+        "data": [0.656066000010469, 0.6212289000104647, 0.6204111999977613],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-3]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6543314000009559,
+        "max": 0.6667870999954175,
+        "mean": 0.6585329666656131,
+        "stddev": 0.0071486773615546525,
+        "rounds": 3,
+        "median": 0.654480400000466,
+        "iqr": 0.009341774995846208,
+        "q1": 0.6543686500008334,
+        "q3": 0.6637104249966796,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6543314000009559,
+        "hd15iqr": 0.6667870999954175,
+        "ops": 1.5185268629197959,
+        "total": 1.9755988999968395,
+        "data": [0.6667870999954175, 0.6543314000009559, 0.654480400000466],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6630108999961521,
+        "max": 0.7115498000057414,
+        "mean": 0.6872825333315026,
+        "stddev": 0.02426945029942012,
+        "rounds": 3,
+        "median": 0.687286899992614,
+        "iqr": 0.03640417500719195,
+        "q1": 0.6690798999952676,
+        "q3": 0.7054840750024596,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6630108999961521,
+        "hd15iqr": 0.7115498000057414,
+        "ops": 1.4550056948961656,
+        "total": 2.0618475999945076,
+        "data": [0.687286899992614, 0.6630108999961521, 0.7115498000057414],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-5]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.6953703999897698,
+        "max": 0.6965879000053974,
+        "mean": 0.6961430666657785,
+        "stddev": 0.0006717012686825251,
+        "rounds": 3,
+        "median": 0.6964709000021685,
+        "iqr": 0.0009131250117206946,
+        "q1": 0.6956455249928695,
+        "q3": 0.6965586500045902,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.6953703999897698,
+        "hd15iqr": 0.6965879000053974,
+        "ops": 1.4364863314513259,
+        "total": 2.0884291999973357,
+        "data": [0.6953703999897698, 0.6965879000053974, 0.6964709000021685],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-6]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.7513474000006681,
+        "max": 0.7700033000000985,
+        "mean": 0.7577450666625131,
+        "stddev": 0.010619337668507757,
+        "rounds": 3,
+        "median": 0.7518844999867724,
+        "iqr": 0.013991924999572802,
+        "q1": 0.7514816749971942,
+        "q3": 0.765473599996767,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.7513474000006681,
+        "hd15iqr": 0.7700033000000985,
+        "ops": 1.3197050617623924,
+        "total": 2.273235199987539,
+        "data": [0.7513474000006681, 0.7700033000000985, 0.7518844999867724],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-7]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8158714000019245,
+        "max": 0.8404286000004504,
+        "mean": 0.8262876333319582,
+        "stddev": 0.012695245045837756,
+        "rounds": 3,
+        "median": 0.8225628999934997,
+        "iqr": 0.018417899998894427,
+        "q1": 0.8175442749998183,
+        "q3": 0.8359621749987127,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8158714000019245,
+        "hd15iqr": 0.8404286000004504,
+        "ops": 1.2102323206358014,
+        "total": 2.4788628999958746,
+        "data": [0.8225628999934997, 0.8158714000019245, 0.8404286000004504],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-8]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.0845726000115974,
+        "max": 1.1713552000001073,
+        "mean": 1.1397520000027725,
+        "stddev": 0.047955008286972495,
+        "rounds": 3,
+        "median": 1.163328199996613,
+        "iqr": 0.06508694999138243,
+        "q1": 1.1042615000078513,
+        "q3": 1.1693484499992337,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.0845726000115974,
+        "hd15iqr": 1.1713552000001073,
+        "ops": 0.8773838519235477,
+        "total": 3.4192560000083176,
+        "data": [1.1713552000001073, 1.0845726000115974, 1.163328199996613],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_gzip[128-9]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_gzip[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "gzip_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.5116465000028256,
+        "max": 1.5472079000028316,
+        "mean": 1.5338586666718281,
+        "stddev": 0.019366646147577153,
+        "rounds": 3,
+        "median": 1.542721600009827,
+        "iqr": 0.02667105000000447,
+        "q1": 1.519415275004576,
+        "q3": 1.5460863250045804,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.5116465000028256,
+        "hd15iqr": 1.5472079000028316,
+        "ops": 0.6519505491140221,
+        "total": 4.601576000015484,
+        "data": [1.542721600009827, 1.5472079000028316, 1.5116465000028256],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-1]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-1]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 1
+      },
+      "param": "64-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.6520046000077855,
+        "max": 1.8768912999948952,
+        "mean": 1.7938844333354307,
+        "stddev": 0.1234626526971116,
+        "rounds": 3,
+        "median": 1.852757400003611,
+        "iqr": 0.1686650249903323,
+        "q1": 1.702192800006742,
+        "q3": 1.8708578249970742,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.6520046000077855,
+        "hd15iqr": 1.8768912999948952,
+        "ops": 0.5574495109145163,
+        "total": 5.381653300006292,
+        "data": [1.852757400003611, 1.6520046000077855, 1.8768912999948952],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-2]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-2]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 2
+      },
+      "param": "64-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.668433200000436,
+        "max": 1.9057528000121238,
+        "mean": 1.751570566673763,
+        "stddev": 0.13366255252319614,
+        "rounds": 3,
+        "median": 1.6805257000087295,
+        "iqr": 0.1779897000087658,
+        "q1": 1.6714563250025094,
+        "q3": 1.8494460250112752,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.668433200000436,
+        "hd15iqr": 1.9057528000121238,
+        "ops": 0.5709161931734229,
+        "total": 5.254711700021289,
+        "data": [1.668433200000436, 1.6805257000087295, 1.9057528000121238],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-3]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-3]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 3
+      },
+      "param": "64-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.666987299991888,
+        "max": 1.9868784999998752,
+        "mean": 1.8556144333269913,
+        "stddev": 0.16748279321562615,
+        "rounds": 3,
+        "median": 1.9129774999892106,
+        "iqr": 0.2399184000059904,
+        "q1": 1.7284848499912187,
+        "q3": 1.968403249997209,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.666987299991888,
+        "hd15iqr": 1.9868784999998752,
+        "ops": 0.5389050559426117,
+        "total": 5.566843299980974,
+        "data": [1.666987299991888, 1.9868784999998752, 1.9129774999892106],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-4]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 4
+      },
+      "param": "64-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8216582000022754,
+        "max": 1.888701999996556,
+        "mean": 1.848992233334381,
+        "stddev": 0.035193562778028355,
+        "rounds": 3,
+        "median": 1.836616500004311,
+        "iqr": 0.05028284999571042,
+        "q1": 1.8253977750027843,
+        "q3": 1.8756806249984947,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8216582000022754,
+        "hd15iqr": 1.888701999996556,
+        "ops": 0.5408351544001078,
+        "total": 5.5469767000031425,
+        "data": [1.836616500004311, 1.8216582000022754, 1.888701999996556],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-5]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-5]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 5
+      },
+      "param": "64-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.8127330999996047,
+        "max": 2.0201442999969004,
+        "mean": 1.9031237000017427,
+        "stddev": 0.10623897187850001,
+        "rounds": 3,
+        "median": 1.876493700008723,
+        "iqr": 0.15555839999797172,
+        "q1": 1.8286732500018843,
+        "q3": 1.984231649999856,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.8127330999996047,
+        "hd15iqr": 2.0201442999969004,
+        "ops": 0.525451918863227,
+        "total": 5.709371100005228,
+        "data": [1.876493700008723, 2.0201442999969004, 1.8127330999996047],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-6]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-6]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 6
+      },
+      "param": "64-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.802056900007301,
+        "max": 1.8914063999982318,
+        "mean": 1.843107233333285,
+        "stddev": 0.04511366174164296,
+        "rounds": 3,
+        "median": 1.835858399994322,
+        "iqr": 0.06701212499319809,
+        "q1": 1.8105072750040563,
+        "q3": 1.8775193999972544,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.802056900007301,
+        "hd15iqr": 1.8914063999982318,
+        "ops": 0.5425620289013169,
+        "total": 5.529321699999855,
+        "data": [1.835858399994322, 1.802056900007301, 1.8914063999982318],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-7]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-7]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 7
+      },
+      "param": "64-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.912542799997027,
+        "max": 1.9855294000008143,
+        "mean": 1.9375296999981704,
+        "stddev": 0.041580676617390525,
+        "rounds": 3,
+        "median": 1.91451689999667,
+        "iqr": 0.05473995000284049,
+        "q1": 1.9130363249969378,
+        "q3": 1.9677762749997783,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.912542799997027,
+        "hd15iqr": 1.9855294000008143,
+        "ops": 0.5161211206212448,
+        "total": 5.812589099994511,
+        "data": [1.91451689999667, 1.9855294000008143, 1.912542799997027],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-8]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-8]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 8
+      },
+      "param": "64-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9824785000091651,
+        "max": 2.0721684000018286,
+        "mean": 2.0350231666719387,
+        "stddev": 0.04678596424574289,
+        "rounds": 3,
+        "median": 2.050422600004822,
+        "iqr": 0.06726742499449756,
+        "q1": 1.9994645250080794,
+        "q3": 2.066731950002577,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9824785000091651,
+        "hd15iqr": 2.0721684000018286,
+        "ops": 0.4913948973049739,
+        "total": 6.105069500015816,
+        "data": [2.0721684000018286, 1.9824785000091651, 2.050422600004822],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-9]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-9]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 9
+      },
+      "param": "64-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9423527000035392,
+        "max": 2.16801619999751,
+        "mean": 2.0399471666654185,
+        "stddev": 0.11587721181356196,
+        "rounds": 3,
+        "median": 2.009472599995206,
+        "iqr": 0.16924762499547796,
+        "q1": 1.959132675001456,
+        "q3": 2.128380299996934,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9423527000035392,
+        "hd15iqr": 2.16801619999751,
+        "ops": 0.49020877419812847,
+        "total": 6.119841499996255,
+        "data": [1.9423527000035392, 2.16801619999751, 2.009472599995206],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-10]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-10]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 10
+      },
+      "param": "64-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.0162548999942373,
+        "max": 2.0951219000126002,
+        "mean": 2.0526028666693796,
+        "stddev": 0.039794000437760914,
+        "rounds": 3,
+        "median": 2.046431800001301,
+        "iqr": 0.059150250013772165,
+        "q1": 2.0237991249960032,
+        "q3": 2.0829493750097754,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.0162548999942373,
+        "hd15iqr": 2.0951219000126002,
+        "ops": 0.487186301957491,
+        "total": 6.1578086000081385,
+        "data": [2.046431800001301, 2.0162548999942373, 2.0951219000126002],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-11]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-11]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 11
+      },
+      "param": "64-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9528016000112984,
+        "max": 2.0529548000049544,
+        "mean": 1.9925528000070092,
+        "stddev": 0.05317431262171169,
+        "rounds": 3,
+        "median": 1.971902000004775,
+        "iqr": 0.07511489999524201,
+        "q1": 1.9575767000096675,
+        "q3": 2.0326916000049096,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9528016000112984,
+        "hd15iqr": 2.0529548000049544,
+        "ops": 0.5018687585074194,
+        "total": 5.977658400021028,
+        "data": [2.0529548000049544, 1.9528016000112984, 1.971902000004775],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-12]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-12]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 12
+      },
+      "param": "64-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.9052263000048697,
+        "max": 2.0206651000044076,
+        "mean": 1.9728371000043505,
+        "stddev": 0.06020837581430198,
+        "rounds": 3,
+        "median": 1.992619900003774,
+        "iqr": 0.08657909999965341,
+        "q1": 1.9270747000045958,
+        "q3": 2.013653800004249,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.9052263000048697,
+        "hd15iqr": 2.0206651000044076,
+        "ops": 0.5068842227256345,
+        "total": 5.918511300013051,
+        "data": [1.9052263000048697, 1.992619900003774, 2.0206651000044076],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-13]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-13]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 13
+      },
+      "param": "64-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.8611843999970006,
+        "max": 2.87876989999495,
+        "mean": 2.86723546666326,
+        "stddev": 0.009993144401795303,
+        "rounds": 3,
+        "median": 2.8617520999978296,
+        "iqr": 0.01318912499846192,
+        "q1": 2.861326324997208,
+        "q3": 2.8745154499956698,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.8611843999970006,
+        "hd15iqr": 2.87876989999495,
+        "ops": 0.3487680072413962,
+        "total": 8.60170639998978,
+        "data": [2.87876989999495, 2.8611843999970006, 2.8617520999978296],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-14]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-14]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 14
+      },
+      "param": "64-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.9850244000117527,
+        "max": 2.9998287000053097,
+        "mean": 2.993274933338398,
+        "stddev": 0.007546594423844151,
+        "rounds": 3,
+        "median": 2.994971699998132,
+        "iqr": 0.011103224995167693,
+        "q1": 2.9875112250083475,
+        "q3": 2.9986144500035152,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.9850244000117527,
+        "hd15iqr": 2.9998287000053097,
+        "ops": 0.33408224178214746,
+        "total": 8.979824800015194,
+        "data": [2.9998287000053097, 2.994971699998132, 2.9850244000117527],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-15]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-15]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 15
+      },
+      "param": "64-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.087678500000038,
+        "max": 3.1572415999980876,
+        "mean": 3.131345766664405,
+        "stddev": 0.038034511989834624,
+        "rounds": 3,
+        "median": 3.1491171999950893,
+        "iqr": 0.05217232499853708,
+        "q1": 3.103038174998801,
+        "q3": 3.155210499997338,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.087678500000038,
+        "hd15iqr": 3.1572415999980876,
+        "ops": 0.31935151034605397,
+        "total": 9.394037299993215,
+        "data": [3.1572415999980876, 3.087678500000038, 3.1491171999950893],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-16]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-16]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 16
+      },
+      "param": "64-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.9144978999975137,
+        "max": 3.949169299987261,
+        "mean": 3.9342243333327738,
+        "stddev": 0.017823392270462177,
+        "rounds": 3,
+        "median": 3.939005800013547,
+        "iqr": 0.02600354999231058,
+        "q1": 3.920624875001522,
+        "q3": 3.9466284249938326,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.9144978999975137,
+        "hd15iqr": 3.949169299987261,
+        "ops": 0.25417970996912537,
+        "total": 11.802672999998322,
+        "data": [3.949169299987261, 3.9144978999975137, 3.939005800013547],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-17]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-17]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 17
+      },
+      "param": "64-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.037284600010025,
+        "max": 4.064585099986289,
+        "mean": 4.047671266666536,
+        "stddev": 0.014774378268671558,
+        "rounds": 3,
+        "median": 4.041144100003294,
+        "iqr": 0.020475374982197536,
+        "q1": 4.038249475008342,
+        "q3": 4.05872484999054,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.037284600010025,
+        "hd15iqr": 4.064585099986289,
+        "ops": 0.2470556362210588,
+        "total": 12.143013799999608,
+        "data": [4.037284600010025, 4.041144100003294, 4.064585099986289],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-18]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-18]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 18
+      },
+      "param": "64-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.567109000010532,
+        "max": 5.597148699991521,
+        "mean": 5.583086866667145,
+        "stddev": 0.01511123031174626,
+        "rounds": 3,
+        "median": 5.585002899999381,
+        "iqr": 0.022529774985741824,
+        "q1": 5.5715824750077445,
+        "q3": 5.594112249993486,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.567109000010532,
+        "hd15iqr": 5.597148699991521,
+        "ops": 0.17911238422069467,
+        "total": 16.749260600001435,
+        "data": [5.585002899999381, 5.597148699991521, 5.567109000010532],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[64-19]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[64-19]",
+      "params": {
+        "chunk_size": 64,
+        "zstd_level": 19
+      },
+      "param": "64-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.977583700005198,
+        "max": 7.038220799993724,
+        "mean": 7.002873666666953,
+        "stddev": 0.03154480028072066,
+        "rounds": 3,
+        "median": 6.992816500001936,
+        "iqr": 0.0454778249913943,
+        "q1": 6.9813919000043825,
+        "q3": 7.026869724995777,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.977583700005198,
+        "hd15iqr": 7.038220799993724,
+        "ops": 0.1427985206644395,
+        "total": 21.008621000000858,
+        "data": [6.992816500001936, 7.038220799993724, 6.977583700005198],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-1]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-1]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 1
+      },
+      "param": "128-1",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.3767310999974143,
+        "max": 0.4667100999940885,
+        "mean": 0.43489319999450043,
+        "stddev": 0.050444100569655356,
+        "rounds": 3,
+        "median": 0.46123839999199845,
+        "iqr": 0.06748424999750569,
+        "q1": 0.3978579249960603,
+        "q3": 0.465342174993566,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.3767310999974143,
+        "hd15iqr": 0.4667100999940885,
+        "ops": 2.299415120798959,
+        "total": 1.3046795999835012,
+        "data": [0.3767310999974143, 0.46123839999199845, 0.4667100999940885],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-2]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-2]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 2
+      },
+      "param": "128-2",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.4392504999996163,
+        "max": 0.4603610999911325,
+        "mean": 0.4532839333308705,
+        "stddev": 0.012153460103975314,
+        "rounds": 3,
+        "median": 0.46024020000186283,
+        "iqr": 0.015832949993637158,
+        "q1": 0.44449792500017793,
+        "q3": 0.4603308749938151,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.4392504999996163,
+        "hd15iqr": 0.4603610999911325,
+        "ops": 2.206122755447542,
+        "total": 1.3598517999926116,
+        "data": [0.46024020000186283, 0.4603610999911325, 0.4392504999996163],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-3]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-3]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 3
+      },
+      "param": "128-3",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.48786069999914616,
+        "max": 0.5084168000030331,
+        "mean": 0.495694766669961,
+        "stddev": 0.011115641025642851,
+        "rounds": 3,
+        "median": 0.4908068000077037,
+        "iqr": 0.015417075002915226,
+        "q1": 0.48859722500128555,
+        "q3": 0.5040143000042008,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.48786069999914616,
+        "hd15iqr": 0.5084168000030331,
+        "ops": 2.0173705014437058,
+        "total": 1.487084300009883,
+        "data": [0.48786069999914616, 0.5084168000030331, 0.4908068000077037],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-4]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-4]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 4
+      },
+      "param": "128-4",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.1126184000022477,
+        "max": 1.1266850999963935,
+        "mean": 1.1203922666657793,
+        "stddev": 0.0071493431153663075,
+        "rounds": 3,
+        "median": 1.121873299998697,
+        "iqr": 0.01055002499560942,
+        "q1": 1.11493212500136,
+        "q3": 1.1254821499969694,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.1126184000022477,
+        "hd15iqr": 1.1266850999963935,
+        "ops": 0.8925445397583298,
+        "total": 3.361176799997338,
+        "data": [1.1266850999963935, 1.1126184000022477, 1.121873299998697],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-5]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-5]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 5
+      },
+      "param": "128-5",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.8993765999912284,
+        "max": 0.9047064000042155,
+        "mean": 0.9026854999974603,
+        "stddev": 0.002888927144044676,
+        "rounds": 3,
+        "median": 0.9039734999969369,
+        "iqr": 0.00399735000974033,
+        "q1": 0.9005258249926555,
+        "q3": 0.9045231750023959,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.8993765999912284,
+        "hd15iqr": 0.9047064000042155,
+        "ops": 1.1078055424650264,
+        "total": 2.708056499992381,
+        "data": [0.9039734999969369, 0.8993765999912284, 0.9047064000042155],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-6]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-6]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 6
+      },
+      "param": "128-6",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 0.911930600006599,
+        "max": 0.9663417999981903,
+        "mean": 0.9334351333333567,
+        "stddev": 0.028942203693320925,
+        "rounds": 3,
+        "median": 0.922032999995281,
+        "iqr": 0.040808399993693456,
+        "q1": 0.9144562000037695,
+        "q3": 0.9552645999974629,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 0.911930600006599,
+        "hd15iqr": 0.9663417999981903,
+        "ops": 1.0713117219285886,
+        "total": 2.80030540000007,
+        "data": [0.9663417999981903, 0.922032999995281, 0.911930600006599],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-7]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-7]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 7
+      },
+      "param": "128-7",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.558176699996693,
+        "max": 1.5786126000020886,
+        "mean": 1.5704864333335233,
+        "stddev": 0.010841271826150927,
+        "rounds": 3,
+        "median": 1.5746700000017881,
+        "iqr": 0.015326925004046643,
+        "q1": 1.5623000249979668,
+        "q3": 1.5776269500020135,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.558176699996693,
+        "hd15iqr": 1.5786126000020886,
+        "ops": 0.636745392239648,
+        "total": 4.71145930000057,
+        "data": [1.5786126000020886, 1.5746700000017881, 1.558176699996693],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-8]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-8]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 8
+      },
+      "param": "128-8",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 1.7009870000038063,
+        "max": 1.7282303999963915,
+        "mean": 1.716192833337118,
+        "stddev": 0.013895292227130833,
+        "rounds": 3,
+        "median": 1.719361100011156,
+        "iqr": 0.020432549994438887,
+        "q1": 1.7055805250056437,
+        "q3": 1.7260130750000826,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 1.7009870000038063,
+        "hd15iqr": 1.7282303999963915,
+        "ops": 0.5826851042464215,
+        "total": 5.148578500011354,
+        "data": [1.719361100011156, 1.7009870000038063, 1.7282303999963915],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-9]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-9]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 9
+      },
+      "param": "128-9",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 2.237959000005503,
+        "max": 2.2409599000093294,
+        "mean": 2.2396245000030226,
+        "stddev": 0.0015274405754037881,
+        "rounds": 3,
+        "median": 2.2399545999942347,
+        "iqr": 0.0022506750028696842,
+        "q1": 2.238457900002686,
+        "q3": 2.2407085750055558,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 2.237959000005503,
+        "hd15iqr": 2.2409599000093294,
+        "ops": 0.4465034205504764,
+        "total": 6.718873500009067,
+        "data": [2.2409599000093294, 2.237959000005503, 2.2399545999942347],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-10]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-10]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 10
+      },
+      "param": "128-10",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.0579901000019163,
+        "max": 3.0766893999971217,
+        "mean": 3.069557666667,
+        "stddev": 0.010108086767996169,
+        "rounds": 3,
+        "median": 3.0739935000019614,
+        "iqr": 0.014024474996404024,
+        "q1": 3.0619909500019276,
+        "q3": 3.0760154249983316,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.0579901000019163,
+        "hd15iqr": 3.0766893999971217,
+        "ops": 0.32577983820249395,
+        "total": 9.208673000001,
+        "data": [3.0739935000019614, 3.0579901000019163, 3.0766893999971217],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-11]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-11]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 11
+      },
+      "param": "128-11",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.462355600000592,
+        "max": 3.4644725999969523,
+        "mean": 3.463245866664996,
+        "stddev": 0.001097875042947982,
+        "rounds": 3,
+        "median": 3.462909399997443,
+        "iqr": 0.0015877499972702935,
+        "q1": 3.4624940499998047,
+        "q3": 3.464081799997075,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.462355600000592,
+        "hd15iqr": 3.4644725999969523,
+        "ops": 0.2887464645884269,
+        "total": 10.389737599994987,
+        "data": [3.462909399997443, 3.462355600000592, 3.4644725999969523],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-12]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-12]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 12
+      },
+      "param": "128-12",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 3.5731067000015173,
+        "max": 3.592095200001495,
+        "mean": 3.582725100000971,
+        "stddev": 0.009496684828369802,
+        "rounds": 3,
+        "median": 3.5829733999999007,
+        "iqr": 0.014241374999983236,
+        "q1": 3.575573375001113,
+        "q3": 3.5898147500010964,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 3.5731067000015173,
+        "hd15iqr": 3.592095200001495,
+        "ops": 0.2791171446560968,
+        "total": 10.748175300002913,
+        "data": [3.5829733999999007, 3.5731067000015173, 3.592095200001495],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-13]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-13]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 13
+      },
+      "param": "128-13",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.728488799999468,
+        "max": 4.781689499999629,
+        "mean": 4.755750933332213,
+        "stddev": 0.026625035054718138,
+        "rounds": 3,
+        "median": 4.757074499997543,
+        "iqr": 0.03990052500012098,
+        "q1": 4.735635224998987,
+        "q3": 4.775535749999108,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.728488799999468,
+        "hd15iqr": 4.781689499999629,
+        "ops": 0.21027173500428242,
+        "total": 14.26725279999664,
+        "data": [4.781689499999629, 4.728488799999468, 4.757074499997543],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-14]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-14]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 14
+      },
+      "param": "128-14",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 4.882053099994664,
+        "max": 4.918474000005517,
+        "mean": 4.9048818000010215,
+        "stddev": 0.019889826259005705,
+        "rounds": 3,
+        "median": 4.914118300002883,
+        "iqr": 0.027315675008139806,
+        "q1": 4.890069399996719,
+        "q3": 4.917385075004859,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 4.882053099994664,
+        "hd15iqr": 4.918474000005517,
+        "ops": 0.20387851140465643,
+        "total": 14.714645400003064,
+        "data": [4.918474000005517, 4.882053099994664, 4.914118300002883],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-15]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-15]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 15
+      },
+      "param": "128-15",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 5.49501820000296,
+        "max": 5.518531300011091,
+        "mean": 5.505601933342405,
+        "stddev": 0.01193075709184162,
+        "rounds": 3,
+        "median": 5.503256300013163,
+        "iqr": 0.017634825006098254,
+        "q1": 5.497077725005511,
+        "q3": 5.514712550011609,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 5.49501820000296,
+        "hd15iqr": 5.518531300011091,
+        "ops": 0.18163318236720183,
+        "total": 16.516805800027214,
+        "data": [5.49501820000296, 5.503256300013163, 5.518531300011091],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-16]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-16]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 16
+      },
+      "param": "128-16",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 6.735094600007869,
+        "max": 6.884405599994352,
+        "mean": 6.7980296333310735,
+        "stddev": 0.07736634731025632,
+        "rounds": 3,
+        "median": 6.774588699991,
+        "iqr": 0.11198324998986209,
+        "q1": 6.744968125003652,
+        "q3": 6.856951374993514,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 6.735094600007869,
+        "hd15iqr": 6.884405599994352,
+        "ops": 0.14710144761607846,
+        "total": 20.39408889999322,
+        "data": [6.735094600007869, 6.884405599994352, 6.774588699991],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-17]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-17]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 17
+      },
+      "param": "128-17",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 7.673737999997684,
+        "max": 7.780380199998035,
+        "mean": 7.7178951333335135,
+        "stddev": 0.05563339429069974,
+        "rounds": 3,
+        "median": 7.699567200004822,
+        "iqr": 0.07998165000026347,
+        "q1": 7.680195299999468,
+        "q3": 7.760176949999732,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 7.673737999997684,
+        "hd15iqr": 7.780380199998035,
+        "ops": 0.12956900589138737,
+        "total": 23.15368540000054,
+        "data": [7.780380199998035, 7.699567200004822, 7.673737999997684],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-18]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-18]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 18
+      },
+      "param": "128-18",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 9.49666889999935,
+        "max": 9.589841000008164,
+        "mean": 9.554727933335622,
+        "stddev": 0.050647291088595725,
+        "rounds": 3,
+        "median": 9.577673899999354,
+        "iqr": 0.06987907500661095,
+        "q1": 9.51692014999935,
+        "q3": 9.586799225005961,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 9.49666889999935,
+        "hd15iqr": 9.589841000008164,
+        "ops": 0.10466022758336072,
+        "total": 28.664183800006867,
+        "data": [9.49666889999935, 9.577673899999354, 9.589841000008164],
+        "iterations": 1
+      }
+    },
+    {
+      "group": "write",
+      "name": "test_write_zstd[128-19]",
+      "fullname": "tests/benchmarks/test_write_tensorstore_benchmark.py::test_write_zstd[128-19]",
+      "params": {
+        "chunk_size": 128,
+        "zstd_level": 19
+      },
+      "param": "128-19",
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 5,
+        "max_time": 1.0,
+        "min_time": 5e-6,
+        "warmup": false
+      },
+      "stats": {
+        "min": 10.338777500001015,
+        "max": 10.590049699996598,
+        "mean": 10.463094466666613,
+        "stddev": 0.12565687391026154,
+        "rounds": 3,
+        "median": 10.460456200002227,
+        "iqr": 0.1884541499966872,
+        "q1": 10.369197175001318,
+        "q3": 10.557651324998005,
+        "iqr_outliers": 0,
+        "stddev_outliers": 1,
+        "outliers": "1;0",
+        "ld15iqr": 10.338777500001015,
+        "hd15iqr": 10.590049699996598,
+        "ops": 0.09557402001729084,
+        "total": 31.38928339999984,
+        "data": [10.338777500001015, 10.460456200002227, 10.590049699996598],
+        "iterations": 1
+      }
+    }
+  ],
+  "datetime": "2025-05-02T15:40:03.883651+00:00",
+  "version": "5.1.0"
+}


### PR DESCRIPTION
Adds example `zarr-python-v2`, `zarr-python-v3` and `tensorstore` benchmark jsons from a run with the full-size image.