### PR TITLE
Download datasets from zenodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This will run all benchmarks via `zarr-python` version 2 + 3 and `tensorstore`
 with the example Human Organ Atlas image. All results will be saved as `.json`
 files to the `data/results` directory.
 
+Note: the first time this command is run, the required datasets will be
+downloaded from Zenodo and cached locally on your computer. Later runs will
+re-use this data, and should be faster.
+
 ### Specific config
 
 `--config=all` will use parameters from all configuration files under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-dependencies = ["imageio", "pytest", "pytest-benchmark", "tox", "jsonschema"]
+dependencies = ["imageio", "pytest", "pytest-benchmark", "tox", "jsonschema", "pooch"]
 description = "zarr benchmarks"
 license = { file = "LICENSE" }
 name = "zarr_benchmarks"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,18 +56,14 @@ def dev_image(request):
 
 @pytest.fixture(scope="session")
 def image(dev_image):
-    """If '--dev_image' isn't set, read the image from a series of jpeg. This process is quite slow, so we only do it once
-    per testing session. If '--dev_image' is set, use a small 100x100x100 numpy array instead - this is useful for quick
+    """If '--dev_image' isn't set, use the heart image from zenodo. This process is quite slow, so we only do it once
+    per testing session. If '--dev_image' is set, use a small 128x128x128 numpy array instead - this is useful for quick
     test runs during development."""
 
     if dev_image:
         return np.random.rand(128, 128, 128)
 
-    return get_image(
-        image_dir_path=pathlib.Path(
-            "data/input/_200.64um_LADAF-2021-17_heart_complete-organ_pag-0.10_0.03_jp2_"
-        )
-    )
+    return get_image()
 
 
 @pytest.fixture()

--- a/tests/tests/test_dataset_fetching.py
+++ b/tests/tests/test_dataset_fetching.py
@@ -1,0 +1,12 @@
+import pytest
+
+from zarr_benchmarks import utils
+
+pytestmark = [pytest.mark.tensorstore, pytest.mark.zarr_python]
+
+
+def test_heart_image():
+    """Check heart image is correctly fetched / cached from zenodo."""
+
+    image = utils.get_image()
+    assert image.shape == (806, 629, 629)


### PR DESCRIPTION
For https://github.com/HEFTIEProject/zarr-benchmarks/issues/73

This PR adds automatic download/caching of the heart dataset from zenodo with `pooch`. 

Test with:
```
tox -- --benchmark-only --rounds=1 --warmup-rounds=0
```

- Note: there's a [warning thrown from zarr-python v3](https://github.com/HEFTIEProject/zarr-benchmarks/issues/73#issuecomment-2922078043) at the moment, which needs a small change to the zarr metadata on zenodo
- I've also added a test to check the image is downloaded/cached correctly. We can remove this if it adds too much time to the CI.