### PR TITLE
Small plot cleanups

### DIFF
--- a/src/zarr_benchmarks/create_plots.py
+++ b/src/zarr_benchmarks/create_plots.py
@@ -258,49 +258,6 @@ def create_read_write_plots_for_package(
         plot_name=f"{package}_chunk_size_all",
     )
 
-    write_chunks_128 = write[write.chunk_size == 128]
-    read_chunks_128 = read[read.chunk_size == 128]
-
-    plot_relplot_benchmarks(
-        write_chunks_128,
-        x_axis="stats.mean",
-        y_axis="compression_ratio",
-        hue="compressor",
-        size="compression_level",
-        title=f"{package}_chunk_size128",
-        sub_dir_name="write",
-        plot_name=f"{package}_chunk_size128",
-    )
-
-    plot_relplot_benchmarks(
-        read_chunks_128,
-        x_axis="stats.mean",
-        y_axis="compression_ratio",
-        hue="compressor",
-        size="compression_level",
-        title=f"{package}_chunk_size128",
-        sub_dir_name="read",
-        plot_name=f"{package}_chunk_size128",
-    )
-
-    plot_relplot_benchmarks(
-        write_chunks_128,
-        x_axis="stats.mean",
-        y_axis="compression_ratio",
-        col="compressor",
-        sub_dir_name="write",
-        plot_name=f"{package}_chunk_size128",
-    )
-
-    plot_relplot_benchmarks(
-        read_chunks_128,
-        x_axis="stats.mean",
-        y_axis="compression_ratio",
-        col="compressor",
-        sub_dir_name="read",
-        plot_name=f"{package}_chunk_size128",
-    )
-
 
 def create_read_write_plots(benchmarks_df: pd.DataFrame) -> None:
     read_write_benchmarks = benchmarks_df[

--- a/src/zarr_benchmarks/create_plots.py
+++ b/src/zarr_benchmarks/create_plots.py
@@ -145,25 +145,19 @@ def create_chunk_size_plots(
         & (benchmarks_df.blosc_shuffle == "shuffle")
     ]
 
+    chunk_size_compression_ratio = chunk_size_benchmarks[
+        chunk_size_benchmarks.group == "compression_ratio"
+    ]
     chunk_size_write = chunk_size_benchmarks[chunk_size_benchmarks.group == "write"]
     chunk_size_read = chunk_size_benchmarks[chunk_size_benchmarks.group == "read"]
 
     plot_relplot_benchmarks(
-        chunk_size_read,
-        x_axis="chunk_size",
+        chunk_size_write,
         y_axis="compression_ratio",
-        col="package",
+        x_axis="chunk_size",
+        title="chunk_size_compression_ratio_all",
         sub_dir_name="chunk_size",
         plot_name="compression_ratio",
-    )
-
-    plot_relplot_benchmarks(
-        chunk_size_write,
-        y_axis="stats.mean",
-        x_axis="chunk_size",
-        col="package",
-        sub_dir_name="chunk_size",
-        plot_name="write",
     )
 
     plot_relplot_benchmarks(
@@ -174,15 +168,6 @@ def create_chunk_size_plots(
         title="chunk_size_write_all",
         sub_dir_name="chunk_size",
         plot_name="write",
-    )
-
-    plot_relplot_benchmarks(
-        chunk_size_read,
-        y_axis="stats.mean",
-        x_axis="chunk_size",
-        col="package",
-        sub_dir_name="chunk_size",
-        plot_name="read",
     )
 
     plot_relplot_benchmarks(

--- a/src/zarr_benchmarks/create_plots.py
+++ b/src/zarr_benchmarks/create_plots.py
@@ -145,9 +145,6 @@ def create_chunk_size_plots(
         & (benchmarks_df.blosc_shuffle == "shuffle")
     ]
 
-    chunk_size_compression_ratio = chunk_size_benchmarks[
-        chunk_size_benchmarks.group == "compression_ratio"
-    ]
     chunk_size_write = chunk_size_benchmarks[chunk_size_benchmarks.group == "write"]
     chunk_size_read = chunk_size_benchmarks[chunk_size_benchmarks.group == "read"]
 

--- a/src/zarr_benchmarks/plotting_functions.py
+++ b/src/zarr_benchmarks/plotting_functions.py
@@ -152,7 +152,7 @@ def plot_relplot_benchmarks(
         col (str | None, optional): name of dataframe column to be used for splitting into subplots. Defaults to None.
     """
     if col is None:
-        facet_kws = None
+        facet_kws = {}
         col_wrap = None
         plot_name = plot_name
     else:
@@ -163,6 +163,7 @@ def plot_relplot_benchmarks(
             col_wrap = 3
         plot_name = plot_name + "_subplots"
 
+    facet_kws["despine"] = False
     graph = sns.relplot(
         data=data,
         x=x_axis,

--- a/src/zarr_benchmarks/plotting_functions.py
+++ b/src/zarr_benchmarks/plotting_functions.py
@@ -158,7 +158,7 @@ def plot_relplot_benchmarks(
     else:
         facet_kws = dict(sharex=True, sharey=True)
         if len(data[col].unique()) < 3:
-            col_wrap = 2
+            col_wrap = 1
         else:
             col_wrap = 3
         plot_name = plot_name + "_subplots"


### PR DESCRIPTION
Some minor edits to plots to improve them a bit:

- Add spines to all 4 sides of the figures
- Plot len(3) figures in a column instead of a row (easier to read on a website)
- Remove redundant chunk size and compressions level plots - the info in the plots I've removed is already in other plots.