### PR TITLE
Small fixes for compatability with `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools"]
 
+
 [project]
 authors = [
     { email = "arc.collaborations@ucl.ac.uk", name = "Centre for Advanced Research Computing" },
@@ -15,7 +16,7 @@ description = "zarr benchmarks"
 license = { file = "LICENSE" }
 name = "zarr_benchmarks"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = "==3.13.*"
 version = "0.0.1"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,46 +4,29 @@ requires = ["setuptools"]
 
 [project]
 authors = [
-    {email = "arc.collaborations@ucl.ac.uk", name = "Centre for Advanced Research Computing"},
+    { email = "arc.collaborations@ucl.ac.uk", name = "Centre for Advanced Research Computing" },
 ]
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-dependencies = [
-    "imageio",
-    "pytest",
-    "pytest-benchmark",
-    "tox",
-    "jsonschema"
-]
+dependencies = ["imageio", "pytest", "pytest-benchmark", "tox", "jsonschema"]
 description = "zarr benchmarks"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 name = "zarr_benchmarks"
 readme = "README.md"
 requires-python = ">=3.11"
 version = "0.0.1"
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit",
-]
-plots = [
-    "matplotlib",
-    "seaborn",
-    "pandas",
-]
-tensorstore = [
-    "tensorstore==0.1.73",
-]
-zarr-python-v2 = [
-    "numcodecs==0.15.1",
-    "zarr==2.18.4",
-]
-zarr-python-v3 = [
-    "numcodecs==0.15.1",
-    "zarr==3.0.6",
-]
+dev = ["pre-commit"]
+plots = ["matplotlib", "seaborn", "pandas"]
+tensorstore = ["tensorstore==0.1.73"]
+zarr-python-v2 = ["numcodecs==0.15.1", "zarr==2.18.4"]
+zarr-python-v3 = ["numcodecs==0.15.1", "zarr==3.0.6"]
+
+[tool.uv]
+conflicts = [[{ extra = "zarr-python-v2" }, { extra = "zarr-python-v3" }]]
 
 [project.urls]
 Homepage = "https://github.com/HEFTIEProject/zarr-benchmarks"
@@ -53,10 +36,7 @@ Issues = "https://github.com/HEFTIEProject/zarr-benchmarks/issues"
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
-markers = [
-    "tensorstore",
-    "zarr_python",
-]
+markers = ["tensorstore", "zarr_python"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]


### PR DESCRIPTION
- Include conflicting extras metadata so `uv sync` works
- Also specify Python==3.13.*, since that's the version we have in the tox file