### PR TITLE
Plot generation

### DIFF
--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -94,7 +94,10 @@ def plot_relplot_benchmarks(
         plot_name = output_filename
     else:
         facet_kws = dict(sharex=True, sharey=True)
-        col_wrap = 3
+        if len(data[col].unique()) < 3:
+            col_wrap = 2
+        else:
+            col_wrap = 3
         plot_name = output_filename + "_subplots"
 
     graph = sns.relplot(
@@ -297,6 +300,30 @@ def create_read_write_plots_for_package(
     write = package_benchmarks[package_benchmarks.group == "write"]
     read = package_benchmarks[package_benchmarks.group == "read"]
 
+    plot_relplot_benchmarks(
+        write,
+        x_axis="stats.mean",
+        y_axis="compression_ratio",
+        hue="compressor",
+        size="compression_level",
+        col="chunk_size",
+        title=f"{package}_chunk_size_all",
+        sub_dir="write",
+        output_filename=f"{package}_chunk_size_all",
+    )
+
+    plot_relplot_benchmarks(
+        read,
+        x_axis="stats.mean",
+        y_axis="compression_ratio",
+        hue="compressor",
+        size="compression_level",
+        col="chunk_size",
+        title=f"{package}_chunk_size_all",
+        sub_dir="read",
+        output_filename=f"{package}_chunk_size_all",
+    )
+
     write_chunks_128 = write[write.chunk_size == 128]
     read_chunks_128 = read[read.chunk_size == 128]
 
@@ -306,9 +333,9 @@ def create_read_write_plots_for_package(
         y_axis="compression_ratio",
         hue="compressor",
         size="compression_level",
-        title=package,
+        title=f"{package}_chunk_size128",
         sub_dir="write",
-        output_filename=package,
+        output_filename=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
@@ -317,27 +344,27 @@ def create_read_write_plots_for_package(
         y_axis="compression_ratio",
         hue="compressor",
         size="compression_level",
-        title=package,
+        title=f"{package}_chunk_size128",
         sub_dir="read",
-        output_filename=package,
+        output_filename=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
         write_chunks_128,
         x_axis="stats.mean",
-        y_axis="compression_level",
+        y_axis="compression_ratio",
         col="compressor",
         sub_dir="write",
-        output_filename=package,
+        output_filename=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
         read_chunks_128,
         x_axis="stats.mean",
-        y_axis="compression_level",
+        y_axis="compression_ratio",
         col="compressor",
         sub_dir="read",
-        output_filename=package,
+        output_filename=f"{package}_chunk_size128",
     )
 
 

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import seaborn as sns
+from matplotlib import pyplot as plt
 
 from zarr_benchmarks import utils
 
@@ -153,6 +154,7 @@ def get_output_path(benchmarks_df: pd.DataFrame, sub_dir: str, plot_name: str) -
 def save_plot_as_png(grid: sns.FacetGrid, output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     grid.savefig(output_path, format="png", dpi=300)
+    plt.close()
 
 
 def create_shuffle_plots(

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -157,6 +157,38 @@ def save_plot_as_png(grid: sns.FacetGrid, output_path: Path) -> None:
     plt.close()
 
 
+def plot_catplot_benchmarks(
+    data: pd.DataFrame,
+    *,
+    x_axis: str,
+    y_axis: str,
+    sub_dir: str,
+    output_filename: str,
+    title: str | None = None,
+    hue: str | None = None,
+) -> None:
+    graph = sns.catplot(
+        data=data,
+        x=x_axis,
+        y=y_axis,
+        hue=hue,
+        kind="bar",
+        height=4,
+        aspect=1.5,
+    )
+    x_axis_label, y_axis_label = get_axis_labels(data, x_axis, y_axis)
+    graph.set_axis_labels(x_axis_label, y_axis_label)
+
+    if title is not None:
+        graph.figure.suptitle(title)
+        graph.figure.subplots_adjust(top=0.9)
+
+    save_plot_as_png(
+        graph,
+        get_output_path(data, sub_dir, output_filename),
+    )
+
+
 def create_shuffle_plots(
     benchmarks_df: pd.DataFrame,
 ) -> None:
@@ -170,49 +202,31 @@ def create_shuffle_plots(
     write = shuffle_benchmarks[shuffle_benchmarks.group == "write"]
     read = shuffle_benchmarks[shuffle_benchmarks.group == "read"]
 
-    graph = sns.catplot(
+    plot_catplot_benchmarks(
         data=read,
-        x="blosc_shuffle",
-        y="compression_ratio",
+        x_axis="blosc_shuffle",
+        y_axis="compression_ratio",
+        sub_dir=sub_dir,
+        output_filename="compression_ratio",
         hue="package",
-        kind="bar",
-        height=4,
-        aspect=1.5,
     )
 
-    save_plot_as_png(
-        graph,
-        get_output_path(shuffle_benchmarks, sub_dir, "compression_ratio"),
-    )
-
-    graph = sns.catplot(
+    plot_catplot_benchmarks(
         data=write,
-        x="blosc_shuffle",
-        y="stats.mean",
+        x_axis="blosc_shuffle",
+        y_axis="stats.mean",
+        sub_dir=sub_dir,
+        output_filename="write",
         hue="package",
-        kind="bar",
-        height=4,
-        aspect=1.5,
     )
 
-    save_plot_as_png(
-        graph,
-        get_output_path(shuffle_benchmarks, sub_dir, "write"),
-    )
-
-    graph = sns.catplot(
+    plot_catplot_benchmarks(
         data=read,
-        x="blosc_shuffle",
-        y="stats.mean",
+        x_axis="blosc_shuffle",
+        y_axis="stats.mean",
+        sub_dir=sub_dir,
+        output_filename="read",
         hue="package",
-        kind="bar",
-        height=4,
-        aspect=1.5,
-    )
-
-    save_plot_as_png(
-        graph,
-        get_output_path(shuffle_benchmarks, sub_dir, "read"),
     )
 
 

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -127,12 +127,12 @@ def plot_relplot_benchmarks(
         facet_kws=facet_kws,
         col_wrap=col_wrap,
     )
-    x_axis_label, y_axis_label = get_axis_labels(data, x_axis, y_axis)
+    x_axis_label, y_axis_label = get_axis_labels(data, x_axis=x_axis, y_axis=y_axis)
     graph.set_axis_labels(x_axis_label, y_axis_label)
 
     if title is not None:
         graph.figure.suptitle(title)
-        graph.figure.subplots_adjust(top=0.9)
+        graph.tight_layout()
 
     save_plot_as_png(
         graph,
@@ -141,7 +141,7 @@ def plot_relplot_benchmarks(
 
 
 def get_axis_labels(
-    benchmark_df: pd.DataFrame, x_axis: str, y_axis: str
+    benchmark_df: pd.DataFrame, *, x_axis: str, y_axis: str
 ) -> tuple[str, str]:
     group = benchmark_df.group.unique()
     if len(group) != 1:
@@ -208,12 +208,12 @@ def plot_catplot_benchmarks(
         height=4,
         aspect=1.5,
     )
-    x_axis_label, y_axis_label = get_axis_labels(data, x_axis, y_axis)
+    x_axis_label, y_axis_label = get_axis_labels(data, x_axis=x_axis, y_axis=y_axis)
     graph.set_axis_labels(x_axis_label, y_axis_label)
 
     if title is not None:
         graph.figure.suptitle(title)
-        graph.figure.subplots_adjust(top=0.9)
+        graph.tight_layout()
 
     save_plot_as_png(
         graph,

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -81,8 +81,8 @@ def plot_relplot_benchmarks(
     *,
     x_axis: str,
     y_axis: str,
-    sub_dir: str,
-    output_filename: str,
+    sub_dir_name: str,
+    plot_name: str,
     title: str | None = None,
     hue: str | None = None,
     size: str | None = None,
@@ -91,14 +91,14 @@ def plot_relplot_benchmarks(
     if col is None:
         facet_kws = None
         col_wrap = None
-        plot_name = output_filename
+        plot_name = plot_name
     else:
         facet_kws = dict(sharex=True, sharey=True)
         if len(data[col].unique()) < 3:
             col_wrap = 2
         else:
             col_wrap = 3
-        plot_name = output_filename + "_subplots"
+        plot_name = plot_name + "_subplots"
 
     graph = sns.relplot(
         data=data,
@@ -122,7 +122,7 @@ def plot_relplot_benchmarks(
 
     save_plot_as_png(
         graph,
-        get_output_path(data, sub_dir, plot_name),
+        get_output_path(data, sub_dir_name, plot_name),
     )
 
 
@@ -146,11 +146,13 @@ def get_axis_labels(
     return x_axis_label, y_axis_label
 
 
-def get_output_path(benchmarks_df: pd.DataFrame, sub_dir: str, plot_name: str) -> Path:
+def get_output_path(
+    benchmarks_df: pd.DataFrame, sub_dir_name: str, plot_name: str
+) -> Path:
     machine_info = benchmarks_df["machine"].iloc[0]
     date = datetime.now().strftime("%Y-%m-%d")
 
-    plots_dir = Path(__file__).parents[2] / "data" / "plots" / sub_dir
+    plots_dir = Path(__file__).parents[2] / "data" / "plots" / sub_dir_name
     return plots_dir / f"{plot_name}_{date}_{machine_info}.png"
 
 
@@ -165,8 +167,8 @@ def plot_catplot_benchmarks(
     *,
     x_axis: str,
     y_axis: str,
-    sub_dir: str,
-    output_filename: str,
+    sub_dir_name: str,
+    plot_name: str,
     title: str | None = None,
     hue: str | None = None,
 ) -> None:
@@ -188,7 +190,7 @@ def plot_catplot_benchmarks(
 
     save_plot_as_png(
         graph,
-        get_output_path(data, sub_dir, output_filename),
+        get_output_path(data, sub_dir_name, plot_name),
     )
 
 
@@ -200,7 +202,7 @@ def create_shuffle_plots(
         & (benchmarks_df.compression_level == 3)
         & (benchmarks_df.chunk_size == 128)
     ]
-    sub_dir = "shuffle"
+    sub_dir_name = "shuffle"
 
     write = shuffle_benchmarks[shuffle_benchmarks.group == "write"]
     read = shuffle_benchmarks[shuffle_benchmarks.group == "read"]
@@ -209,8 +211,8 @@ def create_shuffle_plots(
         data=read,
         x_axis="blosc_shuffle",
         y_axis="compression_ratio",
-        sub_dir=sub_dir,
-        output_filename="compression_ratio",
+        sub_dir_name=sub_dir_name,
+        plot_name="compression_ratio",
         hue="package",
     )
 
@@ -218,8 +220,8 @@ def create_shuffle_plots(
         data=write,
         x_axis="blosc_shuffle",
         y_axis="stats.mean",
-        sub_dir=sub_dir,
-        output_filename="write",
+        sub_dir_name=sub_dir_name,
+        plot_name="write",
         hue="package",
     )
 
@@ -227,8 +229,8 @@ def create_shuffle_plots(
         data=read,
         x_axis="blosc_shuffle",
         y_axis="stats.mean",
-        sub_dir=sub_dir,
-        output_filename="read",
+        sub_dir_name=sub_dir_name,
+        plot_name="read",
         hue="package",
     )
 
@@ -250,8 +252,8 @@ def create_chunk_size_plots(
         x_axis="chunk_size",
         y_axis="compression_ratio",
         col="package",
-        sub_dir="chunk_size",
-        output_filename="compression_ratio",
+        sub_dir_name="chunk_size",
+        plot_name="compression_ratio",
     )
 
     plot_relplot_benchmarks(
@@ -259,8 +261,8 @@ def create_chunk_size_plots(
         y_axis="stats.mean",
         x_axis="chunk_size",
         col="package",
-        sub_dir="chunk_size",
-        output_filename="write",
+        sub_dir_name="chunk_size",
+        plot_name="write",
     )
 
     plot_relplot_benchmarks(
@@ -269,8 +271,8 @@ def create_chunk_size_plots(
         x_axis="chunk_size",
         hue="package",
         title="chunk_size_write_all",
-        sub_dir="chunk_size",
-        output_filename="write",
+        sub_dir_name="chunk_size",
+        plot_name="write",
     )
 
     plot_relplot_benchmarks(
@@ -278,8 +280,8 @@ def create_chunk_size_plots(
         y_axis="stats.mean",
         x_axis="chunk_size",
         col="package",
-        sub_dir="chunk_size",
-        output_filename="read",
+        sub_dir_name="chunk_size",
+        plot_name="read",
     )
 
     plot_relplot_benchmarks(
@@ -288,8 +290,8 @@ def create_chunk_size_plots(
         x_axis="chunk_size",
         hue="package",
         title="chunk_size_read_all",
-        sub_dir="chunk_size",
-        output_filename="read",
+        sub_dir_name="chunk_size",
+        plot_name="read",
     )
 
 
@@ -308,8 +310,8 @@ def create_read_write_plots_for_package(
         size="compression_level",
         col="chunk_size",
         title=f"{package}_chunk_size_all",
-        sub_dir="write",
-        output_filename=f"{package}_chunk_size_all",
+        sub_dir_name="write",
+        plot_name=f"{package}_chunk_size_all",
     )
 
     plot_relplot_benchmarks(
@@ -320,8 +322,8 @@ def create_read_write_plots_for_package(
         size="compression_level",
         col="chunk_size",
         title=f"{package}_chunk_size_all",
-        sub_dir="read",
-        output_filename=f"{package}_chunk_size_all",
+        sub_dir_name="read",
+        plot_name=f"{package}_chunk_size_all",
     )
 
     write_chunks_128 = write[write.chunk_size == 128]
@@ -334,8 +336,8 @@ def create_read_write_plots_for_package(
         hue="compressor",
         size="compression_level",
         title=f"{package}_chunk_size128",
-        sub_dir="write",
-        output_filename=f"{package}_chunk_size128",
+        sub_dir_name="write",
+        plot_name=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
@@ -345,8 +347,8 @@ def create_read_write_plots_for_package(
         hue="compressor",
         size="compression_level",
         title=f"{package}_chunk_size128",
-        sub_dir="read",
-        output_filename=f"{package}_chunk_size128",
+        sub_dir_name="read",
+        plot_name=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
@@ -354,8 +356,8 @@ def create_read_write_plots_for_package(
         x_axis="stats.mean",
         y_axis="compression_ratio",
         col="compressor",
-        sub_dir="write",
-        output_filename=f"{package}_chunk_size128",
+        sub_dir_name="write",
+        plot_name=f"{package}_chunk_size128",
     )
 
     plot_relplot_benchmarks(
@@ -363,8 +365,8 @@ def create_read_write_plots_for_package(
         x_axis="stats.mean",
         y_axis="compression_ratio",
         col="compressor",
-        sub_dir="read",
-        output_filename=f"{package}_chunk_size128",
+        sub_dir_name="read",
+        plot_name=f"{package}_chunk_size128",
     )
 
 
@@ -394,8 +396,8 @@ def create_read_write_plots(benchmarks_df: pd.DataFrame) -> None:
         col="package",
         hue="compressor",
         size="compression_level",
-        sub_dir="read",
-        output_filename="all_packages",
+        sub_dir_name="read",
+        plot_name="all_packages",
     )
 
     plot_relplot_benchmarks(
@@ -405,8 +407,8 @@ def create_read_write_plots(benchmarks_df: pd.DataFrame) -> None:
         col="package",
         hue="compressor",
         size="compression_level",
-        sub_dir="write",
-        output_filename="all_packages",
+        sub_dir_name="write",
+        plot_name="all_packages",
     )
 
 

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -88,6 +88,20 @@ def plot_relplot_benchmarks(
     size: str | None = None,
     col: str | None = None,
 ) -> None:
+    """Generate a scatter plot using seaborn's relplot function with a dataframe as input.
+    Calls a function to save the plot as a PNG file.
+
+    Args:
+        data (pd.DataFrame): Contains the data to be plotted.
+        x_axis (str): name of dataframe column to be used for x-axis
+        y_axis (str): name of dataframe column to be used for y-axis
+        sub_dir_name (str): name of the sub-directory where the plot will be saved within data/plots
+        plot_name (str): name of the plot which will be used for the start of the final filename
+        title (str | None, optional): title of the plot. Defaults to None.
+        hue (str | None, optional): name of dataframe column to be used for the colours in the plot. Defaults to None.
+        size (str | None, optional): name of dataframe column to be used for size of datapoints. Defaults to None.
+        col (str | None, optional): name of dataframe column to be used for splitting into subplots. Defaults to None.
+    """
     if col is None:
         facet_kws = None
         col_wrap = None
@@ -172,6 +186,19 @@ def plot_catplot_benchmarks(
     title: str | None = None,
     hue: str | None = None,
 ) -> None:
+    """Generate a bar plot using seaborn's catplot function with a dataframe as input.
+    Calls a function to save the plot as a PNG file.
+
+
+    Args:
+        data (pd.DataFrame): Contains the data to be plotted.
+        x_axis (str): name of dataframe column to be used for x-axis
+        y_axis (str): name of dataframe column to be used for y-axis
+        sub_dir_name (str): name of the sub-directory where the plot will be saved within data/plots
+        plot_name (str): name of the plot which will be used for the start of the final filename
+        title (str | None, optional): title of the plot. Defaults to None.
+        hue (str | None, optional): name of dataframe column to be used for the colours in the plot. Defaults to None.
+    """
     graph = sns.catplot(
         data=data,
         x=x_axis,

--- a/src/zarr_benchmarks/parse_json_for_plots.py
+++ b/src/zarr_benchmarks/parse_json_for_plots.py
@@ -161,6 +161,68 @@ def save_plot_as_png(grid: sns.FacetGrid, output_path: Path) -> None:
     grid.savefig(output_path, format="png", dpi=300)
 
 
+def create_shuffle_plots(
+    benchmarks_df: pd.DataFrame,
+) -> None:
+    shuffle_benchmarks = benchmarks_df[
+        (benchmarks_df.compressor == "blosc-zstd")
+        & (benchmarks_df.compression_level == 3)
+        & (benchmarks_df.chunk_size == 128)
+    ]
+
+    graph = sns.catplot(
+        data=shuffle_benchmarks,
+        x="blosc_shuffle",
+        y="compression_ratio",
+        hue="package",
+        kind="bar",
+        height=4,
+        aspect=1.5,
+    )
+
+    save_plot_as_png(
+        graph,
+        Path(__file__).parents[2]
+        / "data"
+        / "plots"
+        / "blosc_shuffle_compression_ratio.png",
+    )
+
+    write = shuffle_benchmarks[shuffle_benchmarks.group == "write"]
+
+    graph = sns.catplot(
+        data=write,
+        x="blosc_shuffle",
+        y="stats.mean",
+        hue="package",
+        kind="bar",
+        height=4,
+        aspect=1.5,
+    )
+
+    save_plot_as_png(
+        graph,
+        Path(__file__).parents[2] / "data" / "plots" / "blosc_shuffle_write.png",
+    )
+
+    read = shuffle_benchmarks[shuffle_benchmarks.group == "read"]
+
+    graph = sns.catplot(
+        data=read,
+        x="blosc_shuffle",
+        y="stats.mean",
+        hue="package",
+        kind="bar",
+        height=4,
+        aspect=1.5,
+    )
+
+    save_plot_as_png(
+        graph,
+        Path(__file__).parents[2] / "data" / "plots" / "blosc_shuffle_read.png",
+    )
+
+
 def create_chunk_size_plots(
     benchmarks_df: pd.DataFrame,
 ) -> None:
@@ -325,6 +387,7 @@ def create_all_plots(json_ids: list[str] | None = None) -> None:
 
     # create_read_write_plots(benchmarks_df, zarr_v2_path)
     create_chunk_size_plots(benchmarks_df)
+    create_shuffle_plots(benchmarks_df)
 
     print("Plotting finished 🕺")
     print("Plots saved to 'data/plots'")


### PR DESCRIPTION
Closes #33 

In this PR, code has been written to generate plots as specified in #33 with subdirectories within the `plots` folder for:

- chunk_size
- read
- shuffle
- write

There are `create...plots` functions which call either:

- `plot_relplot_benchmarks` which can plot a single plot or subplots, sets the labels and saves the figure before closing the figure
- `plot_catplot_benchmarks` which plots bar plot then sets the labels and saves etc.

This can be dealt with in a separate PR, but there are 2 examples of plots that could be modified:
- gzip outliers in a read plot `data/plots/read/zarr_python_3_chunk_size_all_subplots_2025-05-09_Windows.png`
![image](https://github.com/user-attachments/assets/9e02d6b7-4dab-48cb-b78b-265a56856434)

- zstd outliers in a write plot `data/plots/write/zarr_python_2_chunk_size_all_subplots_2025-05-09_Windows.png`
![image](https://github.com/user-attachments/assets/9d9f5220-fc39-4f2e-ac8b-e387b092b588)

Suggested solutions are to:
- log scale the mean write/read time (s)
- Removing the outlier compressor in another plot
- Have a separate plot with only blosc compressors
