### PR TITLE
Add filtering for spec v2 and spec v3 plots

### DIFF
--- a/src/zarr_benchmarks/create_plots.py
+++ b/src/zarr_benchmarks/create_plots.py
@@ -215,7 +215,7 @@ def create_read_write_errorbar_plots_for_package(
     zarr_spec: Literal[2, 3],
 ) -> None:
     package_benchmarks = read_write_benchmarks[read_write_benchmarks.package == package]
-    write = package_benchmarks[(package_benchmarks.group == "write")]
+    write = package_benchmarks[package_benchmarks.group == "write"]
     read = package_benchmarks[package_benchmarks.group == "read"]
 
     write_chunks_128 = write[(write.chunk_size == 128) & (write.zarr_spec == zarr_spec)]


### PR DESCRIPTION
Added in filtering for spec_v2 and spec_v3 to the plotting.

In this PR:

- read and write plots are working with the filtering
- chunk size plots are also working
- errorbar plots are ~having the previous issue of being cut off by the x-axis limits~ working with heart data
- shuffle plots ~should be working, but the latest run to get the example results (included in this PR) appear to be missing no_shuffle and bit_shuffle variations.~ working with heart data
