### PR TITLE
Add benchmarks runs with no compressor

### DIFF
--- a/src/zarr_benchmarks/create_plots.py
+++ b/src/zarr_benchmarks/create_plots.py
@@ -25,7 +25,7 @@ def prepare_benchmarks_dataframe(json_dict: dict) -> pd.DataFrame:
     ].max(axis=1)
 
     # create column for type of compressor
-    benchmark_df["compressor"] = ""
+    benchmark_df["compressor"] = None
     blosc_compressors = (
         "blosc-"
         + benchmark_df.loc[
@@ -37,6 +37,13 @@ def prepare_benchmarks_dataframe(json_dict: dict) -> pd.DataFrame:
     )
     benchmark_df.loc[~benchmark_df["params.gzip_level"].isna(), "compressor"] = "gzip"
     benchmark_df.loc[~benchmark_df["params.zstd_level"].isna(), "compressor"] = "zstd"
+    benchmark_df.loc[~benchmark_df["params.no_compressor"].isna(), "compressor"] = (
+        "none"
+    )
+
+    # Give 'no compressor' rows an arbitrary compression level, so they can be shown on plots where point size is
+    # related to compression level
+    benchmark_df.loc[benchmark_df["compressor"] == "none", "compression_level"] = 10
 
     # remove un-needed columns
     stats_cols = [col for col in benchmark_df if col.startswith("stats")]

--- a/src/zarr_benchmarks/read_write_tensorstore.py
+++ b/src/zarr_benchmarks/read_write_tensorstore.py
@@ -40,7 +40,7 @@ def write_zarr_array(
     *,
     overwrite: bool,
     chunks: tuple[int],
-    compressor: dict,
+    compressor: dict | None,
     write_empty_chunks: bool = True,
 ) -> None:
     """Write the v2 zarr spec with tensorstore"""

--- a/src/zarr_benchmarks/read_write_zarr_v2.py
+++ b/src/zarr_benchmarks/read_write_zarr_v2.py
@@ -28,7 +28,7 @@ def write_zarr_array(
     *,
     overwrite: bool,
     chunks: tuple[int],
-    compressor: numcodecs.abc.Codec,
+    compressor: numcodecs.abc.Codec | None,
     write_empty_chunks: bool = True,
 ) -> None:
     if overwrite:

--- a/tests/benchmarks/benchmark_configs/chunk_size.json
+++ b/tests/benchmarks/benchmark_configs/chunk_size.json
@@ -7,5 +7,6 @@
   "blosc_shuffle": ["shuffle"],
   "blosc_cname": ["zstd"],
   "gzip_level": [],
-  "zstd_level": []
+  "zstd_level": [],
+  "no_compressor": false
 }

--- a/tests/benchmarks/benchmark_configs/dev.json
+++ b/tests/benchmarks/benchmark_configs/dev.json
@@ -4,5 +4,6 @@
   "blosc_shuffle": ["shuffle"],
   "blosc_cname": ["zstd"],
   "gzip_level": [1, 3],
-  "zstd_level": [1, 3]
+  "zstd_level": [1, 3],
+  "no_compressor": true
 }

--- a/tests/benchmarks/benchmark_configs/read_write.json
+++ b/tests/benchmarks/benchmark_configs/read_write.json
@@ -13,5 +13,6 @@
   "zstd_level": {
     "min": 1,
     "max": 19
-  }
+  },
+  "no_compressor": true
 }

--- a/tests/benchmarks/benchmark_configs/schema/benchmark.schema.json
+++ b/tests/benchmarks/benchmark_configs/schema/benchmark.schema.json
@@ -140,6 +140,10 @@
           "required": ["min", "max"]
         }
       ]
+    },
+    "no_compressor": {
+      "description": "Whether to run benchmarks with no compressor.",
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
@@ -149,6 +153,7 @@
     "blosc_shuffle",
     "blosc_cname",
     "gzip_level",
-    "zstd_level"
+    "zstd_level",
+    "no_compressor"
   ]
 }

--- a/tests/benchmarks/benchmark_configs/shuffle.json
+++ b/tests/benchmarks/benchmark_configs/shuffle.json
@@ -4,5 +4,6 @@
   "blosc_shuffle": ["bitshuffle", "shuffle", "noshuffle"],
   "blosc_cname": ["zstd"],
   "gzip_level": [],
-  "zstd_level": []
+  "zstd_level": [],
+  "no_compressor": false
 }

--- a/tests/benchmarks/test_read_tensorstore_benchmark.py
+++ b/tests/benchmarks/test_read_tensorstore_benchmark.py
@@ -87,3 +87,29 @@ def test_read_zstd(
         rounds=rounds,
         warmup_rounds=warmup_rounds,
     )
+
+
+@pytest.mark.benchmark(group="read")
+def test_read_no_compressor(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, no_compressor
+):
+    if not no_compressor:
+        pytest.skip("config didn't include no compressor")
+
+    read_write_tensorstore.write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressor=None,
+    )
+
+    compression_ratio = read_write_tensorstore.get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(
+        read_write_tensorstore.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/benchmarks/test_read_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_read_zarr_python_benchmark.py
@@ -91,3 +91,29 @@ def test_read_zstd(
         rounds=rounds,
         warmup_rounds=warmup_rounds,
     )
+
+
+@pytest.mark.benchmark(group="read")
+def test_read_no_compressor(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, no_compressor
+):
+    if not no_compressor:
+        pytest.skip("config didn't include no compressor")
+
+    read_write_zarr.write_zarr_array(
+        image=image,
+        store_path=store_path,
+        overwrite=True,
+        chunks=(chunk_size, chunk_size, chunk_size),
+        compressor=None,
+    )
+
+    compression_ratio = read_write_zarr.get_compression_ratio(store_path)
+    benchmark.extra_info["compression_ratio"] = compression_ratio
+
+    benchmark.pedantic(
+        read_write_zarr.read_zarr_array,
+        args=(store_path,),
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/benchmarks/test_write_tensorstore_benchmark.py
+++ b/tests/benchmarks/test_write_tensorstore_benchmark.py
@@ -86,3 +86,28 @@ def test_write_zstd(
         rounds=rounds,
         warmup_rounds=warmup_rounds,
     )
+
+
+@pytest.mark.benchmark(group="write")
+def test_write_no_compressor(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, no_compressor
+):
+    if not no_compressor:
+        pytest.skip("config didn't include no compressor")
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressor": None,
+        }
+
+    benchmark.pedantic(
+        read_write_tensorstore.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/benchmarks/test_write_zarr_python_benchmark.py
+++ b/tests/benchmarks/test_write_zarr_python_benchmark.py
@@ -90,3 +90,28 @@ def test_write_zstd(
         rounds=rounds,
         warmup_rounds=warmup_rounds,
     )
+
+
+@pytest.mark.benchmark(group="write")
+def test_write_no_compressor(
+    benchmark, image, rounds, warmup_rounds, store_path, chunk_size, no_compressor
+):
+    if not no_compressor:
+        pytest.skip("config didn't include no compressor")
+
+    def setup():
+        remove_output_dir(store_path)
+        return (), {
+            "image": image,
+            "store_path": store_path,
+            "overwrite": False,
+            "chunks": (chunk_size, chunk_size, chunk_size),
+            "compressor": None,
+        }
+
+    benchmark.pedantic(
+        read_write_zarr.write_zarr_array,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def store_path():
     return pathlib.Path("data/output/heart-example.zarr")
 
 
-def expand_min_max(config: dict) -> dict:
+def _expand_min_max(config: dict) -> dict:
     """Expand min/max keys in config to a list of the full range of values."""
 
     for key in ["chunk_size", "blosc_clevel", "gzip_level", "zstd_level"]:
@@ -87,7 +87,16 @@ def expand_min_max(config: dict) -> dict:
     return config
 
 
-def parse_config_files(config_name: str) -> list[dict]:
+def _parse_config_file(config_path: pathlib.Path) -> dict:
+    config = _expand_min_max(read_json_file(config_path))
+
+    # make bool 'no_compressor' a list, to match the other parameters (allows itertools.product to work)
+    config["no_compressor"] = [config["no_compressor"]]
+
+    return config
+
+
+def _parse_config_files(config_name: str) -> list[dict]:
     """Parse json config files. 'all' will parse every config in tests/benchmark_configs (except for dev, which contains
     a small set of parameters for development runs)."""
 
@@ -97,11 +106,11 @@ def parse_config_files(config_name: str) -> list[dict]:
     if config_name == "all":
         for config_file in configs_dir.glob("*.json"):
             if config_file.stem != "dev":
-                config = expand_min_max(read_json_file(config_file))
+                config = _parse_config_file(config_file)
                 configs.append(config)
     else:
         config_file = configs_dir / f"{config_name}.json"
-        config = expand_min_max(read_json_file(config_file))
+        config = _parse_config_file(config_file)
         configs.append(config)
 
     return configs
@@ -112,7 +121,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     once per test function, during the collection stage."""
 
     config_name = metafunc.config.getoption("config")
-    configs = parse_config_files(config_name)
+    configs = _parse_config_files(config_name)
 
     # keys from the config, that are used as arguments for this function
     used_config_keys = [key for key in configs[0] if key in metafunc.fixturenames]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def image(dev_image):
     test runs during development."""
 
     if dev_image:
-        return np.random.rand(100, 100, 100)
+        return np.random.rand(128, 128, 128)
 
     return get_image(
         image_dir_path=pathlib.Path(


### PR DESCRIPTION
Closes https://github.com/HEFTIEProject/zarr-benchmarks/issues/58

This PR adds benchmark runs with no compressor for each package (`zarr_python_v2`, `zarr_python_v2` and `tensorstore`)

- handled by a new line in the config: `no_compressor` = true/false
- added `no_compressor` as a separate benchmark function. This seemed to fit best with the existing structure where we have one benchmark function per compressor.
- changed dev image to size (128, 128, 128) to avoid compression ratios below 1

To test:
```
tox -- --dev-image --rounds=1 --warmup-rounds=0 --config=all
python src/zarr_benchmarks/create_plots.py
```

No compressor appears as another point on the plot:

![Screenshot 2025-05-16 093757](https://github.com/user-attachments/assets/e4c0da86-32ca-4d40-8da2-227a0804244a)

The main downside here is I had to give the 'no compressor' runs an arbitrary compression level so they would show up. This could be a bit confusing given the legend relates size to level (which no compressor doesn't really have). In future, we could consider changing this to a line or similar to make it clear it's different?
![Screenshot 2025-05-16 090150](https://github.com/user-attachments/assets/499e9997-0fb1-4513-bf9b-ade1c32dbe25)
