### PR TITLE
Minor fixes for catplot

### DIFF
--- a/src/zarr_benchmarks/plotting_functions.py
+++ b/src/zarr_benchmarks/plotting_functions.py
@@ -260,10 +260,12 @@ def plot_catplot_benchmarks(
         hue (str | None, optional): name of dataframe column to be used for the colours in the plot. Defaults to None.
     """
     # Before plotting, set the desired order
-    shuffle_order = ["noshuffle", "bitshuffle", "shuffle"]
-    data[x_axis] = pd.Categorical(
-        data["blosc_shuffle"], categories=shuffle_order, ordered=True
-    )
+    if x_axis == "blosc_shuffle":
+        data = data.copy()
+        shuffle_order = ["noshuffle", "bitshuffle", "shuffle"]
+        data[x_axis] = pd.Categorical(
+            data["blosc_shuffle"], categories=shuffle_order, ordered=True
+        )
 
     graph = sns.catplot(
         data=data,


### PR DESCRIPTION
Shuffle plots are looking great - thanks @ruaridhg ! Just noticed a couple of small things when I was looking through on `main`.

This PR:
- only changes to categorical when `x_axis` is `blosc_shuffle`. Currently, if we ever called the catplot function with a different `x_axis`, its column of data would be overwritten with `blosc_shuffle` data
- Creates a copy of the data, before converting to categorical. Currently, the changes to the column's data type persist outside of the catplot function, as the column is changed in-place in the dataframe.